### PR TITLE
feat: tunnel mode disables auth, localhost URL embeds token for one-click access

### DIFF
--- a/bin/ai-or-die.js
+++ b/bin/ai-or-die.js
@@ -108,6 +108,9 @@ async function main() {
     const url = authToken ? `${baseUrl}?token=${authToken}` : baseUrl;
 
     console.log(`\n🚀 ai-or-die is running at: \x1b[1m\x1b[4m${url}\x1b[0m`);
+    if (authToken) {
+      console.log(`   Auth token: \x1b[1m\x1b[33m${authToken}\x1b[0m`);
+    }
 
     // Dev tunnel or browser open
     let tunnel = null;


### PR DESCRIPTION
## Summary

- `--tunnel` mode automatically disables auth (tunnel itself controls access via Microsoft/GitHub login)
- Localhost URL now embeds the token as query parameter: `http://localhost:7777?token=a8Kp2mXv4Q`
- Auth token also printed separately for manual entry
- One-click access: click the URL or copy the token — user's choice

## Output examples

**Tunnel mode:**
```
🌍 TUNNEL MODE — authentication disabled (tunnel controls access)
🚀 ai-or-die is running at: http://localhost:7777
  Tunnel ready: https://aiordie-desktop123.devtunnels.ms
```

**Localhost with auth:**
```
🔐 AUTHENTICATION ENABLED
🚀 ai-or-die is running at: http://localhost:7777?token=a8Kp2mXv4Q
   Auth token: a8Kp2mXv4Q
```

## Test plan
- [ ] CI passes
- [ ] `npx ai-or-die` prints clickable URL with embedded token
- [ ] `npx ai-or-die --tunnel` skips auth, shows tunnel URL