### PR TITLE
fix: resolve Nerd Font regression and improve input responsiveness

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -366,9 +366,17 @@ class ClaudeCodeWebInterface {
 
         // Re-render terminal when fonts finish loading
         if (document.fonts) {
+            // One-shot: handle initial font load
             document.fonts.ready.then(() => {
                 const loaded = document.fonts.check('14px "MesloLGS Nerd Font"');
                 console.log(loaded ? '[Font] MesloLGS Nerd Font loaded' : '[Font] Using fallback font');
+                this.terminal.refresh(0, this.terminal.rows - 1);
+                this.fitTerminal();
+            });
+            // Persistent: handle late-loading Bold/Italic variants
+            // document.fonts.ready is a one-shot promise that won't fire again
+            // when Bold loads after output coalescing delay triggers bold rendering
+            document.fonts.addEventListener('loadingdone', () => {
                 this.terminal.refresh(0, this.terminal.rows - 1);
                 this.fitTerminal();
             });

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -40,6 +40,7 @@
       })();
     </script>
     <link rel="preload" href="fonts/MesloLGSNerdFont-Regular.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="fonts/MesloLGSNerdFont-Bold.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="stylesheet" href="fonts.css">
     <link rel="stylesheet" href="tokens.css">
     <link rel="stylesheet" href="base.css">

--- a/src/public/service-worker.js
+++ b/src/public/service-worker.js
@@ -1,9 +1,14 @@
-const CACHE_NAME = 'ai-or-die-v4';
+// Bump this version when urlsToCache entries are added or removed.
+// Content changes to existing files are handled by the network-first fetch strategy.
+const CACHE_NAME = 'ai-or-die-v5';
 const urlsToCache = [
   '/',
   '/index.html',
   '/fonts.css',
   '/fonts/MesloLGSNerdFont-Regular.woff2',
+  '/fonts/MesloLGSNerdFont-Bold.woff2',
+  '/fonts/MesloLGSNerdFont-Italic.woff2',
+  '/fonts/MesloLGSNerdFont-BoldItalic.woff2',
   '/tokens.css',
   '/base.css',
   '/components/tabs.css',

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,9 @@ const { getFileInfo, computeFileHash, isBinaryFile, sanitizeFileName, isBlockedE
 const UsageReader = require('./usage-reader');
 const UsageAnalytics = require('./usage-analytics');
 
+/** Max bytes to accumulate before flushing coalesced output immediately */
+const MAX_COALESCE_BYTES = 32 * 1024;
+
 class ClaudeCodeWebServer {
   constructor(options = {}) {
     this.port = options.port != null ? options.port : 7777;
@@ -1043,7 +1046,7 @@ class ClaudeCodeWebServer {
         clientNoContextTakeover: true,
         serverMaxWindowBits: 13,
         clientMaxWindowBits: 13,
-        zlibDeflateOptions: { level: 6 }
+        zlibDeflateOptions: { level: 1 }
       },
       verifyClient: (info) => {
         if (!this.noAuth && this.auth) {
@@ -1176,7 +1179,9 @@ class ClaudeCodeWebServer {
               try {
                 const inputBridge = this.getBridgeForAgent(session.agent);
                 if (inputBridge) {
-                  await inputBridge.sendInput(wsInfo.claudeSessionId, data.data);
+                  inputBridge.sendInput(wsInfo.claudeSessionId, data.data).catch(error => {
+                    if (this.dev) console.error(`Input write failed for session ${wsInfo.claudeSessionId}:`, error.message);
+                  });
                 }
               } catch (error) {
                 if (this.dev) {
@@ -1544,6 +1549,8 @@ class ClaudeCodeWebServer {
   // Coalesces output into 16ms windows to reduce WebSocket send frequency.
   // During heavy output (~500 PTY batches/sec), this reduces sends to ~60/sec,
   // freeing the event loop for input message processing.
+  // Flushes immediately when pending output exceeds MAX_COALESCE_BYTES to
+  // bound event loop blocking and provide yield points for input processing.
   _throttledOutputBroadcast(sessionId, data) {
     const session = this.claudeSessions.get(sessionId);
     if (!session) return;
@@ -1552,6 +1559,16 @@ class ClaudeCodeWebServer {
       session._pendingOutput = '';
     }
     session._pendingOutput += data;
+
+    // Cap: flush immediately when buffer exceeds threshold
+    if (session._pendingOutput.length > MAX_COALESCE_BYTES) {
+      if (session._outputFlushTimer) {
+        clearTimeout(session._outputFlushTimer);
+        session._outputFlushTimer = null;
+      }
+      this._flushSessionOutput(sessionId);
+      return;
+    }
 
     if (!session._outputFlushTimer) {
       session._outputFlushTimer = setTimeout(() => {
@@ -1581,6 +1598,10 @@ class ClaudeCodeWebServer {
       if (wsInfo &&
           wsInfo.claudeSessionId === sessionId &&
           wsInfo.ws.readyState === WebSocket.OPEN) {
+        // Backpressure: skip clients that can't consume fast enough
+        if (wsInfo.ws.bufferedAmount > 256 * 1024) {
+          return; // Data remains in outputBuffer for replay on reconnection
+        }
         wsInfo.ws.send(msg);
       }
     });

--- a/test/font-loading.test.js
+++ b/test/font-loading.test.js
@@ -107,6 +107,19 @@ describe('font loading infrastructure', function () {
     it('caches the Regular WOFF2', function () {
       assert.ok(sw.includes('MesloLGSNerdFont-Regular.woff2'), 'service worker must cache the Regular WOFF2');
     });
+
+    it('caches all 4 font WOFF2 variants in urlsToCache', function () {
+      const expectedFonts = [
+        'MesloLGSNerdFont-Regular.woff2',
+        'MesloLGSNerdFont-Bold.woff2',
+        'MesloLGSNerdFont-Italic.woff2',
+        'MesloLGSNerdFont-BoldItalic.woff2'
+      ];
+
+      for (const font of expectedFonts) {
+        assert.ok(sw.includes(font), `service worker urlsToCache must include ${font}`);
+      }
+    });
   });
 
   describe('server.js MIME types', function () {


### PR DESCRIPTION
## Summary

- Fixes Nerd Font glyph regression introduced by output coalescing in #18 (commit 3f884dd)
- Improves keyboard input responsiveness during heavy AI output

## Root Cause: Font Regression

`document.fonts.ready` is a one-shot promise. The 16ms output coalescing delay causes it to resolve before Bold font variant loading is triggered by terminal rendering, leaving no mechanism to refresh xterm.js when late-loading variants arrive. PUA glyphs (powerline icons) render as boxes.

## Root Cause: Input Sluggishness  

Four bottlenecks: `await` on sendInput blocks message handler, zlib level 6 saturates thread pool, no backpressure on slow clients, unbounded coalesced payload size.

## Changes

**Font fixes:**
- Add persistent `document.fonts.addEventListener('loadingdone', ...)` for late-arriving Bold/Italic variants
- Preload Bold WOFF2 alongside Regular in `<head>`
- Cache all 4 WOFF2 variants in service worker (v4 → v5)

**Input responsiveness:**
- Remove `await` on `sendInput` (fire-and-forget; `writeQueue` preserves keystroke ordering)
- Reduce zlib compression level 6 → 1 (~5x faster, frees thread pool workers)
- Add `ws.bufferedAmount` backpressure check (256KB threshold)
- Cap coalesced output at 32KB (`MAX_COALESCE_BYTES`) for bounded event loop blocking

## Test plan
- [ ] Unit tests: backpressure skip, max coalesce flush, PUA integrity, SW font list (35 tests)
- [ ] E2E: Font glyphs after coalesced WS output
- [ ] E2E: Bold PUA codepoint cell widths
- [ ] E2E: All 4 WOFF2 variants served correctly
- [ ] E2E: Input processed during heavy output streaming
- [ ] E2E: Backspace editing with fire-and-forget input
- [ ] E2E: >32KB burst delivered without data loss
- [ ] CI passes on ubuntu-latest + windows-latest