### PR TITLE
refactor: decouple VS Code Server from dev tunnel

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Force LF line endings for shell scripts (prevents CRLF corruption on Windows checkout)
 e2e/fixtures/fake-code.sh text eol=lf
+e2e/fixtures/fake-devtunnel.sh text eol=lf

--- a/docs/adrs/0011-decouple-vscode-server-from-tunnel.md
+++ b/docs/adrs/0011-decouple-vscode-server-from-tunnel.md
@@ -1,0 +1,63 @@
+# ADR-0011: Decouple VS Code Server from Dev Tunnel
+
+## Status
+
+**Accepted**
+
+## Date
+
+2026-02-09
+
+## Context
+
+The VS Code tunnel feature (`src/vscode-tunnel.js`) currently uses `code tunnel`, which bundles both the VS Code Server backend and a Microsoft Dev Tunnel into a single process. This tight coupling causes several issues:
+
+1. **Single point of failure** -- if the tunnel component crashes, the entire VS Code Server dies with it. There is no way to keep the server running on localhost while the tunnel reconnects.
+2. **GitHub-specific auth** -- `code tunnel` requires GitHub device-code authentication (`code tunnel login --provider github`), which is separate from the `devtunnel` auth used by the server-wide tunnel feature (ADR-0002). Users must authenticate twice with different providers.
+3. **No local-only mode** -- the server cannot run without a tunnel. Users who only want local VS Code editing on the same machine are forced through the full tunnel setup.
+4. **Limited tunnel provider choice** -- `code tunnel` hardwires Microsoft's tunnel infrastructure. The server-wide tunnel (ADR-0002) already uses `devtunnel` directly, giving more control over tunnel lifecycle.
+
+The project already has a working `devtunnel` integration in `src/tunnel-manager.js` with CLI discovery, auth, tunnel creation, and resilient hosting with exponential backoff.
+
+## Decision
+
+Replace `code tunnel` with two independent processes per session:
+
+1. **VS Code Server**: `code serve-web --host 127.0.0.1 --port <port> --connection-token <token> --accept-server-license-terms` -- runs a local HTTP server serving the VS Code web UI. No tunnel, no GitHub auth required.
+2. **Dev Tunnel**: `devtunnel create` + `devtunnel port create` + `devtunnel host` -- independently forwards the local port to the internet via a `*.devtunnels.ms` URL. Lifecycle patterns copied from the existing `TunnelManager`.
+
+Key implementation details:
+
+- **Both CLIs required** -- `code` and `devtunnel` must both be installed. The feature fails with install instructions if either is missing.
+- **Port allocation** -- each session gets a unique localhost port from a configurable range (base 9100, range 100). Ports are reserved atomically and validated with a TCP bind probe.
+- **Connection token** -- a random 32-byte hex token is generated per session and passed to both the local URL and the public tunnel URL for access control.
+- **Auth reuse** -- the `devtunnel` CLI persists auth at the OS level (`~/.devtunnels/`). If the server-wide tunnel or any prior session has already authenticated, no additional user interaction is needed.
+- **Sequenced startup** -- server starts first, TCP readiness is verified, then tunnel connects.
+- **Sequenced teardown** -- tunnel is killed first, then cleaned up via `devtunnel delete`, then server is killed.
+- **Independent failure domains** -- if only the tunnel dies at runtime, the server stays alive on localhost while the tunnel restarts with backoff (degraded state). If the server dies, both are restarted.
+
+## Consequences
+
+### Positive
+
+- Independent failure domains: tunnel crash no longer kills the VS Code Server.
+- Unified auth: uses `devtunnel` auth (same as server-wide tunnel) instead of a separate GitHub device-code flow.
+- The connection token provides per-session access control regardless of tunnel access policy.
+- Clearer separation of concerns: server lifecycle vs. tunnel lifecycle are independently managed.
+
+### Negative
+
+- Two processes per session increases resource usage slightly.
+- Port allocation adds complexity (range management, EADDRINUSE retries).
+- The devtunnel lifecycle logic is copied from `TunnelManager` rather than extracted into a shared module, creating two maintenance points for the same CLI interaction patterns.
+
+### Neutral
+
+- The WebSocket protocol message types remain unchanged (`vscode_tunnel_started`, `vscode_tunnel_status`, `vscode_tunnel_auth`, `vscode_tunnel_error`). Payloads gain `localUrl` and `publicUrl` fields alongside the existing `url` field for backward compatibility.
+- The public URL domain changes from `vscode.dev/tunnel/<name>` to `<id>.devtunnels.ms`.
+- The `devtunnel` CLI is already a prerequisite for the server-wide tunnel feature (ADR-0002), so no new external dependency is introduced for users who already have it installed.
+
+## Notes
+
+- Supersedes the `code tunnel` approach introduced in the `feat/vscode-tunnel` branch.
+- Related: ADR-0002 (devtunnels over ngrok) established `devtunnel` as the standard tunnel provider.

--- a/docs/specs/vscode-tunnel.md
+++ b/docs/specs/vscode-tunnel.md
@@ -1,6 +1,6 @@
 # VS Code Tunnel Specification
 
-The VS Code Tunnel feature enables users to launch a VS Code Remote Tunnel directly from the web UI, providing a browser-based VS Code editing experience connected to the server's filesystem.
+The VS Code Tunnel feature enables users to launch a browser-based VS Code editing experience connected to the server's filesystem. It uses a two-process architecture: a local `code serve-web` HTTP server for the IDE, and a `devtunnel host` process that forwards the local port to a public URL.
 
 ---
 
@@ -8,15 +8,26 @@ The VS Code Tunnel feature enables users to launch a VS Code Remote Tunnel direc
 
 The feature spans three layers:
 
-1. **Client UI** (`src/public/vscode-tunnel.js`) — toolbar button, status banners, user interaction
-2. **Server manager** (`src/vscode-tunnel.js`) — process lifecycle, binary discovery, auth flow
-3. **WebSocket protocol** — bidirectional events between client and server
+1. **Client UI** (`src/public/vscode-tunnel.js`) -- toolbar button, status banners, user interaction
+2. **Server manager** (`src/vscode-tunnel.js`) -- two-process lifecycle, binary discovery, auth flow, port allocation
+3. **WebSocket protocol** -- bidirectional events between client and server
+
+### Two-Process Model
+
+Each session gets two independent child processes:
+
+| Process | Command | Purpose |
+|---------|---------|---------|
+| **VS Code Server** | `code serve-web --host 127.0.0.1 --port <port> --connection-token <token> --accept-server-license-terms` | Local HTTP server hosting the VS Code web IDE |
+| **Dev Tunnel** | `devtunnel host <tunnelId>` | Forwards the local port to a `*.devtunnels.ms` public URL |
+
+The server process binds to `127.0.0.1` on an allocated port. The tunnel process makes that port reachable from the internet. A connection token (`crypto.randomBytes(32).toString('hex')`) is appended as `?tkn=<token>` to both the local and public URLs for access control.
 
 ---
 
 ## Client: VSCodeTunnelUI
 
-Source: `src/public/vscode-tunnel.js` (~307 lines)
+Source: `src/public/vscode-tunnel.js`
 
 ### Constructor
 
@@ -25,24 +36,27 @@ Source: `src/public/vscode-tunnel.js` (~307 lines)
 | `app` | Object | Reference to `ClaudeCodeWebInterface` (provides `send()` for WebSocket) |
 | `button` | HTMLElement | `#vscodeTunnelBtn` toolbar button |
 | `banner` | HTMLElement | `#vscodeTunnelBanner` status banner container |
-| `status` | string | `'stopped'` \| `'starting'` \| `'running'` \| `'error'` |
-| `url` | string \| null | Tunnel URL (e.g., `https://vscode.dev/tunnel/<name>`) |
+| `status` | string | `'stopped'` \| `'starting'` \| `'running'` \| `'degraded'` \| `'error'` |
+| `url` | string \| null | Primary URL (public if available, otherwise local) |
+| `localUrl` | string \| null | Local URL (e.g., `http://localhost:9100/?tkn=<token>`) |
+| `publicUrl` | string \| null | Public URL (e.g., `https://<id>.devtunnels.ms/?tkn=<token>`) |
 | `authUrl` | string \| null | Authentication URL for device code flow |
 | `deviceCode` | string \| null | Device code for authentication |
+| `_bannerDismissed` | boolean | Whether the user has dismissed the banner |
 
 ### Public API
 
 | Method | Description |
 |--------|-------------|
-| `toggle()` | Start if stopped/error, show banner if running/starting |
+| `toggle()` | Start if stopped/error, show banner if running/starting/degraded |
 | `start()` | Send `start_vscode_tunnel` via `this.app.send()`, show starting banner |
-| `stop()` | Send `stop_vscode_tunnel` via `this.app.send()`, reset state |
-| `copyUrl()` | Copy tunnel URL to clipboard with visual feedback |
-| `openUrl()` | Open tunnel URL in new browser tab |
+| `stop()` | Send `stop_vscode_tunnel` via `this.app.send()`, reset all URL state |
+| `copyUrl()` | Copy `this.url` to clipboard with visual feedback |
+| `openUrl()` | Open `this.url` in new browser tab |
 | `handleMessage(data)` | Route incoming WebSocket events to update state and banner |
 | `dismiss()` | Hide banner without stopping the tunnel |
 
-**Important:** The `start()` and `stop()` methods use `this.app.send()` (not direct WebSocket access). The `send()` method on `ClaudeCodeWebInterface` (`app.js:715`) handles JSON serialization and WebSocket readyState checking. This is the established pattern used throughout the codebase.
+The `start()` and `stop()` methods use `this.app.send()` (not direct WebSocket access). The `send()` method on `ClaudeCodeWebInterface` (`app.js`) handles JSON serialization and WebSocket readyState checking.
 
 ### Banner States
 
@@ -50,24 +64,30 @@ Source: `src/public/vscode-tunnel.js` (~307 lines)
 |-------|---------|---------|
 | Starting | `start()` called | Spinner + "Starting VS Code Tunnel..." + Cancel button |
 | Auth | `vscode_tunnel_auth` received | Auth URL + device code + "Open Auth Page" button |
-| Running | `vscode_tunnel_started` received | Tunnel URL + Copy/Open/Stop buttons |
-| Error | `vscode_tunnel_error` received | Error message + Retry button (+ install link if not found) |
+| Running | `vscode_tunnel_started` received | Tunnel URL (stripped of protocol/query) + Copy/Open/Stop buttons |
+| Degraded | `vscode_tunnel_status` with `status: 'degraded'` | Spinner + "VS Code Tunnel reconnecting... Server running locally." + Stop button |
+| Restarting | `vscode_tunnel_status` with `status: 'restarting'` | Spinner + "Reconnecting VS Code Tunnel..." + Cancel button |
+| Error | `vscode_tunnel_error` received | Error message + Retry button (+ install methods if not found) |
 | Dismissed | User clicks X | Banner hidden, tunnel continues running |
+
+The running banner displays the URL in a generic format (protocol and query string stripped), not tied to any specific domain pattern. The `_renderRunningBanner` method strips `https?://` prefix and `?...` suffix for display.
 
 ### Toolbar Button CSS Classes
 
 | Class | Meaning |
 |-------|---------|
 | (none) | Stopped, default gray |
-| `.starting` | Orange, spinning animation |
+| `.starting` | Orange, spinning animation (also used for `restarting` and `degraded`) |
 | `.running` | Green with dot indicator |
 | `.error` | Red with dot indicator |
+
+The `_updateButton()` method maps `degraded` and `restarting` statuses to the `.starting` CSS class.
 
 ---
 
 ## Server: VSCodeTunnelManager
 
-Source: `src/vscode-tunnel.js` (~520 lines)
+Source: `src/vscode-tunnel.js`
 
 ### Constructor Options
 
@@ -76,18 +96,32 @@ Source: `src/vscode-tunnel.js` (~520 lines)
 | `dev` | boolean | `false` | Enable verbose stdout logging |
 | `onEvent` | function | `() => {}` | Callback for tunnel events: `(sessionId, event)` |
 
+### Constructor Behavior
+
+At construction time, two parallel async discovery operations are kicked off:
+
+1. `_findCommand()` -- locates the `code` CLI executable
+2. `_findDevtunnelCommand()` -- locates the `devtunnel` CLI executable
+
+Both resolve into `this._initPromise` (a `Promise.all`). The instance properties `_command`, `_commandChecked`, `_available` track the VS Code CLI. The properties `_devtunnelCommand`, `_devtunnelChecked`, `_devtunnelAvailable` track the devtunnel CLI.
+
+Additionally, the constructor initializes `_reservedPorts` (a `Set`) for tracking allocated ports across sessions.
+
 ### Public API
 
 | Method | Description |
 |--------|-------------|
-| `async isAvailable()` | Check if `code` CLI exists (waits for discovery) |
-| `isAvailableSync()` | Cached availability (safe after init) |
-| `async start(sessionId, workingDir)` | Start a tunnel for a session |
-| `async stop(sessionId)` | Stop a session's tunnel |
-| `getStatus(sessionId)` | Get tunnel status/URL/PID |
+| `async isAvailable()` | Check if both `code` and `devtunnel` CLIs exist (waits for discovery) |
+| `isAvailableSync()` | Cached availability (returns `this._available && this._devtunnelAvailable`) |
+| `async start(sessionId, workingDir)` | Start server + tunnel for a session |
+| `async stop(sessionId)` | Sequenced teardown: kill tunnel, delete devtunnel, kill server, release port |
+| `getStatus(sessionId)` | Get tunnel status, localUrl, publicUrl, PIDs |
 | `async stopAll()` | Stop all tunnels (server shutdown) |
+| `clearAvailabilityCache()` | Re-run both CLI discovery operations |
 
-### Binary Discovery (`_findCommand`)
+### Binary Discovery
+
+#### VS Code CLI (`_findCommand`)
 
 Platform-specific candidate paths checked in order:
 
@@ -110,69 +144,211 @@ Platform-specific candidate paths checked in order:
 4. `~/.local/bin/code`
 5. PATH fallback via `which code`
 
+Candidate paths are tested with `fs.accessSync(candidate, fs.constants.X_OK)`.
+
+#### Dev Tunnel CLI (`_findDevtunnelCommand`)
+
+Uses PATH-only discovery: `where devtunnel` (Windows) or `which devtunnel` (macOS/Linux) with a 5-second timeout. No fixed candidate paths.
+
+### Authentication Flow
+
+Authentication uses the `devtunnel` CLI's OS-level credential store (Microsoft/GitHub device-code flow). There is no direct GitHub auth.
+
+| Step | Command | Behavior |
+|------|---------|----------|
+| Auth check | `devtunnel user show` | 10s timeout. Exit code 0 = authenticated. |
+| Login | `devtunnel user login` | Spawned as child process. Stdout/stderr parsed for device code URLs. |
+
+**Device code detection** parses output for:
+- `https://microsoft.com/devicelogin` with code pattern `[A-Z0-9]{6,9}` (primary)
+- `https://github.com/login/device` with code pattern `[A-Z0-9]{4}-[A-Z0-9]{4}` (fallback)
+
+Both stdout and stderr are checked (devtunnel may output to either stream). When a device code URL is detected, a `vscode_tunnel_auth` event is emitted so the client can display the auth banner.
+
+Login timeout: 2 minutes (`LOGIN_TIMEOUT_MS`). If exceeded, the login process is killed and authentication is reported as failed.
+
+Cancellation: the user can click Cancel during login; `stop()` kills the login process via `tunnel._loginProcess`.
+
 ### Process Lifecycle
 
-The tunnel start is a two-phase process:
+The tunnel start is a four-phase process:
 
-**Phase 1 — Authentication:**
-1. **Auth check:** `code tunnel user show` (5s timeout) determines if user is already logged in
-2. **Login (if needed):** `code tunnel login --provider github` spawns the device-code flow
-3. **Stdout parsing:** Detects `github.com/login/device` URL and device code (`XXXX-YYYY`), also handles `microsoft.com/devicelogin` as fallback
-4. **Auth event:** Emits `vscode_tunnel_auth` with `authUrl` and `deviceCode` so the client can display the auth banner
-5. **Login timeout:** 2 minutes (`LOGIN_TIMEOUT_MS`) — kills login process and reports failure if exceeded
-6. **Cancellation:** User can click Cancel during login; `stop()` kills the login process via `tunnel._loginProcess`
+**Phase 1 -- Authentication:**
+1. Run `devtunnel user show` to check existing credentials
+2. If not authenticated, run `devtunnel user login` (device-code flow)
+3. Emit `vscode_tunnel_auth` events as device code URLs appear in output
+4. Wait for login to complete (exit code 0) or timeout/cancel
 
-**Phase 2 — Tunnel:**
-1. **Spawn:** `code tunnel --accept-server-license-terms --no-sleep --name <name>`
-2. **Stdout parsing:** Detects tunnel URL (`https://vscode.dev/tunnel/...`), also retains auth-URL parsing as a defensive fallback for token-expired-mid-session scenarios
-3. **URL timeout:** 30s warning if no URL appears (process kept alive)
-4. **Health check:** Every 60s, verifies tunnel process is still running
-5. **Auto-restart:** On non-zero exit, exponential backoff (1s → 30s cap, max 10 retries)
-6. **Stability reset:** After 60s stable uptime, retry counter resets to 0
+**Phase 2 -- Server Spawn:**
+1. Spawn `code serve-web --host 127.0.0.1 --port <port> --connection-token <token> --accept-server-license-terms`
+2. On Windows, `shell: true` is set (required for `.cmd`/`.bat` files)
+3. Parse stdout for `http://localhost` or "Web UI available at" to detect readiness
+4. Fallback: after `URL_TIMEOUT_MS` (30s), set `localUrl` optimistically and continue
+5. On EADDRINUSE in stderr, release the port, allocate the next one, retry (up to `PORT_RETRY_MAX` = 3 times)
 
-### Tunnel Name Format
+**Phase 3 -- TCP Readiness Wait:**
+1. `_waitForPort(port, PORT_WAIT_TIMEOUT_MS)` polls TCP connect to `127.0.0.1:<port>`
+2. Polls every 200ms until a connection succeeds or `PORT_WAIT_TIMEOUT_MS` (10s) expires
 
-`aiordie-<first 12 chars of sessionId, alphanumeric only>`
+**Phase 4 -- Tunnel Setup:**
+1. `devtunnel create <tunnelId> --allow-anonymous` (idempotent; "Conflict" = already exists)
+2. `devtunnel port create <tunnelId> -p <localPort>` (idempotent)
+3. `devtunnel host <tunnelId>` spawned as long-running child process
+4. Stdout parsed for `https://<id>.devtunnels.ms` URL
+5. Connection token appended: `<baseUrl>?tkn=<token>` (or `&tkn=<token>` if URL already has query params)
+6. On URL detection, status set to `running`, emit `vscode_tunnel_started`
+
+### Tunnel ID Format
+
+`aiordie-vscode-<first 12 chars of sessionId, non-alphanumeric stripped>`
+
+### Port Allocation
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `VSCODE_BASE_PORT` | `9100` (configurable via `VSCODE_BASE_PORT` env var) | Start of port range |
+| `VSCODE_PORT_RANGE` | `100` | Number of ports in range (9100-9199) |
+| `PORT_RETRY_MAX` | `3` | Max EADDRINUSE retries per server spawn |
+| `PORT_WAIT_TIMEOUT_MS` | `10000` | Max wait for TCP readiness (10 seconds) |
+
+`_allocatePort()` scans from `VSCODE_BASE_PORT` to `VSCODE_BASE_PORT + VSCODE_PORT_RANGE - 1`, returning the first port not in `_reservedPorts`. Returns `null` if all ports are exhausted.
+
+### Connection Token
+
+Generated via `crypto.randomBytes(32).toString('hex')` -- a 64-character hex string. Appended as `?tkn=<token>` to both local and public URLs. The token is set once per tunnel lifecycle and reused across restarts.
+
+### Tunnel State
+
+Each session's tunnel is tracked in `this.tunnels` (a `Map<string, Object>`). The state object fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `serverProcess` | ChildProcess \| null | The `code serve-web` process |
+| `tunnelProcess` | ChildProcess \| null | The `devtunnel host` process |
+| `_loginProcess` | ChildProcess \| null | The `devtunnel user login` process (during auth) |
+| `localPort` | number | Allocated port from the range |
+| `connectionToken` | string | 64-char hex token |
+| `localUrl` | string \| null | `http://localhost:<port>/?tkn=<token>` |
+| `publicUrl` | string \| null | `https://<id>.devtunnels.ms/?tkn=<token>` |
+| `tunnelId` | string | `aiordie-vscode-<sessionPrefix>` |
+| `status` | string | `'starting'` \| `'running'` \| `'degraded'` \| `'restarting'` \| `'error'` |
+| `sessionId` | string | The associated session ID |
+| `workingDir` | string | Working directory for the VS Code server |
+| `retryCount` | number | Current crash retry counter (resets after stability threshold) |
+| `stopping` | boolean | Whether stop has been requested |
+| `_lastSpawnTime` | number \| null | Timestamp of last server spawn |
+| `_totalRestarts` | number | Lifetime restart count |
+| `_stabilityTimer` | Timeout \| null | Timer for retry counter reset |
+| `_restartDelayTimer` | Timeout \| null | Timer for backoff delay |
+| `_restartDelayResolve` | function \| null | Resolve function to abort backoff wait |
+| `_whichDied` | `'server'` \| `'tunnel'` \| null | Which process exited, drives restart strategy |
+
+### Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `starting` | Server or tunnel is being spawned |
+| `running` | Both server and tunnel processes are alive, public URL available |
+| `degraded` | Tunnel process died but server is still alive; local URL still works |
+| `restarting` | Server died, both processes being restarted |
+| `error` | Fatal failure, retry budget exhausted |
+| `stopped` | No processes running (after `stop()` or before `start()`) |
+
+### Restart Behavior
+
+Auto-restart uses capped exponential backoff: `2^(retryCount-1) * 1s`, capped at 30s, max 10 retries.
+
+**Restart strategy depends on `_whichDied`:**
+
+| Died | Behavior |
+|------|----------|
+| `tunnel` (server still alive) | Set status to `degraded`, clear `publicUrl`, restart tunnel only (`_ensureDevtunnel` + `_spawnTunnel`). Local URL remains available. |
+| `server` | Kill tunnel process too, clear both URLs, set status to `restarting`, restart both (`_spawnServer` + `_waitForPort` + `_ensureDevtunnel` + `_spawnTunnel`). |
+
+After `STABILITY_THRESHOLD_MS` (60s) of stable uptime, the retry counter resets to 0 so future crashes get a fresh retry budget.
+
+### Stop Sequence
+
+`stop(sessionId)` performs a sequenced teardown:
+
+1. Set `stopping = true`, clear stability timer
+2. Kill login process if in-progress
+3. Abort any pending restart backoff delay
+4. Kill tunnel process (`SIGTERM`, escalate to `SIGKILL` after 5s)
+5. Delete the devtunnel: `devtunnel delete <tunnelId> -y` (fire-and-forget, 10s timeout)
+6. Kill server process (`SIGTERM`, escalate to `SIGKILL` after 5s)
+7. Release port from `_reservedPorts`, remove tunnel state from map
+8. Emit `vscode_tunnel_status` with `status: 'stopped'`
 
 ### Configuration
 
 | Env Variable | Default | Description |
 |-------------|---------|-------------|
-| `MAX_VSCODE_TUNNELS` | 5 | Max concurrent tunnels server-wide |
+| `MAX_VSCODE_TUNNELS` | `5` | Max concurrent tunnels server-wide |
+| `VSCODE_BASE_PORT` | `9100` | Start of the local port range |
 
 ### Constants
 
-| Constant | Default | Description |
-|----------|---------|-------------|
-| `LOGIN_TIMEOUT_MS` | 120000 | Max time for user to complete device-code auth (2 minutes) |
-| `URL_TIMEOUT_MS` | 30000 | Max wait for tunnel URL after spawn |
-| `MAX_RETRIES` | 10 | Crash retry budget before giving up |
-| `STABILITY_THRESHOLD_MS` | 60000 | Uptime before retry counter resets |
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `MAX_RETRIES` | `10` | Crash retry budget before giving up |
+| `URL_TIMEOUT_MS` | `30000` | Max wait for URL after spawn (30s) |
+| `HEALTH_CHECK_INTERVAL_MS` | `60000` | Health check interval (60s) |
+| `STABILITY_THRESHOLD_MS` | `60000` | Uptime before retry counter resets (60s) |
+| `MIN_RESTART_DELAY_MS` | `1000` | Minimum restart backoff (1s) |
+| `MAX_RESTART_DELAY_MS` | `30000` | Maximum restart backoff cap (30s) |
+| `LOGIN_TIMEOUT_MS` | `120000` | Max time for device-code auth (2 minutes) |
+| `VSCODE_BASE_PORT` | `9100` | Start of port range (overridable via env var) |
+| `VSCODE_PORT_RANGE` | `100` | Number of ports in range |
+| `PORT_RETRY_MAX` | `3` | Max EADDRINUSE retries per server spawn |
+| `PORT_WAIT_TIMEOUT_MS` | `10000` | Max wait for TCP readiness (10s) |
+| `DEFAULT_MAX_TUNNELS` | `5` | Default max concurrent tunnels |
+
+### Health Check
+
+Every 60s (`HEALTH_CHECK_INTERVAL_MS`), the health check interval inspects all active tunnels:
+
+- If the server process is dead and status is `running` or `degraded`: set `_whichDied = 'server'`, trigger restart
+- If the tunnel process is dead and status is `running`: set `_whichDied = 'tunnel'`, trigger restart
+- When no tunnels remain, the health check interval is cleared
+
+The health check is started lazily on the first `start()` call via `_ensureHealthCheck()`.
 
 ---
 
 ## WebSocket Protocol
 
-### Client → Server
+### Client -> Server
 
 | Message Type | Fields | Description |
 |-------------|--------|-------------|
-| `start_vscode_tunnel` | (none) | Start tunnel for current session |
+| `start_vscode_tunnel` | (none) | Start server + tunnel for current session |
 | `stop_vscode_tunnel` | `sessionId?` | Stop tunnel (defaults to current session) |
 | `vscode_tunnel_status` | (none) | Query tunnel status |
 
-### Server → Client (broadcast to session)
+### Server -> Client (broadcast to session)
 
 | Message Type | Fields | Description |
 |-------------|--------|-------------|
-| `vscode_tunnel_started` | `url` | Tunnel is running, URL available |
-| `vscode_tunnel_status` | `status`, `url?`, `pid?` | Status update |
-| `vscode_tunnel_auth` | `authUrl`, `deviceCode` | Authentication required |
-| `vscode_tunnel_error` | `message`, `error?`, `fatal?` | Error occurred |
+| `vscode_tunnel_started` | `url`, `localUrl`, `publicUrl` | Both processes running, URLs available |
+| `vscode_tunnel_status` | `status`, `localUrl?`, `publicUrl?`, `url?`, `pid?`, `tunnelPid?`, `attempt?`, `maxRetries?` | Status update (includes URLs when applicable) |
+| `vscode_tunnel_auth` | `authUrl`, `deviceCode` | Authentication required (device code flow) |
+| `vscode_tunnel_error` | `message`, `error?`, `fatal?`, `install?` | Error occurred |
+
+**Notes on `vscode_tunnel_started`:**
+- `url` is set to `publicUrl` (the public devtunnel URL with token)
+- `localUrl` is `http://localhost:<port>/?tkn=<token>`
+- `publicUrl` is `https://<id>.devtunnels.ms/?tkn=<token>` (or `null` if tunnel setup failed but server is running)
+
+**Notes on `vscode_tunnel_status`:**
+- When `status` is `degraded`, `localUrl` is included (server still running) but `publicUrl` is absent
+- When `status` is `restarting`, both `localUrl` and `publicUrl` are absent
+- When `status` is `stopped`, all URL fields are null on the client side
+- The `attempt` and `maxRetries` fields are included during `degraded` and `restarting` states
 
 ### Server Guards
 
-- `start_vscode_tunnel` requires `wsInfo.claudeSessionId` — client must join a session first
+- `start_vscode_tunnel` requires `wsInfo.claudeSessionId` -- client must join a session first
 - If no session joined, responds with `vscode_tunnel_error: "Join a session first"`
 
 ---
@@ -201,26 +377,32 @@ WebSocket message routing (in `handleMessage`): events `vscode_tunnel_started`, 
 ### server.js
 
 Server-side handlers in `ClaudeCodeWebServer`:
-- `handleStartVSCodeTunnel(wsId, data)` — validates session, starts tunnel
-- `handleStopVSCodeTunnel(wsId, data)` — stops tunnel
-- `handleVSCodeTunnelStatus(wsId)` — returns current status
-- `handleVSCodeTunnelEvent(sessionId, event)` — broadcasts events to session connections
+- `handleStartVSCodeTunnel(wsId, data)` -- validates session, starts tunnel via `vscodeTunnel.start()`
+- `handleStopVSCodeTunnel(wsId, data)` -- stops tunnel via `vscodeTunnel.stop()`
+- `handleVSCodeTunnelStatus(wsId)` -- returns current status via `vscodeTunnel.getStatus()`
+- `handleVSCodeTunnelEvent(sessionId, event)` -- broadcasts events to session connections via `broadcastToSession()`
 
 ### /api/config
 
-The config endpoint includes tunnel availability:
+The config endpoint includes tunnel availability under the `vscodeTunnel` key:
+
 ```json
 {
-  "tools": {
-    "vscodeTunnel": { "available": true }
+  "vscodeTunnel": {
+    "available": true,
+    "devtunnelAvailable": true
   }
 }
 ```
+
+- `available`: `true` when both `code` and `devtunnel` CLIs are found (via `isAvailableSync()`)
+- `devtunnelAvailable`: `true` when the `devtunnel` CLI specifically is found (via `_devtunnelAvailable`)
+- When `available` is `false`, an `install` object with install methods is included (from `InstallAdvisor`)
 
 ---
 
 ## Styling
 
-Source: `src/public/components/vscode-tunnel.css` (~237 lines)
+Source: `src/public/components/vscode-tunnel.css`
 
-The banner and button use dedicated CSS with responsive layout. Mobile viewports stack banner content vertically.
+The banner and button use dedicated CSS with responsive layout. Mobile viewports stack banner content vertically. The degraded state reuses the starting banner's spinner animation.

--- a/e2e/fixtures/fake-code.cmd
+++ b/e2e/fixtures/fake-code.cmd
@@ -1,7 +1,16 @@
 @echo off
-REM Mock VS Code tunnel CLI for E2E testing.
-REM Simulates the output of `code tunnel --accept-server-license-terms --no-sleep`.
+REM Mock VS Code CLI for E2E testing.
+REM Handles both `code serve-web` (new two-process model) and legacy `code tunnel`.
 
+REM --- serve-web subcommand (local VS Code HTTP server) ---
+if "%1"=="serve-web" (
+  echo Web UI available at http://localhost:9100
+  REM Stay alive until killed (real code serve-web is a long-running server)
+  ping -n 3601 127.0.0.1 >nul
+  exit /b 0
+)
+
+REM --- Legacy: tunnel subcommand ---
 REM Fast-fail for `code tunnel user show` (auth check) — exit 1 = not authenticated
 if "%1"=="tunnel" if "%2"=="user" exit /b 1
 

--- a/e2e/fixtures/fake-code.sh
+++ b/e2e/fixtures/fake-code.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
-# Mock VS Code tunnel CLI for E2E testing.
-# Simulates the output of `code tunnel --accept-server-license-terms --no-sleep`.
+# Mock VS Code CLI for E2E testing.
+# Handles both `code serve-web` (new two-process model) and legacy `code tunnel`.
 
+# --- serve-web subcommand (local VS Code HTTP server) ---
+if [ "$1" = "serve-web" ]; then
+  echo "Web UI available at http://localhost:9100"
+  # Stay alive until killed (real code serve-web is a long-running server)
+  sleep 3600
+  exit 0
+fi
+
+# --- Legacy: tunnel subcommand ---
 # Fast-fail for `code tunnel user show` (auth check) — exit 1 = not authenticated
 if [ "$1" = "tunnel" ] && [ "$2" = "user" ]; then
   exit 1

--- a/e2e/fixtures/fake-devtunnel.cmd
+++ b/e2e/fixtures/fake-devtunnel.cmd
@@ -1,0 +1,36 @@
+@echo off
+REM Mock devtunnel CLI for E2E testing.
+REM Simulates the subcommands used by VSCodeTunnelManager's two-process model.
+
+REM --- user show: auth check (exit 0 = authenticated) ---
+if "%1"=="user" if "%2"=="show" exit /b 0
+
+REM --- user login: authenticate (exit 0 = success) ---
+if "%1"=="user" if "%2"=="login" exit /b 0
+
+REM --- create: create a named tunnel ---
+if "%1"=="create" (
+  echo Created tunnel
+  exit /b 0
+)
+
+REM --- port create: configure port forwarding ---
+if "%1"=="port" if "%2"=="create" (
+  echo Port configured
+  exit /b 0
+)
+
+REM --- host: start hosting the tunnel (long-running) ---
+if "%1"=="host" (
+  echo Connect via browser: https://mock-e2e-test.devtunnels.ms
+  REM Stay alive until killed (real devtunnel host is a long-running daemon)
+  ping -n 3601 127.0.0.1 >nul
+  exit /b 0
+)
+
+REM --- delete: remove a tunnel ---
+if "%1"=="delete" exit /b 0
+
+REM Unknown subcommand
+echo Unknown subcommand: %* 1>&2
+exit /b 1

--- a/e2e/fixtures/fake-devtunnel.sh
+++ b/e2e/fixtures/fake-devtunnel.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Mock devtunnel CLI for E2E testing.
+# Simulates the subcommands used by VSCodeTunnelManager's two-process model.
+
+# --- user show: auth check (exit 0 = authenticated) ---
+if [ "$1" = "user" ] && [ "$2" = "show" ]; then
+  exit 0
+fi
+
+# --- user login: authenticate (exit 0 = success) ---
+if [ "$1" = "user" ] && [ "$2" = "login" ]; then
+  exit 0
+fi
+
+# --- create: create a named tunnel ---
+if [ "$1" = "create" ]; then
+  echo "Created tunnel"
+  exit 0
+fi
+
+# --- port create: configure port forwarding ---
+if [ "$1" = "port" ] && [ "$2" = "create" ]; then
+  echo "Port configured"
+  exit 0
+fi
+
+# --- host: start hosting the tunnel (long-running) ---
+if [ "$1" = "host" ]; then
+  echo "Connect via browser: https://mock-e2e-test.devtunnels.ms"
+  # Stay alive until killed (real devtunnel host is a long-running daemon)
+  sleep 3600
+  exit 0
+fi
+
+# --- delete: remove a tunnel ---
+if [ "$1" = "delete" ]; then
+  exit 0
+fi
+
+# Unknown subcommand — exit with error
+echo "Unknown subcommand: $*" >&2
+exit 1

--- a/src/server.js
+++ b/src/server.js
@@ -459,6 +459,7 @@ class ClaudeCodeWebServer {
         tools,
         vscodeTunnel: {
           available: vscodeTunnelAvailable,
+          devtunnelAvailable: this.vscodeTunnel._devtunnelAvailable,
           ...(!vscodeTunnelAvailable ? { install: this.installAdvisor.getInstallInfo('vscode') } : {}),
         },
         ...(prerequisites ? { prerequisites } : {}),

--- a/src/vscode-tunnel.js
+++ b/src/vscode-tunnel.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const { spawn, execFile } = require('child_process');
+const crypto = require('crypto');
+const net = require('net');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
@@ -13,10 +15,16 @@ const STABILITY_THRESHOLD_MS = 60000;  // 60s uptime = "stable", resets retryCou
 const MIN_RESTART_DELAY_MS = 1000;
 const MAX_RESTART_DELAY_MS = 30000;    // cap backoff at 30s
 const LOGIN_TIMEOUT_MS = 120000;       // 2 minutes for user to complete device-code auth
+const VSCODE_BASE_PORT = parseInt(process.env.VSCODE_BASE_PORT || '9100', 10);
+const VSCODE_PORT_RANGE = 100;         // ports 9100-9199
+const PORT_RETRY_MAX = 3;             // max retries on EADDRINUSE
+const PORT_WAIT_TIMEOUT_MS = 10000;   // max wait for TCP readiness
 
 /**
- * Manages VS Code tunnel processes on a per-session basis.
- * Each session can have at most one tunnel; server-wide limit is configurable.
+ * Manages VS Code Server + Dev Tunnel processes on a per-session basis.
+ * Each session gets two independent processes:
+ *   1. `code serve-web` — local VS Code HTTP server
+ *   2. `devtunnel host` — forwards the local port to the internet
  */
 class VSCodeTunnelManager {
   constructor(options = {}) {
@@ -25,25 +33,40 @@ class VSCodeTunnelManager {
     this.onEvent = options.onEvent || (() => {}); // callback(sessionId, event)
     this.dev = options.dev || false;
 
+    // VS Code CLI discovery
     this._command = null;
     this._commandChecked = false;
     this._available = false;
+
+    // devtunnel CLI discovery
+    this._devtunnelCommand = null;
+    this._devtunnelChecked = false;
+    this._devtunnelAvailable = false;
+
     this._healthInterval = null;
+    this._reservedPorts = new Set();
 
     // Kick off async command discovery at construction time
-    this._initPromise = this._findCommand().then((cmd) => {
-      this._command = cmd;
-      this._commandChecked = true;
-      this._available = !!cmd;
-    });
+    this._initPromise = Promise.all([
+      this._findCommand().then((cmd) => {
+        this._command = cmd;
+        this._commandChecked = true;
+        this._available = !!cmd;
+      }),
+      this._findDevtunnelCommand().then((cmd) => {
+        this._devtunnelCommand = cmd;
+        this._devtunnelChecked = true;
+        this._devtunnelAvailable = !!cmd;
+      }),
+    ]);
   }
 
   /**
    * Check if VS Code CLI is available (async, waits for discovery).
    */
   async isAvailable() {
-    if (!this._commandChecked) await this._initPromise;
-    return this._available;
+    if (!this._commandChecked || !this._devtunnelChecked) await this._initPromise;
+    return this._available && this._devtunnelAvailable;
   }
 
   /**
@@ -51,18 +74,18 @@ class VSCodeTunnelManager {
    * Safe to call after constructor has had time to discover.
    */
   isAvailableSync() {
-    return this._available;
+    return this._available && this._devtunnelAvailable;
   }
 
   /**
-   * Start a VS Code tunnel for the given session.
+   * Start a VS Code Server + Dev Tunnel for the given session.
    */
   async start(sessionId, workingDir) {
     // Already running for this session
     if (this.tunnels.has(sessionId)) {
       const existing = this.tunnels.get(sessionId);
       if (existing.status === 'running' || existing.status === 'starting') {
-        return { success: false, error: 'Tunnel already active for this session', url: existing.url };
+        return { success: false, error: 'Tunnel already active for this session', url: existing.publicUrl || existing.localUrl };
       }
     }
 
@@ -72,75 +95,123 @@ class VSCodeTunnelManager {
       return { success: false, error: `Maximum tunnel limit reached (${this.maxTunnels}). Stop an existing tunnel first.` };
     }
 
-    // Check CLI availability
-    const available = await this.isAvailable();
-    if (!available) {
+    // Check VS Code CLI availability
+    if (!this._commandChecked || !this._devtunnelChecked) await this._initPromise;
+    if (!this._available) {
       const installInfo = this._getInstallInfo();
       return { success: false, error: 'not_found', message: this._installInstructions(), install: installInfo };
     }
 
+    // Check devtunnel CLI availability (required)
+    if (!this._devtunnelAvailable) {
+      return { success: false, error: 'not_found', message: this._devtunnelInstallInstructions() };
+    }
+
+    // Allocate port + generate token
+    const localPort = this._allocatePort();
+    if (localPort === null) {
+      return { success: false, error: 'No available ports in range. Stop an existing tunnel first.' };
+    }
+    const connectionToken = this._generateToken();
+
     // Create tunnel state early so stop() can cancel an in-progress login
     const tunnel = {
-      process: null,
+      serverProcess: null,
+      tunnelProcess: null,
       _loginProcess: null,
-      url: null,
+      localPort,
+      connectionToken,
+      localUrl: null,
+      publicUrl: null,
+      tunnelId: `aiordie-vscode-${sessionId.slice(0, 12).replace(/[^a-z0-9-]/gi, '')}`,
       status: 'starting',
       sessionId,
       workingDir: workingDir || process.cwd(),
       retryCount: 0,
       stopping: false,
-      name: `aiordie-${sessionId.slice(0, 12).replace(/[^a-z0-9-]/gi, '')}`,
-      // Resilience tracking
       _lastSpawnTime: null,
       _totalRestarts: 0,
       _stabilityTimer: null,
       _restartDelayTimer: null,
       _restartDelayResolve: null,
+      _whichDied: null, // 'server' | 'tunnel' | null
     };
     this.tunnels.set(sessionId, tunnel);
+    this._reservedPorts.add(localPort);
 
     this._emitEvent(sessionId, 'vscode_tunnel_status', { status: 'starting' });
-    console.warn(`[VSCODE-TUNNEL] Starting tunnel for session ${sessionId} (cwd: ${tunnel.workingDir})`);
+    console.warn(`[VSCODE-TUNNEL] Starting for session ${sessionId} (port: ${localPort}, cwd: ${tunnel.workingDir})`);
 
-    // Check authentication; if not authed, run explicit login flow
-    const authed = await this._checkAuth();
+    // Check devtunnel auth (OS-level credential store)
+    const authed = await this._checkDevtunnelAuth();
     if (!authed) {
-      console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: not authenticated, starting login flow`);
-      const loginOk = await this._login(sessionId);
+      console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: devtunnel not authenticated, starting login flow`);
+      const loginOk = await this._loginDevtunnel(sessionId);
       if (tunnel.stopping) {
-        this.tunnels.delete(sessionId);
+        this._cleanupTunnel(sessionId);
         return { success: false, error: 'Tunnel start cancelled' };
       }
       if (!loginOk) {
         tunnel.status = 'error';
         tunnel.lastError = 'Authentication failed or was cancelled';
-        this.tunnels.delete(sessionId);
+        this._cleanupTunnel(sessionId);
         this._emitEvent(sessionId, 'vscode_tunnel_error', {
-          message: 'Authentication failed or was cancelled. Click Retry to try again.',
+          message: 'DevTunnel authentication failed or was cancelled. Click Retry to try again.',
         });
         return { success: false, error: 'Authentication failed or was cancelled' };
       }
-      console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: login successful, starting tunnel`);
+      console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: devtunnel login successful`);
     }
 
     // Start health check interval (once)
     this._ensureHealthCheck();
 
-    // Spawn the tunnel process
-    await this._spawn(sessionId);
+    // Spawn VS Code Server
+    const serverOk = await this._spawnServer(sessionId);
+    if (!serverOk) {
+      const current = this.tunnels.get(sessionId);
+      if (current) {
+        this._cleanupTunnel(sessionId);
+      }
+      return { success: false, error: 'Failed to start VS Code Server' };
+    }
+
+    // Wait for TCP readiness
+    await this._waitForPort(tunnel.localPort, PORT_WAIT_TIMEOUT_MS);
+
+    if (tunnel.stopping) {
+      this._cleanupTunnel(sessionId);
+      return { success: false, error: 'Tunnel start cancelled' };
+    }
+
+    // Create devtunnel and spawn tunnel process
+    const tunnelReady = await this._ensureDevtunnel(sessionId);
+    if (!tunnelReady) {
+      // Server is running but tunnel setup failed
+      tunnel.status = 'error';
+      tunnel.lastError = 'Failed to create devtunnel';
+      this._emitEvent(sessionId, 'vscode_tunnel_error', {
+        message: 'Failed to set up dev tunnel. VS Code Server is running locally.',
+      });
+      return { success: false, error: 'Failed to create devtunnel' };
+    }
+
+    await this._spawnTunnel(sessionId);
 
     const current = this.tunnels.get(sessionId);
-    if (current && current.url) {
-      return { success: true, url: current.url };
+    if (current && current.publicUrl) {
+      return { success: true, url: current.publicUrl, localUrl: current.localUrl, publicUrl: current.publicUrl };
+    } else if (current && current.localUrl) {
+      return { success: true, url: current.localUrl, localUrl: current.localUrl, publicUrl: null };
     } else if (current && current.status === 'error') {
       return { success: false, error: current.lastError || 'Failed to start tunnel' };
     }
 
-    return { success: true, url: null }; // still starting (auth flow, etc.)
+    return { success: true, url: null };
   }
 
   /**
-   * Stop a VS Code tunnel for the given session.
+   * Stop a VS Code tunnel for the given session (sequenced teardown).
    */
   async stop(sessionId) {
     const tunnel = this.tunnels.get(sessionId);
@@ -162,23 +233,25 @@ class VSCodeTunnelManager {
       tunnel._restartDelayResolve = null;
     }
 
-    if (tunnel.process) {
-      await new Promise((resolve) => {
-        const timeout = setTimeout(() => {
-          try { tunnel.process.kill('SIGKILL'); } catch {}
-          resolve();
-        }, 5000);
-
-        tunnel.process.once('exit', () => {
-          clearTimeout(timeout);
-          resolve();
-        });
-
-        try { tunnel.process.kill(); } catch {}
-      });
+    // Step 1: Kill tunnel process first
+    if (tunnel.tunnelProcess) {
+      await this._killProcess(tunnel.tunnelProcess);
+      tunnel.tunnelProcess = null;
     }
 
-    this.tunnels.delete(sessionId);
+    // Step 2: Clean up devtunnel (fire-and-forget)
+    if (this._devtunnelCommand) {
+      execFile(this._devtunnelCommand, ['delete', tunnel.tunnelId, '-y'], { timeout: 10000 }, () => {});
+    }
+
+    // Step 3: Kill server process
+    if (tunnel.serverProcess) {
+      await this._killProcess(tunnel.serverProcess);
+      tunnel.serverProcess = null;
+    }
+
+    // Step 4: Release port
+    this._cleanupTunnel(sessionId);
     this._emitEvent(sessionId, 'vscode_tunnel_status', { status: 'stopped' });
     console.warn(`[VSCODE-TUNNEL] Stopped tunnel for session ${sessionId}`);
     return { success: true };
@@ -189,11 +262,14 @@ class VSCodeTunnelManager {
    */
   getStatus(sessionId) {
     const tunnel = this.tunnels.get(sessionId);
-    if (!tunnel) return { status: 'stopped', url: null };
+    if (!tunnel) return { status: 'stopped', url: null, localUrl: null, publicUrl: null };
     return {
       status: tunnel.status,
-      url: tunnel.url,
-      pid: tunnel.process ? tunnel.process.pid : null,
+      localUrl: tunnel.localUrl,
+      publicUrl: tunnel.publicUrl,
+      url: tunnel.publicUrl || tunnel.localUrl,
+      pid: tunnel.serverProcess ? tunnel.serverProcess.pid : null,
+      tunnelPid: tunnel.tunnelProcess ? tunnel.tunnelProcess.pid : null,
     };
   }
 
@@ -218,7 +294,7 @@ class VSCodeTunnelManager {
   _activeCount() {
     let count = 0;
     for (const t of this.tunnels.values()) {
-      if (t.status === 'running' || t.status === 'starting') count++;
+      if (t.status === 'running' || t.status === 'starting' || t.status === 'degraded') count++;
     }
     return count;
   }
@@ -227,6 +303,85 @@ class VSCodeTunnelManager {
     this.onEvent(sessionId, { type, ...data });
   }
 
+  _cleanupTunnel(sessionId) {
+    const tunnel = this.tunnels.get(sessionId);
+    if (tunnel) {
+      this._reservedPorts.delete(tunnel.localPort);
+    }
+    this.tunnels.delete(sessionId);
+  }
+
+  /**
+   * Kill a child process with SIGTERM, escalating to SIGKILL after 5s.
+   */
+  _killProcess(proc) {
+    return new Promise((resolve) => {
+      if (!proc || proc.exitCode !== null) {
+        resolve();
+        return;
+      }
+
+      const timeout = setTimeout(() => {
+        try { proc.kill('SIGKILL'); } catch {}
+        resolve();
+      }, 5000);
+
+      proc.once('exit', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      try { proc.kill(); } catch {}
+    });
+  }
+
+  // ── Port Allocation ──────────────────────────────────────────
+
+  /**
+   * Allocate a free port from the range. Returns null if exhausted.
+   */
+  _allocatePort() {
+    for (let p = VSCODE_BASE_PORT; p < VSCODE_BASE_PORT + VSCODE_PORT_RANGE; p++) {
+      if (!this._reservedPorts.has(p)) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Generate a random connection token.
+   */
+  _generateToken() {
+    return crypto.randomBytes(32).toString('hex');
+  }
+
+  /**
+   * Wait for a TCP port to accept connections.
+   */
+  _waitForPort(port, timeoutMs) {
+    const start = Date.now();
+    return new Promise((resolve) => {
+      const attempt = () => {
+        if (Date.now() - start > timeoutMs) {
+          resolve(false);
+          return;
+        }
+        const sock = net.createConnection({ port, host: '127.0.0.1' }, () => {
+          sock.destroy();
+          resolve(true);
+        });
+        sock.on('error', () => {
+          sock.destroy();
+          setTimeout(attempt, 200);
+        });
+      };
+      attempt();
+    });
+  }
+
+  // ── VS Code CLI Discovery ────────────────────────────────────
+
   /**
    * Locate the `code` CLI executable.
    */
@@ -234,7 +389,6 @@ class VSCodeTunnelManager {
     const isWin = process.platform === 'win32';
     const home = os.homedir();
 
-    // Platform-specific candidate paths
     const candidates = [];
     if (isWin) {
       const localAppData = process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
@@ -259,7 +413,6 @@ class VSCodeTunnelManager {
       );
     }
 
-    // Try absolute paths first
     for (const candidate of candidates) {
       try {
         fs.accessSync(candidate, fs.constants.X_OK);
@@ -269,7 +422,6 @@ class VSCodeTunnelManager {
       }
     }
 
-    // Fallback: PATH lookup
     const checker = isWin ? 'where' : 'which';
     return new Promise((resolve) => {
       execFile(checker, ['code'], { timeout: 5000 }, (err, stdout) => {
@@ -283,77 +435,54 @@ class VSCodeTunnelManager {
     });
   }
 
+  // ── devtunnel CLI Discovery ──────────────────────────────────
+
   /**
-   * Check if the user is authenticated with VS Code tunnels.
+   * Locate the `devtunnel` CLI executable.
+   * Note: devtunnel is a standalone binary; does NOT need shell: true on Windows.
    */
-  async _checkAuth() {
-    if (!this._command) return false;
-    const opts = { timeout: 5000 };
-    // Windows .cmd/.bat files need shell to execute
-    if (process.platform === 'win32') opts.shell = true;
+  async _findDevtunnelCommand() {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
     return new Promise((resolve) => {
-      execFile(this._command, ['tunnel', 'user', 'show'], opts, (err) => {
+      execFile(checker, ['devtunnel'], { timeout: 5000 }, (err, stdout) => {
+        if (err) {
+          resolve(null);
+        } else {
+          const found = stdout.toString().trim().split(/\r?\n/)[0];
+          resolve(found || null);
+        }
+      });
+    });
+  }
+
+  /**
+   * Check if user is authenticated with devtunnel (OS-level credential store).
+   */
+  async _checkDevtunnelAuth() {
+    if (!this._devtunnelCommand) return false;
+    return new Promise((resolve) => {
+      execFile(this._devtunnelCommand, ['user', 'show'], { timeout: 10000 }, (err) => {
         resolve(!err);
       });
     });
   }
 
-  _installInstructions() {
-    const isWin = process.platform === 'win32';
-    const isMac = process.platform === 'darwin';
-    let instructions = 'VS Code CLI not found. Install VS Code from https://code.visualstudio.com/download';
-    if (isWin) {
-      instructions += '\nThen run "Install \'code\' command in PATH" from the VS Code Command Palette.';
-    } else if (isMac) {
-      instructions += '\nThen run "Shell Command: Install \'code\' command in PATH" from VS Code.';
-    } else {
-      instructions += '\nThe `code` command is usually added to PATH automatically after installation.';
-    }
-    return instructions;
-  }
-
-  _getInstallInfo() {
-    try {
-      const InstallAdvisor = require('./install-advisor');
-      const advisor = new InstallAdvisor();
-      return advisor.getInstallInfo('vscode');
-    } catch {
-      return null;
-    }
-  }
-
-  clearAvailabilityCache() {
-    this._command = null;
-    this._commandChecked = false;
-    this._available = false;
-    this._initPromise = this._findCommand().then((cmd) => {
-      this._command = cmd;
-      this._commandChecked = true;
-      this._available = !!cmd;
-    });
-  }
-
   /**
-   * Run `code tunnel login --provider github` and wait for completion.
+   * Run `devtunnel user login` and wait for completion.
    * Emits vscode_tunnel_auth events so the client can show the device code.
-   * Returns true if login succeeded, false otherwise.
    */
-  async _login(sessionId) {
+  async _loginDevtunnel(sessionId) {
     const tunnel = this.tunnels.get(sessionId);
     if (!tunnel || tunnel.stopping) return false;
 
-    const args = ['tunnel', 'login', '--provider', 'github'];
     const spawnOptions = {
       cwd: tunnel.workingDir,
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env },
     };
-    if (process.platform === 'win32') {
-      spawnOptions.shell = true;
-    }
 
     return new Promise((resolve) => {
-      tunnel._loginProcess = spawn(this._command, args, spawnOptions);
+      tunnel._loginProcess = spawn(this._devtunnelCommand, ['user', 'login'], spawnOptions);
 
       let outputBuffer = '';
       let resolved = false;
@@ -361,7 +490,7 @@ class VSCodeTunnelManager {
       const timeout = setTimeout(() => {
         if (!resolved) {
           resolved = true;
-          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: login timed out after ${LOGIN_TIMEOUT_MS / 1000}s`);
+          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: devtunnel login timed out after ${LOGIN_TIMEOUT_MS / 1000}s`);
           try { tunnel._loginProcess.kill(); } catch {}
           tunnel._loginProcess = null;
           resolve(false);
@@ -371,21 +500,9 @@ class VSCodeTunnelManager {
       tunnel._loginProcess.stdout.on('data', (data) => {
         const output = data.toString();
         outputBuffer += output;
-        if (this.dev) process.stdout.write(`  [vscode-login] ${output}`);
+        if (this.dev) process.stdout.write(`  [devtunnel-login] ${output}`);
 
-        // Check for GitHub device code auth prompt
-        const githubMatch = output.match(/https:\/\/github\.com\/login\/device/i)
-          || outputBuffer.match(/https:\/\/github\.com\/login\/device/i);
-        if (githubMatch) {
-          const codeMatch = outputBuffer.match(/code\s+([A-Z0-9]{4}-[A-Z0-9]{4})/i);
-          const deviceCode = codeMatch ? codeMatch[1] : null;
-          this._emitEvent(sessionId, 'vscode_tunnel_auth', {
-            authUrl: 'https://github.com/login/device',
-            deviceCode,
-          });
-        }
-
-        // Also handle Microsoft devicelogin as fallback
+        // Check for Microsoft device code auth prompt
         const msMatch = output.match(/https:\/\/microsoft\.com\/devicelogin/i)
           || outputBuffer.match(/https:\/\/microsoft\.com\/devicelogin/i);
         if (msMatch) {
@@ -396,18 +513,44 @@ class VSCodeTunnelManager {
             deviceCode,
           });
         }
+
+        // Also handle GitHub device code as fallback
+        const githubMatch = output.match(/https:\/\/github\.com\/login\/device/i)
+          || outputBuffer.match(/https:\/\/github\.com\/login\/device/i);
+        if (githubMatch) {
+          const codeMatch = outputBuffer.match(/code\s+([A-Z0-9]{4}-[A-Z0-9]{4})/i);
+          const deviceCode = codeMatch ? codeMatch[1] : null;
+          this._emitEvent(sessionId, 'vscode_tunnel_auth', {
+            authUrl: 'https://github.com/login/device',
+            deviceCode,
+          });
+        }
       });
 
       tunnel._loginProcess.stderr.on('data', (data) => {
         const output = data.toString().trim();
-        if (output && this.dev) console.error(`  [vscode-login] ${output}`);
+        if (output) {
+          outputBuffer += output;
+          if (this.dev) console.error(`  [devtunnel-login] ${output}`);
+
+          // Also check stderr for auth URLs (devtunnel may use stderr)
+          const msMatch = output.match(/https:\/\/microsoft\.com\/devicelogin/i);
+          if (msMatch) {
+            const codeMatch = outputBuffer.match(/code\s+([A-Z0-9]{6,9})/i);
+            const deviceCode = codeMatch ? codeMatch[1] : null;
+            this._emitEvent(sessionId, 'vscode_tunnel_auth', {
+              authUrl: 'https://microsoft.com/devicelogin',
+              deviceCode,
+            });
+          }
+        }
       });
 
       tunnel._loginProcess.on('error', (err) => {
         clearTimeout(timeout);
         if (!resolved) {
           resolved = true;
-          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: login process error: ${err.message}`);
+          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: devtunnel login error: ${err.message}`);
           tunnel._loginProcess = null;
           resolve(false);
         }
@@ -419,25 +562,29 @@ class VSCodeTunnelManager {
         if (!resolved) {
           resolved = true;
           const success = code === 0;
-          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: login exited with code ${code}`);
+          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: devtunnel login exited with code ${code}`);
           resolve(success);
         }
       });
     });
   }
 
+  // ── VS Code Server ───────────────────────────────────────────
+
   /**
-   * Spawn the `code tunnel` process and wait for the URL.
+   * Spawn `code serve-web` and wait for readiness.
+   * Returns true if server started successfully.
    */
-  async _spawn(sessionId) {
+  async _spawnServer(sessionId, retryAttempt = 0) {
     const tunnel = this.tunnels.get(sessionId);
-    if (!tunnel || tunnel.stopping) return;
+    if (!tunnel || tunnel.stopping) return false;
 
     const args = [
-      'tunnel',
+      'serve-web',
+      '--host', '127.0.0.1',
+      '--port', String(tunnel.localPort),
+      '--connection-token', tunnel.connectionToken,
       '--accept-server-license-terms',
-      '--no-sleep',
-      '--name', tunnel.name,
     ];
 
     return new Promise((resolve) => {
@@ -451,107 +598,230 @@ class VSCodeTunnelManager {
       if (process.platform === 'win32') {
         spawnOptions.shell = true;
       }
-      tunnel.process = spawn(this._command, args, spawnOptions);
 
-      let urlResolved = false;
+      tunnel.serverProcess = spawn(this._command, args, spawnOptions);
+
+      let readyResolved = false;
       let outputBuffer = '';
 
-      // Timeout: if no URL appears within 30s, warn
+      const readyTimeout = setTimeout(() => {
+        if (!readyResolved) {
+          readyResolved = true;
+          // Server may still be starting — set localUrl optimistically
+          tunnel.localUrl = `http://localhost:${tunnel.localPort}/?tkn=${tunnel.connectionToken}`;
+          resolve(true);
+        }
+      }, URL_TIMEOUT_MS);
+
+      tunnel.serverProcess.stdout.on('data', (data) => {
+        const output = data.toString();
+        outputBuffer += output;
+        if (this.dev) process.stdout.write(`  [vscode-server] ${output}`);
+
+        // Parse "Web UI available at http://localhost:<port>"
+        const readyMatch = output.match(/https?:\/\/localhost[:\d]*/i)
+          || output.match(/Web UI available at/i);
+        if (readyMatch && !readyResolved) {
+          readyResolved = true;
+          clearTimeout(readyTimeout);
+          tunnel.localUrl = `http://localhost:${tunnel.localPort}/?tkn=${tunnel.connectionToken}`;
+          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: VS Code Server ready at ${tunnel.localUrl}`);
+          resolve(true);
+        }
+      });
+
+      tunnel.serverProcess.stderr.on('data', (data) => {
+        const output = data.toString().trim();
+        if (output) {
+          if (this.dev) console.error(`  [vscode-server] ${output}`);
+
+          // Detect EADDRINUSE and retry with next port
+          if (output.includes('EADDRINUSE') || output.includes('address already in use')) {
+            if (!readyResolved && retryAttempt < PORT_RETRY_MAX) {
+              readyResolved = true;
+              clearTimeout(readyTimeout);
+              console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: port ${tunnel.localPort} in use, retrying...`);
+              try { tunnel.serverProcess.kill(); } catch {}
+              tunnel.serverProcess = null;
+
+              // Release old port, allocate new one
+              this._reservedPorts.delete(tunnel.localPort);
+              const newPort = this._allocatePort();
+              if (newPort === null) {
+                resolve(false);
+                return;
+              }
+              tunnel.localPort = newPort;
+              this._reservedPorts.add(newPort);
+              this._spawnServer(sessionId, retryAttempt + 1).then(resolve);
+              return;
+            }
+          }
+        }
+      });
+
+      tunnel.serverProcess.on('error', (err) => {
+        clearTimeout(readyTimeout);
+        if (!readyResolved) {
+          readyResolved = true;
+          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: server process error: ${err.message}`);
+          resolve(false);
+        }
+      });
+
+      tunnel.serverProcess.on('exit', (code) => {
+        clearTimeout(readyTimeout);
+        tunnel.serverProcess = null;
+
+        if (!readyResolved) {
+          readyResolved = true;
+          resolve(false);
+        }
+
+        // Auto-restart if not intentionally stopped
+        if (!tunnel.stopping && this.tunnels.has(sessionId)) {
+          tunnel._whichDied = 'server';
+          this._restart(sessionId);
+        }
+      });
+    });
+  }
+
+  // ── Dev Tunnel ───────────────────────────────────────────────
+
+  /**
+   * Create the named devtunnel and configure its port.
+   * Both commands are idempotent — "Conflict" means it already exists.
+   */
+  async _ensureDevtunnel(sessionId) {
+    const tunnel = this.tunnels.get(sessionId);
+    if (!tunnel || tunnel.stopping) return false;
+
+    // Step 1: Create the tunnel (allow anonymous so token handles access control)
+    const tunnelCreated = await this._execDevtunnel(
+      ['create', tunnel.tunnelId, '--allow-anonymous'],
+      sessionId
+    );
+    if (!tunnelCreated) return false;
+
+    // Step 2: Configure the port
+    const portCreated = await this._execDevtunnel(
+      ['port', 'create', tunnel.tunnelId, '-p', String(tunnel.localPort)],
+      sessionId
+    );
+    if (!portCreated) return false;
+
+    return true;
+  }
+
+  /**
+   * Run a devtunnel command. Returns true on success or "Conflict" (already exists).
+   */
+  async _execDevtunnel(args, sessionId) {
+    return new Promise((resolve) => {
+      execFile(this._devtunnelCommand, args, { timeout: 15000 }, (err, stdout, stderr) => {
+        if (err) {
+          const output = (stderr || stdout || '').toString();
+          if (output.includes('Conflict')) {
+            resolve(true);
+          } else {
+            console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: devtunnel ${args[0]} failed: ${output || err.message}`);
+            resolve(false);
+          }
+        } else {
+          resolve(true);
+        }
+      });
+    });
+  }
+
+  /**
+   * Spawn `devtunnel host` and wait for the public URL.
+   */
+  async _spawnTunnel(sessionId) {
+    const tunnel = this.tunnels.get(sessionId);
+    if (!tunnel || tunnel.stopping) return;
+
+    const args = ['host', tunnel.tunnelId];
+
+    return new Promise((resolve) => {
+      // devtunnel is a standalone binary — no shell: true needed
+      tunnel.tunnelProcess = spawn(this._devtunnelCommand, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      let urlResolved = false;
+
       const urlTimeout = setTimeout(() => {
         if (!urlResolved) {
           urlResolved = true;
-          // Don't kill — it might still be in auth flow. Just resolve.
+          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: devtunnel started but no URL within ${URL_TIMEOUT_MS / 1000}s`);
           resolve();
         }
       }, URL_TIMEOUT_MS);
 
-      tunnel.process.stdout.on('data', (data) => {
+      tunnel.tunnelProcess.stdout.on('data', (data) => {
         const output = data.toString();
-        outputBuffer += output;
-        if (this.dev) process.stdout.write(`  [vscode-tunnel] ${output}`);
+        if (this.dev) process.stdout.write(`  [devtunnel] ${output}`);
 
-        // Check for device code auth prompt
-        const authMatch = output.match(/https:\/\/github\.com\/login\/device/i)
-          || outputBuffer.match(/https:\/\/github\.com\/login\/device/i);
-        if (authMatch) {
-          // Extract the code (usually appears as "enter code XXXX-YYYY")
-          const codeMatch = outputBuffer.match(/code\s+([A-Z0-9]{4}-[A-Z0-9]{4})/i);
-          const deviceCode = codeMatch ? codeMatch[1] : null;
-          this._emitEvent(sessionId, 'vscode_tunnel_auth', {
-            authUrl: 'https://github.com/login/device',
-            deviceCode,
-          });
-        }
-
-        // Also check for Microsoft login device code
-        const msAuthMatch = output.match(/https:\/\/microsoft\.com\/devicelogin/i)
-          || outputBuffer.match(/https:\/\/microsoft\.com\/devicelogin/i);
-        if (msAuthMatch) {
-          const codeMatch = outputBuffer.match(/code\s+([A-Z0-9]{6,9})/i);
-          const deviceCode = codeMatch ? codeMatch[1] : null;
-          this._emitEvent(sessionId, 'vscode_tunnel_auth', {
-            authUrl: 'https://microsoft.com/devicelogin',
-            deviceCode,
-          });
-        }
-
-        // Check for tunnel URL
-        const urlMatch = output.match(/https:\/\/vscode\.dev\/tunnel\/[^\s,)>]*/);
-        if (urlMatch && !tunnel.url) {
-          tunnel.url = urlMatch[0].trim();
+        const match = output.match(/https:\/\/[\w.-]+\.devtunnels\.ms[^\s,]*/);
+        if (match && !tunnel.publicUrl) {
+          // Append connection token to the public URL
+          const baseUrl = match[0].trim();
+          const separator = baseUrl.includes('?') ? '&' : '?';
+          tunnel.publicUrl = `${baseUrl}${separator}tkn=${tunnel.connectionToken}`;
           tunnel.status = 'running';
           urlResolved = true;
           clearTimeout(urlTimeout);
           this._startStabilityTimer(tunnel);
-          this._emitEvent(sessionId, 'vscode_tunnel_started', { url: tunnel.url });
+          this._emitEvent(sessionId, 'vscode_tunnel_started', {
+            url: tunnel.publicUrl,
+            localUrl: tunnel.localUrl,
+            publicUrl: tunnel.publicUrl,
+          });
+          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: tunnel active at ${tunnel.publicUrl}`);
           resolve();
         }
       });
 
-      tunnel.process.stderr.on('data', (data) => {
+      tunnel.tunnelProcess.stderr.on('data', (data) => {
         const output = data.toString().trim();
         if (output) {
-          if (this.dev) console.error(`  [vscode-tunnel] ${output}`);
-          // Forward significant errors
+          if (this.dev) console.error(`  [devtunnel] ${output}`);
           if (output.toLowerCase().includes('error') || output.toLowerCase().includes('failed')) {
             this._emitEvent(sessionId, 'vscode_tunnel_error', { message: output });
           }
         }
       });
 
-      tunnel.process.on('error', (err) => {
+      tunnel.tunnelProcess.on('error', (err) => {
         clearTimeout(urlTimeout);
-        tunnel.status = 'error';
-        tunnel.lastError = err.message;
-        this._emitEvent(sessionId, 'vscode_tunnel_error', { message: err.message });
+        console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: devtunnel process error: ${err.message}`);
         if (!urlResolved) {
           urlResolved = true;
           resolve();
         }
       });
 
-      tunnel.process.on('exit', (code, signal) => {
+      tunnel.tunnelProcess.on('exit', (code) => {
         clearTimeout(urlTimeout);
-        this._clearStabilityTimer(tunnel);
-        tunnel.process = null;
+        tunnel.tunnelProcess = null;
 
         if (!urlResolved) {
           urlResolved = true;
           resolve();
         }
 
-        // Auto-restart if not intentionally stopped
-        if (!tunnel.stopping && code !== 0) {
+        // Auto-restart tunnel only (server may still be alive)
+        if (!tunnel.stopping && this.tunnels.has(sessionId)) {
+          tunnel._whichDied = 'tunnel';
           this._restart(sessionId);
-        } else if (!tunnel.stopping) {
-          // Clean exit
-          tunnel.status = 'stopped';
-          this.tunnels.delete(sessionId);
-          this._emitEvent(sessionId, 'vscode_tunnel_status', { status: 'stopped' });
         }
       });
     });
   }
+
+  // ── Resilience ───────────────────────────────────────────────
 
   /**
    * Start the stability timer. After STABILITY_THRESHOLD_MS of uptime,
@@ -579,7 +849,9 @@ class VSCodeTunnelManager {
 
   /**
    * Auto-restart with capped exponential backoff.
-   * retryCount resets after stable uptime via _startStabilityTimer().
+   * Behavior depends on which process died:
+   *   - tunnel only: restart tunnel, server stays alive (degraded)
+   *   - server: kill tunnel too, restart both
    */
   async _restart(sessionId) {
     const tunnel = this.tunnels.get(sessionId);
@@ -587,6 +859,10 @@ class VSCodeTunnelManager {
 
     tunnel._totalRestarts++;
     tunnel.retryCount++;
+    this._clearStabilityTimer(tunnel);
+
+    const whichDied = tunnel._whichDied || 'server';
+    tunnel._whichDied = null;
 
     const uptimeMs = tunnel._lastSpawnTime ? Date.now() - tunnel._lastSpawnTime : 0;
     const uptimeStr = uptimeMs > 60000
@@ -601,7 +877,10 @@ class VSCodeTunnelManager {
         fatal: true,
       });
       console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: ${tunnel.lastError} Total lifetime restarts: ${tunnel._totalRestarts}. Last uptime: ${uptimeStr}.`);
-      this.tunnels.delete(sessionId);
+      // Kill remaining process
+      if (tunnel.serverProcess) await this._killProcess(tunnel.serverProcess);
+      if (tunnel.tunnelProcess) await this._killProcess(tunnel.tunnelProcess);
+      this._cleanupTunnel(sessionId);
       return;
     }
 
@@ -609,19 +888,44 @@ class VSCodeTunnelManager {
       Math.pow(2, tunnel.retryCount - 1) * MIN_RESTART_DELAY_MS,
       MAX_RESTART_DELAY_MS
     );
-    tunnel.status = 'restarting';
-    this._emitEvent(sessionId, 'vscode_tunnel_status', {
-      status: 'restarting',
-      attempt: tunnel.retryCount,
-      maxRetries: MAX_RETRIES,
-    });
 
-    console.warn(
-      `[VSCODE-TUNNEL] Session ${sessionId} lost after ${uptimeStr} uptime. ` +
-      `Restarting in ${delay / 1000}s (attempt ${tunnel.retryCount}/${MAX_RETRIES}, ` +
-      `lifetime restarts: ${tunnel._totalRestarts})...`
-    );
+    if (whichDied === 'tunnel' && tunnel.serverProcess) {
+      // Tunnel died but server is still alive — degraded mode
+      tunnel.status = 'degraded';
+      tunnel.publicUrl = null;
+      this._emitEvent(sessionId, 'vscode_tunnel_status', {
+        status: 'degraded',
+        localUrl: tunnel.localUrl,
+        attempt: tunnel.retryCount,
+        maxRetries: MAX_RETRIES,
+      });
+      console.warn(
+        `[VSCODE-TUNNEL] Session ${sessionId}: tunnel lost after ${uptimeStr}. ` +
+        `Server still running. Restarting tunnel in ${delay / 1000}s ` +
+        `(attempt ${tunnel.retryCount}/${MAX_RETRIES}).`
+      );
+    } else {
+      // Server died — kill tunnel too, restart both
+      if (tunnel.tunnelProcess) {
+        try { tunnel.tunnelProcess.kill(); } catch {}
+        tunnel.tunnelProcess = null;
+      }
+      tunnel.status = 'restarting';
+      tunnel.localUrl = null;
+      tunnel.publicUrl = null;
+      this._emitEvent(sessionId, 'vscode_tunnel_status', {
+        status: 'restarting',
+        attempt: tunnel.retryCount,
+        maxRetries: MAX_RETRIES,
+      });
+      console.warn(
+        `[VSCODE-TUNNEL] Session ${sessionId}: server lost after ${uptimeStr}. ` +
+        `Restarting in ${delay / 1000}s (attempt ${tunnel.retryCount}/${MAX_RETRIES}, ` +
+        `lifetime restarts: ${tunnel._totalRestarts}).`
+      );
+    }
 
+    // Wait with backoff
     await new Promise((resolve) => {
       tunnel._restartDelayResolve = resolve;
       tunnel._restartDelayTimer = setTimeout(resolve, delay);
@@ -631,34 +935,122 @@ class VSCodeTunnelManager {
     });
     tunnel._restartDelayResolve = null;
 
-    if (!tunnel.stopping && this.tunnels.has(sessionId)) {
-      tunnel.url = null;
+    if (tunnel.stopping || !this.tunnels.has(sessionId)) return;
+
+    if (whichDied === 'tunnel' && tunnel.serverProcess) {
+      // Restart tunnel only
       tunnel.status = 'starting';
-      await this._spawn(sessionId);
+      const tunnelReady = await this._ensureDevtunnel(sessionId);
+      if (tunnelReady && !tunnel.stopping) {
+        await this._spawnTunnel(sessionId);
+      }
+    } else {
+      // Restart both
+      tunnel.status = 'starting';
+      const serverOk = await this._spawnServer(sessionId);
+      if (serverOk && !tunnel.stopping) {
+        await this._waitForPort(tunnel.localPort, PORT_WAIT_TIMEOUT_MS);
+        if (!tunnel.stopping) {
+          const tunnelReady = await this._ensureDevtunnel(sessionId);
+          if (tunnelReady && !tunnel.stopping) {
+            await this._spawnTunnel(sessionId);
+          }
+        }
+      }
     }
   }
 
   /**
-   * Periodic health check — detect externally killed tunnel processes.
+   * Periodic health check — detect externally killed processes.
    */
   _ensureHealthCheck() {
     if (this._healthInterval) return;
     this._healthInterval = setInterval(() => {
       for (const [sessionId, tunnel] of this.tunnels) {
-        if (tunnel.status === 'running' && (!tunnel.process || tunnel.process.exitCode !== null)) {
-          console.warn(`[VSCODE-TUNNEL] Session ${sessionId} tunnel process died externally`);
-          tunnel.status = 'stopped';
-          this.tunnels.delete(sessionId);
-          this._emitEvent(sessionId, 'vscode_tunnel_status', { status: 'stopped', reason: 'process_died' });
+        if (tunnel.stopping) continue;
+
+        const serverDead = tunnel.status !== 'starting' && tunnel.status !== 'restarting'
+          && (!tunnel.serverProcess || tunnel.serverProcess.exitCode !== null);
+        const tunnelDead = tunnel.status !== 'starting' && tunnel.status !== 'restarting'
+          && (!tunnel.tunnelProcess || tunnel.tunnelProcess.exitCode !== null);
+
+        if (serverDead && (tunnel.status === 'running' || tunnel.status === 'degraded')) {
+          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: server process died externally`);
+          tunnel._whichDied = 'server';
+          this._restart(sessionId);
+        } else if (tunnelDead && tunnel.status === 'running') {
+          console.warn(`[VSCODE-TUNNEL] Session ${sessionId}: tunnel process died externally`);
+          tunnel._whichDied = 'tunnel';
+          this._restart(sessionId);
         }
       }
 
-      // Clean up interval if no tunnels active
       if (this.tunnels.size === 0) {
         clearInterval(this._healthInterval);
         this._healthInterval = null;
       }
     }, HEALTH_CHECK_INTERVAL_MS);
+  }
+
+  // ── Install Instructions ─────────────────────────────────────
+
+  _installInstructions() {
+    const isWin = process.platform === 'win32';
+    const isMac = process.platform === 'darwin';
+    let instructions = 'VS Code CLI not found. Install VS Code from https://code.visualstudio.com/download';
+    if (isWin) {
+      instructions += '\nThen run "Install \'code\' command in PATH" from the VS Code Command Palette.';
+    } else if (isMac) {
+      instructions += '\nThen run "Shell Command: Install \'code\' command in PATH" from VS Code.';
+    } else {
+      instructions += '\nThe `code` command is usually added to PATH automatically after installation.';
+    }
+    return instructions;
+  }
+
+  _devtunnelInstallInstructions() {
+    const isWin = process.platform === 'win32';
+    const isMac = process.platform === 'darwin';
+    let instructions = 'devtunnel CLI not found. Install it:';
+    if (isWin) {
+      instructions += '\n  winget install Microsoft.devtunnel';
+    } else if (isMac) {
+      instructions += '\n  brew install --cask devtunnel';
+    } else {
+      instructions += '\n  curl -sL https://aka.ms/DevTunnelCliInstall | bash';
+    }
+    return instructions;
+  }
+
+  _getInstallInfo() {
+    try {
+      const InstallAdvisor = require('./install-advisor');
+      const advisor = new InstallAdvisor();
+      return advisor.getInstallInfo('vscode');
+    } catch {
+      return null;
+    }
+  }
+
+  clearAvailabilityCache() {
+    this._command = null;
+    this._commandChecked = false;
+    this._available = false;
+    this._devtunnelCommand = null;
+    this._devtunnelChecked = false;
+    this._devtunnelAvailable = false;
+    this._initPromise = Promise.all([
+      this._findCommand().then((cmd) => {
+        this._command = cmd;
+        this._commandChecked = true;
+        this._available = !!cmd;
+      }),
+      this._findDevtunnelCommand().then((cmd) => {
+        this._devtunnelCommand = cmd;
+        this._devtunnelChecked = true;
+        this._devtunnelAvailable = !!cmd;
+      }),
+    ]);
   }
 }
 

--- a/test/vscode-tunnel.test.js
+++ b/test/vscode-tunnel.test.js
@@ -14,6 +14,8 @@ describe('VSCodeTunnelManager', function () {
     await manager.stopAll();
   });
 
+  // ── Constructor ────────────────────────────────────────────
+
   describe('constructor', function () {
     it('should initialize with empty tunnels map', function () {
       assert(manager.tunnels instanceof Map);
@@ -38,7 +40,20 @@ describe('VSCodeTunnelManager', function () {
         }
       }
     });
+
+    it('should discover both code and devtunnel CLIs during init', async function () {
+      await manager._initPromise;
+      assert.strictEqual(manager._commandChecked, true);
+      assert.strictEqual(manager._devtunnelChecked, true);
+    });
+
+    it('should initialize _reservedPorts as empty Set', function () {
+      assert(manager._reservedPorts instanceof Set);
+      assert.strictEqual(manager._reservedPorts.size, 0);
+    });
   });
+
+  // ── isAvailable ────────────────────────────────────────────
 
   describe('isAvailable', function () {
     it('should return a boolean', async function () {
@@ -46,27 +61,113 @@ describe('VSCodeTunnelManager', function () {
       assert(typeof result === 'boolean');
     });
 
-    it('isAvailableSync should return boolean after init', async function () {
+    it('should return true only when both code AND devtunnel are available', async function () {
+      await manager._initPromise;
+
+      // Both available
+      manager._available = true;
+      manager._devtunnelAvailable = true;
+      assert.strictEqual(await manager.isAvailable(), true);
+
+      // Only code available
+      manager._available = true;
+      manager._devtunnelAvailable = false;
+      assert.strictEqual(await manager.isAvailable(), false);
+
+      // Only devtunnel available
+      manager._available = false;
+      manager._devtunnelAvailable = true;
+      assert.strictEqual(await manager.isAvailable(), false);
+
+      // Neither available
+      manager._available = false;
+      manager._devtunnelAvailable = false;
+      assert.strictEqual(await manager.isAvailable(), false);
+    });
+  });
+
+  // ── isAvailableSync ────────────────────────────────────────
+
+  describe('isAvailableSync', function () {
+    it('should return boolean after init completes', async function () {
       await manager._initPromise;
       const result = manager.isAvailableSync();
       assert(typeof result === 'boolean');
     });
-  });
 
-  describe('getStatus', function () {
-    it('should return stopped status for unknown session', function () {
-      const status = manager.getStatus('nonexistent');
-      assert.strictEqual(status.status, 'stopped');
-      assert.strictEqual(status.url, null);
+    it('should return true only when both CLIs are cached as available', async function () {
+      await manager._initPromise;
+
+      manager._available = true;
+      manager._devtunnelAvailable = true;
+      assert.strictEqual(manager.isAvailableSync(), true);
+
+      manager._available = true;
+      manager._devtunnelAvailable = false;
+      assert.strictEqual(manager.isAvailableSync(), false);
+
+      manager._available = false;
+      manager._devtunnelAvailable = true;
+      assert.strictEqual(manager.isAvailableSync(), false);
     });
   });
 
+  // ── Port Allocation ────────────────────────────────────────
+
+  describe('_allocatePort', function () {
+    it('should allocate from base port 9100', function () {
+      const port = manager._allocatePort();
+      assert.strictEqual(port, 9100);
+    });
+
+    it('should allocate sequential ports skipping reserved', function () {
+      manager._reservedPorts.add(9100);
+      assert.strictEqual(manager._allocatePort(), 9101);
+    });
+
+    it('should skip multiple reserved ports', function () {
+      manager._reservedPorts.add(9100);
+      manager._reservedPorts.add(9101);
+      manager._reservedPorts.add(9102);
+      assert.strictEqual(manager._allocatePort(), 9103);
+    });
+
+    it('should return null when all ports are exhausted', function () {
+      // Reserve all 100 ports in the range (9100-9199)
+      for (let p = 9100; p < 9200; p++) {
+        manager._reservedPorts.add(p);
+      }
+      assert.strictEqual(manager._allocatePort(), null);
+    });
+  });
+
+  // ── Token Generation ───────────────────────────────────────
+
+  describe('_generateToken', function () {
+    it('should produce a 64-char hex string', function () {
+      const token = manager._generateToken();
+      assert.strictEqual(typeof token, 'string');
+      assert.strictEqual(token.length, 64);
+      assert(/^[0-9a-f]{64}$/.test(token), 'Token should be lowercase hex');
+    });
+
+    it('should produce unique tokens on successive calls', function () {
+      const a = manager._generateToken();
+      const b = manager._generateToken();
+      assert.notStrictEqual(a, b);
+    });
+  });
+
+  // ── start ──────────────────────────────────────────────────
+
   describe('start', function () {
-    it('should return error when CLI not found', async function () {
-      // Force command to null
+    it('should return error when VS Code CLI not found', async function () {
       manager._command = null;
       manager._commandChecked = true;
       manager._available = false;
+      manager._devtunnelCommand = 'fake-devtunnel';
+      manager._devtunnelChecked = true;
+      manager._devtunnelAvailable = true;
 
       const result = await manager.start('test-session', '/tmp');
       assert.strictEqual(result.success, false);
@@ -75,9 +176,29 @@ describe('VSCodeTunnelManager', function () {
       assert(result.message.includes('VS Code CLI not found'));
     });
 
+    it('should return error when devtunnel CLI not found', async function () {
+      manager._command = 'fake-code';
+      manager._commandChecked = true;
+      manager._available = true;
+      manager._devtunnelCommand = null;
+      manager._devtunnelChecked = true;
+      manager._devtunnelAvailable = false;
+
+      const result = await manager.start('test-session', '/tmp');
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.error, 'not_found');
+      assert(typeof result.message === 'string');
+      assert(result.message.includes('devtunnel'));
+    });
+
     it('should reject duplicate tunnel for same session', async function () {
-      // Simulate an active tunnel
-      manager.tunnels.set('test-session', { status: 'running', url: 'https://vscode.dev/tunnel/test' });
+      manager.tunnels.set('test-session', {
+        status: 'running',
+        serverProcess: null,
+        tunnelProcess: null,
+        localUrl: 'http://localhost:9100/?tkn=abc',
+        publicUrl: 'https://test.devtunnels.ms/?tkn=abc',
+      });
 
       const result = await manager.start('test-session', '/tmp');
       assert.strictEqual(result.success, false);
@@ -85,10 +206,12 @@ describe('VSCodeTunnelManager', function () {
     });
 
     it('should enforce max tunnel limit', async function () {
-      // Fill up to the limit
-      manager._command = 'fake';
+      manager._command = 'fake-code';
       manager._commandChecked = true;
       manager._available = true;
+      manager._devtunnelCommand = 'fake-devtunnel';
+      manager._devtunnelChecked = true;
+      manager._devtunnelAvailable = true;
       manager.maxTunnels = 2;
 
       manager.tunnels.set('s1', { status: 'running' });
@@ -98,7 +221,95 @@ describe('VSCodeTunnelManager', function () {
       assert.strictEqual(result.success, false);
       assert(result.error.includes('Maximum tunnel limit'));
     });
+
+    it('should count degraded tunnels toward the active limit', async function () {
+      manager._command = 'fake-code';
+      manager._commandChecked = true;
+      manager._available = true;
+      manager._devtunnelCommand = 'fake-devtunnel';
+      manager._devtunnelChecked = true;
+      manager._devtunnelAvailable = true;
+      manager.maxTunnels = 2;
+
+      manager.tunnels.set('s1', { status: 'running' });
+      manager.tunnels.set('s2', { status: 'degraded' });
+
+      const result = await manager.start('s3', '/tmp');
+      assert.strictEqual(result.success, false);
+      assert(result.error.includes('Maximum tunnel limit'));
+    });
+
+    it('should call _loginDevtunnel when not authenticated', async function () {
+      manager._command = 'fake-code';
+      manager._commandChecked = true;
+      manager._available = true;
+      manager._devtunnelCommand = 'fake-devtunnel';
+      manager._devtunnelChecked = true;
+      manager._devtunnelAvailable = true;
+
+      let authChecked = false;
+      let loginCalled = false;
+      let serverSpawned = false;
+
+      manager._checkDevtunnelAuth = async () => { authChecked = true; return false; };
+      manager._loginDevtunnel = async () => { loginCalled = true; return true; };
+      manager._spawnServer = async () => { serverSpawned = true; return true; };
+      manager._waitForPort = async () => true;
+      manager._ensureDevtunnel = async () => true;
+      manager._spawnTunnel = async () => {};
+
+      const result = await manager.start('test-session', '/tmp');
+      assert.strictEqual(authChecked, true, '_checkDevtunnelAuth should have been called');
+      assert.strictEqual(loginCalled, true, '_loginDevtunnel should have been called');
+      assert.strictEqual(serverSpawned, true, '_spawnServer should have been called after login');
+      assert.strictEqual(result.success, true);
+    });
+
+    it('should return error when devtunnel login fails', async function () {
+      manager._command = 'fake-code';
+      manager._commandChecked = true;
+      manager._available = true;
+      manager._devtunnelCommand = 'fake-devtunnel';
+      manager._devtunnelChecked = true;
+      manager._devtunnelAvailable = true;
+
+      const events = [];
+      manager.onEvent = (sessionId, event) => { events.push(event); };
+
+      manager._checkDevtunnelAuth = async () => false;
+      manager._loginDevtunnel = async () => false;
+
+      const result = await manager.start('test-session', '/tmp');
+      assert.strictEqual(result.success, false);
+      assert(result.error.includes('Authentication failed'));
+
+      const errorEvent = events.find(e => e.type === 'vscode_tunnel_error');
+      assert(errorEvent, 'Should emit vscode_tunnel_error event');
+    });
+
+    it('should skip login when already authenticated', async function () {
+      manager._command = 'fake-code';
+      manager._commandChecked = true;
+      manager._available = true;
+      manager._devtunnelCommand = 'fake-devtunnel';
+      manager._devtunnelChecked = true;
+      manager._devtunnelAvailable = true;
+
+      let loginCalled = false;
+
+      manager._checkDevtunnelAuth = async () => true;
+      manager._loginDevtunnel = async () => { loginCalled = true; return true; };
+      manager._spawnServer = async () => true;
+      manager._waitForPort = async () => true;
+      manager._ensureDevtunnel = async () => true;
+      manager._spawnTunnel = async () => {};
+
+      await manager.start('test-session', '/tmp');
+      assert.strictEqual(loginCalled, false, '_loginDevtunnel should NOT have been called');
+    });
   });
+
+  // ── stop ───────────────────────────────────────────────────
 
   describe('stop', function () {
     it('should return success for unknown session', async function () {
@@ -109,7 +320,61 @@ describe('VSCodeTunnelManager', function () {
     it('should clean up tunnel state after stop', async function () {
       manager.tunnels.set('test-session', {
         status: 'running',
-        process: null,
+        serverProcess: null,
+        tunnelProcess: null,
+        _loginProcess: null,
+        localPort: 9100,
+        connectionToken: 'abc',
+        localUrl: 'http://localhost:9100/?tkn=abc',
+        publicUrl: 'https://test.devtunnels.ms/?tkn=abc',
+        tunnelId: 'aiordie-vscode-test',
+        stopping: false,
+        _stabilityTimer: null,
+        _restartDelayTimer: null,
+        _restartDelayResolve: null,
+      });
+      manager._reservedPorts.add(9100);
+
+      await manager.stop('test-session');
+      assert.strictEqual(manager.tunnels.has('test-session'), false);
+    });
+
+    it('should release the reserved port after stop', async function () {
+      manager.tunnels.set('test-session', {
+        status: 'running',
+        serverProcess: null,
+        tunnelProcess: null,
+        _loginProcess: null,
+        localPort: 9105,
+        connectionToken: 'abc',
+        localUrl: null,
+        publicUrl: null,
+        tunnelId: 'aiordie-vscode-test',
+        stopping: false,
+        _stabilityTimer: null,
+        _restartDelayTimer: null,
+        _restartDelayResolve: null,
+      });
+      manager._reservedPorts.add(9105);
+
+      await manager.stop('test-session');
+      assert.strictEqual(manager._reservedPorts.has(9105), false);
+    });
+
+    it('should emit stopped status event', async function () {
+      const events = [];
+      manager.onEvent = (sessionId, event) => { events.push({ sessionId, ...event }); };
+
+      manager.tunnels.set('test-session', {
+        status: 'running',
+        serverProcess: null,
+        tunnelProcess: null,
+        _loginProcess: null,
+        localPort: 9100,
+        connectionToken: 'abc',
+        localUrl: null,
+        publicUrl: null,
+        tunnelId: 'aiordie-vscode-test',
         stopping: false,
         _stabilityTimer: null,
         _restartDelayTimer: null,
@@ -117,19 +382,142 @@ describe('VSCodeTunnelManager', function () {
       });
 
       await manager.stop('test-session');
-      assert.strictEqual(manager.tunnels.has('test-session'), false);
+
+      const stoppedEvent = events.find(e => e.type === 'vscode_tunnel_status' && e.status === 'stopped');
+      assert(stoppedEvent, 'Should emit vscode_tunnel_status with status stopped');
+      assert.strictEqual(stoppedEvent.sessionId, 'test-session');
+    });
+
+    it('should abort pending restart delay', async function () {
+      let resolveWasCalled = false;
+      const timer = setTimeout(() => {}, 60000);
+      manager.tunnels.set('test-session', {
+        status: 'restarting',
+        serverProcess: null,
+        tunnelProcess: null,
+        _loginProcess: null,
+        localPort: 9100,
+        connectionToken: 'abc',
+        localUrl: null,
+        publicUrl: null,
+        tunnelId: 'aiordie-vscode-test',
+        stopping: false,
+        _stabilityTimer: null,
+        _restartDelayTimer: timer,
+        _restartDelayResolve: () => { resolveWasCalled = true; },
+      });
+
+      await manager.stop('test-session');
+      assert.strictEqual(resolveWasCalled, true, 'Pending restart delay should be resolved');
     });
   });
 
+  // ── stopAll ────────────────────────────────────────────────
+
   describe('stopAll', function () {
     it('should stop all tunnels', async function () {
-      manager.tunnels.set('s1', { status: 'running', process: null, stopping: false, _stabilityTimer: null, _restartDelayTimer: null, _restartDelayResolve: null });
-      manager.tunnels.set('s2', { status: 'running', process: null, stopping: false, _stabilityTimer: null, _restartDelayTimer: null, _restartDelayResolve: null });
+      manager.tunnels.set('s1', {
+        status: 'running',
+        serverProcess: null,
+        tunnelProcess: null,
+        _loginProcess: null,
+        localPort: 9100,
+        stopping: false,
+        _stabilityTimer: null,
+        _restartDelayTimer: null,
+        _restartDelayResolve: null,
+      });
+      manager.tunnels.set('s2', {
+        status: 'running',
+        serverProcess: null,
+        tunnelProcess: null,
+        _loginProcess: null,
+        localPort: 9101,
+        stopping: false,
+        _stabilityTimer: null,
+        _restartDelayTimer: null,
+        _restartDelayResolve: null,
+      });
 
       await manager.stopAll();
       assert.strictEqual(manager.tunnels.size, 0);
     });
   });
+
+  // ── getStatus ──────────────────────────────────────────────
+
+  describe('getStatus', function () {
+    it('should return stopped status for unknown session', function () {
+      const status = manager.getStatus('nonexistent');
+      assert.strictEqual(status.status, 'stopped');
+      assert.strictEqual(status.url, null);
+      assert.strictEqual(status.localUrl, null);
+      assert.strictEqual(status.publicUrl, null);
+    });
+
+    it('should return localUrl, publicUrl, and url fields', function () {
+      manager.tunnels.set('test-session', {
+        status: 'running',
+        localUrl: 'http://localhost:9100/?tkn=abc',
+        publicUrl: 'https://test.devtunnels.ms/?tkn=abc',
+        serverProcess: { pid: 1234 },
+        tunnelProcess: { pid: 5678 },
+      });
+
+      const status = manager.getStatus('test-session');
+      assert.strictEqual(status.status, 'running');
+      assert.strictEqual(status.localUrl, 'http://localhost:9100/?tkn=abc');
+      assert.strictEqual(status.publicUrl, 'https://test.devtunnels.ms/?tkn=abc');
+      assert.strictEqual(status.url, 'https://test.devtunnels.ms/?tkn=abc');
+      assert.strictEqual(status.pid, 1234);
+      assert.strictEqual(status.tunnelPid, 5678);
+    });
+
+    it('should fall back url to localUrl when publicUrl is null', function () {
+      manager.tunnels.set('test-session', {
+        status: 'degraded',
+        localUrl: 'http://localhost:9100/?tkn=abc',
+        publicUrl: null,
+        serverProcess: { pid: 1234 },
+        tunnelProcess: null,
+      });
+
+      const status = manager.getStatus('test-session');
+      assert.strictEqual(status.url, 'http://localhost:9100/?tkn=abc');
+      assert.strictEqual(status.publicUrl, null);
+      assert.strictEqual(status.tunnelPid, null);
+    });
+
+    it('should return null pids when processes are absent', function () {
+      manager.tunnels.set('test-session', {
+        status: 'starting',
+        localUrl: null,
+        publicUrl: null,
+        serverProcess: null,
+        tunnelProcess: null,
+      });
+
+      const status = manager.getStatus('test-session');
+      assert.strictEqual(status.pid, null);
+      assert.strictEqual(status.tunnelPid, null);
+    });
+  });
+
+  // ── _activeCount ───────────────────────────────────────────
+
+  describe('_activeCount', function () {
+    it('should count running, starting, and degraded tunnels', function () {
+      manager.tunnels.set('s1', { status: 'running' });
+      manager.tunnels.set('s2', { status: 'starting' });
+      manager.tunnels.set('s3', { status: 'degraded' });
+      manager.tunnels.set('s4', { status: 'error' });
+      manager.tunnels.set('s5', { status: 'stopped' });
+
+      assert.strictEqual(manager._activeCount(), 3);
+    });
+  });
+
+  // ── event callback ─────────────────────────────────────────
 
   describe('event callback', function () {
     it('should not emit events when CLI is not found', async function () {
@@ -138,16 +526,15 @@ describe('VSCodeTunnelManager', function () {
         events.push({ sessionId, ...event });
       };
 
-      // Force not found — start() returns early before emitting any events
       manager._command = null;
       manager._commandChecked = true;
       manager._available = false;
+      manager._devtunnelChecked = true;
 
       const result = await manager.start('test-session', '/tmp');
       assert.strictEqual(result.success, false);
       assert.strictEqual(result.error, 'not_found');
 
-      // No events emitted because start() returns before creating tunnel state
       assert.strictEqual(events.length, 0, 'Expected no events when CLI not found');
     });
 
@@ -157,7 +544,6 @@ describe('VSCodeTunnelManager', function () {
         events.push({ sessionId, ...event });
       };
 
-      // Manually call _emitEvent to verify the callback works
       manager._emitEvent('test-session', 'vscode_tunnel_status', { status: 'starting' });
 
       assert.strictEqual(events.length, 1);
@@ -167,91 +553,54 @@ describe('VSCodeTunnelManager', function () {
     });
   });
 
-  describe('authentication flow', function () {
-    it('should call _login when not authenticated', async function () {
-      manager._command = 'fake';
-      manager._commandChecked = true;
-      manager._available = true;
-
-      let loginCalled = false;
-      let spawnCalled = false;
-
-      // Stub _checkAuth to return false (not authenticated)
-      manager._checkAuth = async () => false;
-      // Stub _login to return true (login succeeded)
-      manager._login = async () => { loginCalled = true; return true; };
-      // Stub _spawn to no-op
-      manager._spawn = async () => { spawnCalled = true; };
-
-      const result = await manager.start('test-session', '/tmp');
-      assert.strictEqual(loginCalled, true, '_login should have been called');
-      assert.strictEqual(spawnCalled, true, '_spawn should have been called after login');
-      assert.strictEqual(result.success, true);
-    });
-
-    it('should return error when login fails', async function () {
-      manager._command = 'fake';
-      manager._commandChecked = true;
-      manager._available = true;
-
-      const events = [];
-      manager.onEvent = (sessionId, event) => { events.push(event); };
-
-      // Stub _checkAuth to return false (not authenticated)
-      manager._checkAuth = async () => false;
-      // Stub _login to return false (login failed)
-      manager._login = async () => false;
-
-      const result = await manager.start('test-session', '/tmp');
-      assert.strictEqual(result.success, false);
-      assert(result.error.includes('Authentication failed'));
-      // Should have emitted an error event
-      const errorEvent = events.find(e => e.type === 'vscode_tunnel_error');
-      assert(errorEvent, 'Should emit vscode_tunnel_error event');
-    });
-
-    it('should skip _login when already authenticated', async function () {
-      manager._command = 'fake';
-      manager._commandChecked = true;
-      manager._available = true;
-
-      let loginCalled = false;
-
-      // Stub _checkAuth to return true (already authenticated)
-      manager._checkAuth = async () => true;
-      manager._login = async () => { loginCalled = true; return true; };
-      manager._spawn = async () => {};
-
-      await manager.start('test-session', '/tmp');
-      assert.strictEqual(loginCalled, false, '_login should NOT have been called');
-    });
-  });
+  // ── clearAvailabilityCache ─────────────────────────────────
 
   describe('clearAvailabilityCache', function () {
-    it('should reset state and re-run discovery', async function () {
-      // Set initial state
+    it('should reset both code and devtunnel discovery state', async function () {
+      // Set initial state for both CLIs
       manager._command = '/usr/bin/code';
       manager._commandChecked = true;
       manager._available = true;
+      manager._devtunnelCommand = '/usr/bin/devtunnel';
+      manager._devtunnelChecked = true;
+      manager._devtunnelAvailable = true;
 
       manager.clearAvailabilityCache();
 
-      // Should have reset state
+      // Code CLI state should be reset
       assert.strictEqual(manager._command, null);
       assert.strictEqual(manager._commandChecked, false);
       assert.strictEqual(manager._available, false);
 
+      // devtunnel CLI state should be reset
+      assert.strictEqual(manager._devtunnelCommand, null);
+      assert.strictEqual(manager._devtunnelChecked, false);
+      assert.strictEqual(manager._devtunnelAvailable, false);
+
       // Wait for re-discovery to complete
       await manager._initPromise;
       assert.strictEqual(manager._commandChecked, true);
+      assert.strictEqual(manager._devtunnelChecked, true);
     });
   });
 
+  // ── _installInstructions ───────────────────────────────────
+
   describe('_installInstructions', function () {
-    it('should return platform-specific instructions', function () {
+    it('should return platform-specific instructions for VS Code', function () {
       const instructions = manager._installInstructions();
       assert(typeof instructions === 'string');
       assert(instructions.includes('code.visualstudio.com'));
+    });
+  });
+
+  // ── _devtunnelInstallInstructions ──────────────────────────
+
+  describe('_devtunnelInstallInstructions', function () {
+    it('should return instructions for devtunnel CLI', function () {
+      const instructions = manager._devtunnelInstallInstructions();
+      assert(typeof instructions === 'string');
+      assert(instructions.includes('devtunnel'));
     });
   });
 });


### PR DESCRIPTION
## Summary

- Replace bundled `code tunnel` with two independent processes: `code serve-web` (local VS Code HTTP server) + `devtunnel host` (tunnel forwarding)
- Independent failure domains: tunnel crash no longer kills the VS Code Server (degraded mode with auto-restart)
- Unified auth: uses devtunnel OS-level credentials instead of separate GitHub device-code flow
- Per-session port allocation (9100-9199) with connection token access control

## Changes

| File | Description |
|------|-------------|
| `src/vscode-tunnel.js` | Core refactor: two-process lifecycle, port allocation, TCP readiness, sequenced teardown |
| `src/server.js` | Added `devtunnelAvailable` to `/api/config` |
| `src/public/vscode-tunnel.js` | Dual-URL support, degraded banner, generic URL display |
| `test/vscode-tunnel.test.js` | 39 tests covering port allocation, dual-CLI, two-process lifecycle |
| `e2e/fixtures/fake-devtunnel.*` | New fake devtunnel CLI scripts for E2E |
| `e2e/fixtures/fake-code.*` | Updated with `serve-web` subcommand |
| `e2e/tests/16-vscode-tunnel.spec.js` | Updated for devtunnels.ms URLs |
| `docs/adrs/0011-*` | ADR documenting the architectural decision |
| `docs/specs/vscode-tunnel.md` | Full spec rewrite for two-process architecture |

## Test plan

- [x] Unit tests: 39 tests passing locally (`test/vscode-tunnel.test.js`)
- [ ] CI: Unit tests on ubuntu-latest + windows-latest
- [ ] CI: E2E tests with fake-code + fake-devtunnel fixtures
- [ ] CI: Lint / validation scripts