### PR TITLE
feat: PWA install section + LAN self-signed-cert docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,20 @@ ai-or-die --tunnel
 
 When `--tunnel` is active, auth is disabled — the tunnel itself controls access.
 
+## Install as a PWA
+
+ai-or-die is an installable progressive web app. Open Settings → Install in the app, or use the install icon in your browser's address bar. The installed app runs in its own window with offline-capable shell caching.
+
+**Browser support**: Chrome / Edge / Samsung Internet support one-tap install. Firefox desktop does not have native install — use the browser menu to pin the tab. Safari iOS uses Share → Add to Home Screen.
+
+**Installing on LAN devices**: Browsers refuse to install PWAs over an HTTPS origin whose certificate isn't trusted by the device. The auto-generated cert from `--https` is self-signed, so a phone or tablet connecting to `https://<your-mac-ip>:7777` will see the in-app Install panel say *"Not available in this browser."* even though the browser supports install. Three ways around this:
+
+1. **Use `--tunnel`** *(easiest)* — Microsoft Dev Tunnels gives you a public URL with a real Let's Encrypt cert. Devices install via the public URL with no setup.
+2. **Trust the self-signed cert** on each device — copy `~/.ai-or-die/certs/server.cert` to the device and install it as a trusted root in the OS certificate store.
+3. **Provide a CA-signed cert** via `--cert` / `--key`. [mkcert](https://github.com/FiloSottile/mkcert) is a low-friction option for development.
+
+See [docs/history/pwa-install-lan-self-signed-cert.md](docs/history/pwa-install-lan-self-signed-cert.md) for the device-by-device procedure and the underlying browser-policy reasoning.
+
 ## Architecture
 
 ```

--- a/docs/history/pwa-install-lan-self-signed-cert.md
+++ b/docs/history/pwa-install-lan-self-signed-cert.md
@@ -1,0 +1,44 @@
+# PWA install on LAN with `--https` self-signed cert
+
+## Symptom
+
+Users reported the in-app Install panel (Settings → Install) shows **"Not available in this browser."** when accessing the server from another device on the local network via the auto-generated self-signed certificate (`ai-or-die --https`). The same Chrome that says "Not available" on the LAN URL will install the app cleanly when pointed at `https://localhost`.
+
+## Investigation
+
+Phase 0 ran a Playwright probe with full Chromium 145 against an isolated server on port 11202 and against the user's `--https` server on port 11206. Two scenarios:
+
+| Origin | Cert trust | `installabilityErrors` | `_installState` | Settings panel text |
+|---|---|---|---|---|
+| `http://localhost:11202` | n/a (localhost) | `[]` | `available` | "Ready to install as a standalone app." |
+| `https://localhost:11206` (self-signed cert) | localhost-secure exception | `[]` | `available` | "Ready to install as a standalone app." |
+| `https://10.0.0.9:11206` (same cert, LAN IP) | untrusted | `[{"errorId":"not-from-secure-origin"}]` | `unavailable` | **"Not available in this browser."** |
+
+The LAN scenario also shows `navigator.serviceWorker.getRegistrations()` returning `[]` — the service worker never registers because Chrome refuses SW installation on an untrusted origin.
+
+## Root cause
+
+Chromium's installability evaluator treats only `localhost` / `127.0.0.1` / `[::1]` as secure-by-default. Every other origin must produce an HTTPS connection with a **certificate signed by a CA in the device's trust store**. The auto-generated cert at `~/.ai-or-die/certs/server.cert` (created by `bin/ai-or-die.js` when `--https` is set without `--cert`/`--key`) is self-signed; even after the user clicks through Chrome's interstitial, the connection is treated as `not-from-secure-origin` for installability purposes. PWA install (and service-worker registration, and several other powerful-feature gates) silently refuses.
+
+The in-app state machine (`src/public/app.js:92-125`) cannot detect this because `window.isSecureContext` returns `true` for any `https:` URL, including untrusted ones — there is no JS API that surfaces "this connection is technically HTTPS but the browser doesn't trust the cert." After the 3-second fallback timer, the state machine falls through to `'unavailable'` with the catch-all message "Not available in this browser." That message is technically wrong: the browser does support PWA install; it's the deployment that doesn't meet criteria.
+
+## Why the prior icon-MIME hypothesis was wrong
+
+A separate bug exists in the codebase: `src/server.js:310-337` declares icons in the manifest as `"type": "image/png"` but actually serves SVG bytes with `Content-Type: image/svg+xml`. We initially suspected this caused Chromium's icon decoder to reject the manifest. The Phase 0 probe disproved it — Chromium 145 successfully decodes the SVG and the install prompt fires anyway on a localhost-secure origin. The MIME mismatch is a real wire-protocol contract violation that may affect Safari iOS and Firefox Android, but it does not cause the user-visible "Not available on LAN" symptom.
+
+## Workarounds for users
+
+There are three ways to install the PWA on a LAN device:
+
+1. **Use `--tunnel`** *(recommended)* — `ai-or-die --tunnel` exposes the server through Microsoft Dev Tunnels with a real Let's Encrypt certificate. LAN devices install via the public `*.devtunnels.ms` URL with no cert trust step.
+2. **Trust the self-signed cert on each device** — copy `~/.ai-or-die/certs/server.cert` to the device and install it as a trusted root in the OS certificate store (Keychain Access on macOS, Settings → General → VPN & Device Management → Profile → enable Certificate Trust on iOS, Settings → Security → Install certificate on Android, Trusted Root Certification Authorities on Windows). Once trusted, Chrome treats the LAN HTTPS as secure and installability becomes available.
+3. **Use a CA-signed cert** — provide `--cert` and `--key` pointing at a real certificate covering the LAN IP or hostname. mkcert (`mkcert localhost 10.0.0.9`) is a low-friction option for development environments.
+
+## Future work (not committed)
+
+Options for an in-app fix:
+- When the state machine times out without `beforeinstallprompt` AND `location.protocol === 'https:'` AND `location.hostname` is not localhost, replace the generic "Not available" copy with a specific cert-trust explanation and a link to the workaround.
+- Add `--tunnel` recommendation to the install-unavailable state when `location.host` looks like a private IP (RFC 1918 ranges).
+- Fix the icon MIME mismatch (`src/server.js:310-337`) as a separate hardening pass for non-Chromium browsers.
+
+None of these changes the underlying Chromium behavior; the cert trust requirement is enforced by the browser and cannot be bypassed from page JavaScript.

--- a/docs/specs/client-app.md
+++ b/docs/specs/client-app.md
@@ -400,25 +400,59 @@ See the [Authentication Specification](authentication.md) for full details. Key 
 
 Source: `src/public/service-worker.js`
 
-- **Cache name:** `claude-code-web-v1`
-- **Precached resources:** `/`, `/index.html`, `/style.css`, `/app.js`, `/session-manager.js`, `/plan-detector.js`
-- **Strategy for API/WebSocket routes:** Network only, with a 503 offline fallback.
-- **Strategy for static assets:** Network first, cache on success, fall back to cache when offline.
+- **Cache name:** `ai-or-die-v9` (bump on every cache-shape change).
+- **Precached resources:** root paths (`/`, `/index.html`), all stylesheets (tokens, base, components, mobile, main), JS modules (app, command-palette, clipboard-handler, session-manager, plan-detector, splits, icons, voice-handler, image-handler, input-overlay, feedback-manager, file-browser, file-editor, extra-keys), and the MesloLGS Nerd Font WOFF2 variants (other Nerd Font families are cached on demand).
+- **Strategy for API/WebSocket routes:** Network only, with a 503 offline fallback for `/api/*`.
+- **Strategy for versioned CDN assets** (unpkg, cdnjs, jsdelivr, Google Fonts): Cache-first.
+- **Strategy for static assets:** Network first, cache on success, fall back to cache when offline. Navigations fall back to `/index.html` when offline.
 - Activates immediately via `skipWaiting()` + `clients.claim()`.
 - Cleans up old caches on activation.
+- Handles `SKIP_WAITING` postMessage from the client to roll out new versions without waiting.
+- Routes notification clicks to existing windows or opens a new tab with session context.
 
 ### Manifest
 
 Source: `src/public/manifest.json`
 
-Provides installable PWA metadata. Icons are dynamically generated SVGs served by the Express server at `/icon-{size}.png`.
+Provides installable PWA metadata. Served at `/manifest.json` with `Cache-Control: no-cache` so manifest changes propagate on the next visit.
 
-### Dynamic Icon Generation
+Icons are currently served by dynamic Express routes at `/icon-{size}.png` (sizes 16, 32, 144, 180, 192, 512). The manifest declares `"type": "image/png"` for icon entries; the routes return SVG bytes with `Content-Type: image/svg+xml`. Chromium 145 tolerates this MIME mismatch but it is a wire-protocol contract violation — Safari iOS Add-to-Home-Screen and Firefox Android may reject it. See [docs/history/pwa-install-lan-self-signed-cert.md](../history/pwa-install-lan-self-signed-cert.md) for context; a follow-up is tracked but not yet shipped.
 
-The server generates SVG icons at sizes 16, 32, 144, 180, 192, and 512 pixels:
-- Dark background (`#1a1a1a`) with rounded corners.
-- Monospace "CC" text in orange (`#ff6b00`).
-- Served as `image/svg+xml` with a 1-year `Cache-Control`.
+Screenshots at `/screenshot-wide.png` and `/screenshot-narrow.png` similarly serve SVG bytes despite the `.png` URL.
+
+### Installability requirements
+
+PWA install is gated by the browser, not by the server. Chrome / Edge / Samsung Internet require **all** of:
+
+- A web app manifest with `name`, `short_name` / `name`, `start_url`, `display`, and an icon ≥ 192×192.
+- A registered service worker with a `fetch` handler (covered above).
+- A **secure context**. This means one of:
+  - `http://localhost` / `http://127.0.0.1` / `http://[::1]` (treated as secure regardless of cert)
+  - HTTPS with a certificate signed by a CA in the device's trust store
+
+The `--https` flag generates a self-signed certificate. **Connections from another device on the LAN to that cert (e.g. `https://10.0.0.9:7777`) are not considered a secure context for installability**, even after the user clicks through Chrome's interstitial. `window.isSecureContext` still returns `true`, but Chromium internally rejects the origin with `not-from-secure-origin` and refuses to register the service worker or fire `beforeinstallprompt`.
+
+Workarounds for LAN testing: use `--tunnel` (Microsoft Dev Tunnels supplies a CA-signed cert), trust the self-signed cert manually on each device, or supply a real cert via `--cert`/`--key`. See [docs/history/pwa-install-lan-self-signed-cert.md](../history/pwa-install-lan-self-signed-cert.md) for the device-by-device procedure.
+
+### Install state machine
+
+Source: `src/public/app.js` (`_installState`, `_setInstallState`, `_updateInstallSection`, `_triggerInstall`, lines 92-125 and 3260-3370).
+
+Single `_installState` property drives both the floating Install button and the Settings → Install panel. States:
+
+| State | Trigger | UI |
+|---|---|---|
+| `checking` | Initial; resolves within 3s | "Checking install availability..." |
+| `available` | `beforeinstallprompt` fired and was preventDefault'd | "Ready to install as a standalone app." + button |
+| `prompting` | User clicked install; awaiting `userChoice` | "Installing..." (button disabled) |
+| `installed` | `appinstalled` fired or `_isInstalledPWA()` returns true on init | Section hidden |
+| `unavailable-ios` | iOS device detected | iOS Share/Add-to-Home instructions |
+| `unavailable-https` | `window.isSecureContext === false` | "Requires a secure connection. Use localhost or restart with --https." |
+| `unavailable-browser` | Firefox or Samsung Internet | "Use your browser's menu to add this app to your home screen." |
+| `unavailable` | 3-second timer expired with no other condition matching | "Not available in this browser." (catch-all; in practice often a cert-trust failure on LAN — see history doc) |
+| `dismissed` | User rejected the install prompt | "Install was cancelled. Reload the page to try again." |
+
+The 3-second fallback timer is a heuristic — `beforeinstallprompt` typically fires within a few hundred ms of page load on real hardware once criteria are met. The listener overrides the late-arriving event if the timer fires first.
 
 ---
 

--- a/e2e/tests/44-settings-sections.spec.js
+++ b/e2e/tests/44-settings-sections.spec.js
@@ -25,7 +25,7 @@ test.afterEach(async ({ page }, testInfo) => {
 
 test.describe('Settings Grouped Sections', () => {
 
-  test('settings modal has 5 section headers', async ({ page }) => {
+  test('settings modal has 6 section headers', async ({ page }) => {
     setupPageCapture(page);
     const sessionId = await createSessionViaApi(port, 'settings-sections');
     await page.goto(url);
@@ -37,17 +37,17 @@ test.describe('Settings Grouped Sections', () => {
     await page.click('#settingsBtn');
     await page.waitForSelector('.settings-modal.active', { timeout: 5000 });
 
-    // Verify 5 section headers exist
     const sections = await page.evaluate(() => {
       const headers = document.querySelectorAll('.setting-section-header');
       return Array.from(headers).map(h => h.textContent.trim());
     });
-    expect(sections).toHaveLength(5);
+    expect(sections).toHaveLength(6);
     expect(sections).toContain('Terminal');
     expect(sections).toContain('Voice Input');
     expect(sections).toContain('Notifications');
     expect(sections).toContain('Display');
     expect(sections).toContain('Advanced');
+    expect(sections).toContain('Install');
   });
 
   test('clicking section header collapses the section', async ({ page }) => {

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -88,6 +88,42 @@ class ClaudeCodeWebInterface {
         this._planDetectTimer = null;
         this._planTextDecoder = new TextDecoder();
 
+        // PWA install state machine
+        this._installState = 'checking'; // checking | available | prompting | installed | unavailable-https | unavailable-ios | unavailable-browser | unavailable
+        this._deferredPrompt = null;
+
+        // Register beforeinstallprompt early — it fires once and can't be recaptured
+        window.addEventListener('beforeinstallprompt', (e) => {
+            e.preventDefault();
+            this._deferredPrompt = e;
+            this._setInstallState('available');
+        });
+
+        window.addEventListener('appinstalled', () => {
+            this._deferredPrompt = null;
+            this._setInstallState('installed');
+        });
+
+        // Resolve initial install state after a short delay (give beforeinstallprompt time to fire)
+        this._isInstalled = this._isInstalledPWA();
+        if (this._isInstalled) {
+            this._installState = 'installed';
+        } else {
+            this._installCheckTimer = setTimeout(() => {
+                if (this._installState === 'checking') {
+                    if (this._isIOS()) {
+                        this._setInstallState('unavailable-ios');
+                    } else if (!this._isSecureContext()) {
+                        this._setInstallState('unavailable-https');
+                    } else if (this._isFirefox() || this._isSamsungInternet()) {
+                        this._setInstallState('unavailable-browser');
+                    } else {
+                        this._setInstallState('unavailable');
+                    }
+                }
+            }, 3000);
+        }
+
         this.init();
     }
 
@@ -3189,6 +3225,142 @@ class ClaudeCodeWebInterface {
         if (notifVolumeValue) notifVolumeValue.textContent = (settings.notifVolume ?? 30) + '%';
         const notifDesktop = document.getElementById('notifDesktop');
         if (notifDesktop) notifDesktop.checked = settings.notifDesktop ?? true;
+
+        // Update install section
+        this._updateInstallSection();
+    }
+
+    // --- PWA Install State Machine ---
+
+    _isInstalledPWA() {
+        return window.matchMedia('(display-mode: standalone)').matches
+            || window.matchMedia('(display-mode: window-controls-overlay)').matches
+            || window.matchMedia('(display-mode: minimal-ui)').matches
+            || window.matchMedia('(display-mode: fullscreen)').matches
+            || navigator.standalone === true;
+    }
+
+    _isIOS() {
+        return /iPad|iPhone|iPod/.test(navigator.userAgent)
+            || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    }
+
+    _isSecureContext() {
+        return window.isSecureContext;
+    }
+
+    _isFirefox() {
+        return /Firefox/.test(navigator.userAgent) && !/Seamonkey/.test(navigator.userAgent);
+    }
+
+    _isSamsungInternet() {
+        return /SamsungBrowser/.test(navigator.userAgent);
+    }
+
+    _setInstallState(state) {
+        this._installState = state;
+
+        // Update floating button
+        const existingBtn = document.getElementById('installBtn');
+        if (state === 'available') {
+            if (!existingBtn) {
+                const installBtn = document.createElement('button');
+                installBtn.id = 'installBtn';
+                installBtn.className = 'install-btn';
+                installBtn.innerHTML = '<span class="icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="M8 11l4 4 4-4"/><path d="M5 21h14"/></svg></span> Install App';
+                installBtn.addEventListener('click', () => this._triggerInstall());
+                document.body.appendChild(installBtn);
+            }
+        } else if (existingBtn) {
+            existingBtn.remove();
+        }
+
+        // Update settings section (idempotent — safe to call whether settings is open or not)
+        this._updateInstallSection();
+    }
+
+    _updateInstallSection() {
+        const statusText = document.getElementById('installStatusText');
+        const installBtn = document.getElementById('settingsInstallBtn');
+        const iosInstructions = document.getElementById('installIOSInstructions');
+
+        if (!statusText) return; // settings DOM not ready
+
+        // Bind click handler once
+        if (installBtn && !installBtn._installBound) {
+            installBtn.addEventListener('click', () => this._triggerInstall());
+            installBtn._installBound = true;
+        }
+
+        // Hide all optional elements by default
+        if (installBtn) installBtn.style.display = 'none';
+        if (iosInstructions) iosInstructions.style.display = 'none';
+
+        // If running inside installed PWA, hide the entire section
+        const section = document.querySelector('[data-section="install"]');
+        if (section) {
+            section.style.display = this._isInstalled ? 'none' : '';
+        }
+
+        switch (this._installState) {
+            case 'checking':
+                statusText.textContent = 'Checking install availability...';
+                break;
+            case 'available':
+                statusText.textContent = 'Ready to install as a standalone app.';
+                if (installBtn) {
+                    installBtn.style.display = '';
+                    installBtn.disabled = false;
+                }
+                break;
+            case 'prompting':
+                statusText.textContent = 'Installing...';
+                if (installBtn) {
+                    installBtn.style.display = '';
+                    installBtn.disabled = true;
+                }
+                break;
+            case 'installed':
+                statusText.textContent = 'Already installed.';
+                break;
+            case 'unavailable-ios':
+                statusText.textContent = '';
+                if (iosInstructions) iosInstructions.style.display = '';
+                break;
+            case 'unavailable-https':
+                statusText.textContent = 'Requires a secure connection. Use localhost or restart with --https.';
+                break;
+            case 'unavailable-browser':
+                statusText.textContent = 'Use your browser\'s menu to add this app to your home screen.';
+                break;
+            case 'dismissed':
+                statusText.textContent = 'Install was cancelled. Reload the page to try again.';
+                break;
+            default:
+                statusText.textContent = 'Not available in this browser.';
+                break;
+        }
+    }
+
+    async _triggerInstall() {
+        if (!this._deferredPrompt) return;
+
+        this._setInstallState('prompting');
+        const prompt = this._deferredPrompt;
+        this._deferredPrompt = null; // null out BEFORE calling to prevent double-invoke
+
+        try {
+            prompt.prompt();
+            const { outcome } = await prompt.userChoice;
+            if (outcome === 'dismissed') {
+                // Prompt is consumed — can't re-prompt without a page reload
+                this._setInstallState('dismissed');
+            }
+            // If accepted, appinstalled event will fire and set state to 'installed'
+        } catch (err) {
+            console.error('Install prompt error:', err);
+            this._setInstallState('unavailable');
+        }
     }
 
     hideSettings() {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -456,6 +456,24 @@
                             </div>
                         </div>
                     </div>
+
+                    <div class="setting-section" data-section="install">
+                        <div class="setting-section-header" tabindex="0" role="button" aria-expanded="true">Install</div>
+                        <div class="setting-section-content">
+                            <div class="setting-group" id="installStatusGroup">
+                                <div id="installStatus" aria-live="polite">
+                                    <span id="installStatusText">Checking...</span>
+                                </div>
+                                <button class="btn btn-primary" id="settingsInstallBtn" style="display:none; margin-top: 8px;">
+                                    <span class="icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="M8 11l4 4 4-4"/><path d="M5 21h14"/></svg></span>
+                                    Install App
+                                </button>
+                                <div id="installIOSInstructions" style="display:none;">
+                                    <small>Tap the <strong>Share</strong> button <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align: middle;"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg> then <strong>Add to Home Screen</strong></small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="modal-footer">
                     <button class="btn btn-secondary" id="resetSettingsBtn">Reset to Defaults</button>
@@ -768,44 +786,6 @@
                     });
             });
         }
-        
-        // Handle app install prompt
-        let deferredPrompt;
-        window.addEventListener('beforeinstallprompt', (e) => {
-            // Prevent Chrome 67 and earlier from automatically showing the prompt
-            e.preventDefault();
-            // Stash the event so it can be triggered later
-            deferredPrompt = e;
-            
-            // Create install button if it doesn't exist
-            if (!document.getElementById('installBtn')) {
-                const installBtn = document.createElement('button');
-                installBtn.id = 'installBtn';
-                installBtn.className = 'install-btn';
-                installBtn.innerHTML = '<span class="icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="M8 11l4 4 4-4"/><path d="M5 21h14"/></svg></span> Install App';
-                
-                installBtn.addEventListener('click', async () => {
-                    if (deferredPrompt) {
-                        deferredPrompt.prompt();
-                        const { outcome } = await deferredPrompt.userChoice;
-                        console.log(`User response to install prompt: ${outcome}`);
-                        deferredPrompt = null;
-                        installBtn.remove();
-                    }
-                });
-                
-                document.body.appendChild(installBtn);
-            }
-        });
-        
-        // Handle successful installation
-        window.addEventListener('appinstalled', () => {
-            console.log('PWA was installed');
-            const installBtn = document.getElementById('installBtn');
-            if (installBtn) {
-                installBtn.remove();
-            }
-        });
     </script>
 </body>
 </html>

--- a/src/public/manifest.json
+++ b/src/public/manifest.json
@@ -2,6 +2,7 @@
   "name": "ai-or-die",
   "short_name": "ai-or-die",
   "description": "Universal AI coding terminal",
+  "id": "/",
   "start_url": "/",
   "display": "standalone",
   "display_override": ["window-controls-overlay", "standalone", "minimal-ui"],
@@ -14,13 +15,25 @@
       "src": "/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ],
   "categories": ["developer", "productivity", "utilities"],
@@ -38,8 +51,16 @@
     {
       "src": "/screenshot-wide.png",
       "sizes": "1280x720",
-      "type": "image/png",
+      "type": "image/svg+xml",
+      "form_factor": "wide",
       "label": "ai-or-die Interface"
+    },
+    {
+      "src": "/screenshot-narrow.png",
+      "sizes": "540x720",
+      "type": "image/svg+xml",
+      "form_factor": "narrow",
+      "label": "ai-or-die Mobile"
     }
   ]
 }

--- a/src/server.js
+++ b/src/server.js
@@ -23,6 +23,38 @@ const SttEngine = require('./stt-engine');
 const CircularBuffer = require('./utils/circular-buffer');
 const RestartManager = require('./restart-manager');
 
+// Pre-built PWA screenshot SVG buffers (served at /screenshot-wide.png and /screenshot-narrow.png)
+const SCREENSHOT_WIDE_BUF = Buffer.from(`
+  <svg width="1280" height="720" viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg">
+    <rect width="1280" height="720" fill="#161b22"/>
+    <rect x="0" y="0" width="1280" height="36" fill="#0d1117"/>
+    <circle cx="20" cy="18" r="6" fill="#ff5f57" opacity="0.8"/>
+    <circle cx="40" cy="18" r="6" fill="#febc2e" opacity="0.8"/>
+    <circle cx="60" cy="18" r="6" fill="#28c840" opacity="0.8"/>
+    <text x="640" y="22" text-anchor="middle" font-family="system-ui,sans-serif" font-size="13" fill="#8b949e">ai-or-die</text>
+    <rect x="24" y="56" width="1232" height="640" rx="8" fill="#0d1117" opacity="0.6"/>
+    <text x="48" y="90" font-family="'JetBrains Mono',monospace" font-size="14" fill="#8b949e">~  ai-or-die</text>
+    <text x="48" y="130" font-family="'JetBrains Mono',monospace" font-size="20" fill="#ff6b00">&gt;_</text>
+    <text x="88" y="130" font-family="'JetBrains Mono',monospace" font-size="16" fill="#c9d1d9">Ready for input...</text>
+    <rect x="48" y="140" width="2" height="18" fill="#ff6b00" opacity="0.8"/>
+    <text x="48" y="640" font-family="system-ui,sans-serif" font-size="12" fill="#484f58">Universal AI coding terminal</text>
+  </svg>
+`);
+
+const SCREENSHOT_NARROW_BUF = Buffer.from(`
+  <svg width="540" height="720" viewBox="0 0 540 720" xmlns="http://www.w3.org/2000/svg">
+    <rect width="540" height="720" fill="#161b22"/>
+    <rect x="0" y="0" width="540" height="36" fill="#0d1117"/>
+    <text x="270" y="22" text-anchor="middle" font-family="system-ui,sans-serif" font-size="13" fill="#8b949e">ai-or-die</text>
+    <rect x="12" y="48" width="516" height="660" rx="8" fill="#0d1117" opacity="0.6"/>
+    <text x="28" y="80" font-family="'JetBrains Mono',monospace" font-size="13" fill="#8b949e">~  ai-or-die</text>
+    <text x="28" y="116" font-family="'JetBrains Mono',monospace" font-size="18" fill="#ff6b00">&gt;_</text>
+    <text x="62" y="116" font-family="'JetBrains Mono',monospace" font-size="14" fill="#c9d1d9">Ready for input...</text>
+    <rect x="28" y="126" width="2" height="16" fill="#ff6b00" opacity="0.8"/>
+    <text x="28" y="660" font-family="system-ui,sans-serif" font-size="11" fill="#484f58">Universal AI coding terminal</text>
+  </svg>
+`);
+
 /** Foreground/background session priority constants */
 const COALESCE_MS_FG = 16;       // 60 flushes/sec for active session
 const COALESCE_MS_BG = 200;      // 5 flushes/sec for background sessions
@@ -257,6 +289,7 @@ class ClaudeCodeWebServer {
     // Serve manifest.json with correct MIME type
     this.app.get('/manifest.json', (req, res) => {
       res.setHeader('Content-Type', 'application/manifest+json');
+      res.setHeader('Cache-Control', 'no-cache');
       if (global.__SEA_MODE__) {
         this._sendSeaAsset(res, 'public/manifest.json');
       } else {
@@ -301,6 +334,19 @@ class ClaudeCodeWebServer {
         res.setHeader('Cache-Control', 'public, max-age=31536000');
         res.send(svgBuffer);
       });
+    });
+
+    // PWA Screenshot routes - serve pre-built branded screenshots
+    this.app.get('/screenshot-wide.png', (req, res) => {
+      res.setHeader('Content-Type', 'image/svg+xml');
+      res.setHeader('Cache-Control', 'public, max-age=31536000');
+      res.send(SCREENSHOT_WIDE_BUF);
+    });
+
+    this.app.get('/screenshot-narrow.png', (req, res) => {
+      res.setHeader('Content-Type', 'image/svg+xml');
+      res.setHeader('Cache-Control', 'public, max-age=31536000');
+      res.send(SCREENSHOT_NARROW_BUF);
     });
 
     // Auth status endpoint - always accessible


### PR DESCRIPTION
## Summary

- Adds an **Install** section to Settings with a unified 9-state install state machine (`feat: e118c33`), so users can install the app as a PWA from one consistent location regardless of browser/OS.
- Documents the **LAN install limitation with self-signed certs** (`docs: e8ffab8`) — Chromium refuses PWA install on non-localhost HTTPS origins whose certs aren't in the device trust store, so the auto-generated cert from `--https` fails install on phones/tablets connecting via LAN IP. Three workarounds documented (`--tunnel`, trust the cert, bring-your-own cert).

## Findings from Phase 0 probe

A Playwright/CDP probe against an isolated server reproduced the user-reported "Not available in this browser" exactly when accessing `https://<lan-ip>:<port>` with the `--https` self-signed cert: `Page.getInstallabilityErrors` returned `[{"errorId":"not-from-secure-origin"}]`, the service worker never registered, and the install state machine fell through to `unavailable`. The same server on `https://localhost` installed cleanly. See [`docs/history/pwa-install-lan-self-signed-cert.md`](docs/history/pwa-install-lan-self-signed-cert.md) for the full evidence trail.

## What this is NOT

- Not a fix for the underlying browser policy (Chromium's cert-trust requirement is intentional and not bypassable from page JS).
- Not a fix for the icon MIME mismatch (`/icon-*.png` URLs serve SVG bytes). Phase 0 confirmed Chrome 145 tolerates this, but it remains a wire-protocol contract violation that may affect Safari iOS / Firefox Android — tracked as future work in the history doc.
- Not an in-app message change for the `unavailable` state (current copy says "Not available in this browser." which is misleading on LAN; future work, not committed here).

## Test plan

- [ ] Open `https://localhost:<port>` in Chrome — Settings → Install shows "Ready to install as a standalone app." with active button; clicking it triggers the native install prompt
- [ ] Open `https://<lan-ip>:<port>` from a phone after clicking through the cert warning — Settings → Install shows "Not available in this browser." (matches docs)
- [ ] Run `ai-or-die --tunnel`, install the public `*.devtunnels.ms` URL on a phone — install succeeds (matches workaround #1)
- [ ] On iOS Safari: Settings → Install shows the Share/Add-to-Home-Screen instructions (no regression on existing `unavailable-ios` path)
- [ ] On Firefox desktop: Settings → Install shows "Use your browser's menu..." (no regression on `unavailable-browser` path)
- [ ] CI green