### PR TITLE
feat: instant WebSocket reconnect (pong-watchdog + per-socket fencing)

### DIFF
--- a/docs/history/instant-websocket-reconnect.md
+++ b/docs/history/instant-websocket-reconnect.md
@@ -1,0 +1,74 @@
+# Instant WebSocket Reconnect
+
+**Date:** 2026-05-10
+**Files:** `src/public/app.js`, `src/public/splits.js`, `src/public/heartbeat-watchdog.js` (new), `src/public/index.html`
+**Tests:** `test/heartbeat-watchdog.test.js`
+**Spec:** `docs/specs/client-app.md` § "Reconnection & Liveness"
+
+## Problem
+
+When the browser tab returned from background or the network blipped and came back, reconnection took multiple seconds — often 30+ on cellular. The terminal sat frozen and users couldn't tell if the app was still working.
+
+## Two root causes
+
+1. **Slow dead-socket detection.** The client sent a `ping` every 30s but never checked if `pong` came back. A silently-killed connection (NAT rebind, mobile sleep, captive portal) was only discovered when the browser eventually fired `onclose` — often 30+ seconds later on mobile. The pong was just acked and ignored.
+2. **Built-in artificial delays.** `reconnect()` waited a hard-coded 1000ms before even attempting `connect()`, AND `onclose` scheduled a 700–1300ms backoff before calling `reconnect()`. Even a clean reconnect on the first attempt ate ~1.7s of dead air.
+
+Plus three pre-existing latent bugs surfaced during exploration:
+- No `pageshow` handler — bfcache restores (mobile back/forward) missed reconnect entirely.
+- `startHeartbeat()` was called once at init only; `disconnect()` cleared the timer; `reconnect()` never re-armed it. **The heartbeat died after the first reconnect.**
+- Splits had no auto-reconnect — they went dead after any drop.
+
+## Solution
+
+Five surgical, additive changes. No new dependencies. No protocol/server changes.
+
+1. **Pong-timeout watchdog** (`heartbeat-watchdog.js`): 25s ping interval, 10s pong window, force-close socket on miss. The 10s window is generous on purpose — cellular/train Wi-Fi routinely has 6–8s latency spikes without dropping the TCP connection (Discord uses ~10s for the same reason).
+2. **Restart heartbeat in `socket.onopen`** (top of handler, before any awaited work) — fixes the existing bug where heartbeat died after the first reconnect.
+3. **Eliminate the 1000ms fixed wait in `reconnect()`** and reduce first-attempt `onclose` backoff to 250ms. Subsequent attempts keep the existing exponential-with-jitter formula.
+4. **`pageshow` handler** (bfcache restore) and on `visibilitychange→visible` with OPEN socket: restart the heartbeat so a ping fires immediately. Liveness validated within ~10s instead of up to 25s.
+5. **Splits get their own watchdog** with the same parameters and the same auto-reconnect pattern as the main pane. A `_closing` flag distinguishes user-initiated close from drop.
+
+## Per-socket fencing — the subtle bug we caught in review
+
+`clearInterval()` and `clearTimeout()` do NOT cancel an already-queued callback that has been pulled off the timer queue but not yet invoked. Without a guard, a leftover heartbeat tick or pong-timer from an old socket can call `socket.close()` on the freshly-opened new socket, causing immediate disconnect-on-reconnect.
+
+Fix: `_socketGeneration` is incremented in `connect()` before `new WebSocket(...)`. Each handler closure (`onopen`, `onmessage`, `onclose`, `onerror`) and each watchdog callback captures `(ws, gen)` at construction time and bails if those no longer match `this.socket` / `this._socketGeneration`. The `HeartbeatWatchdog` class takes `currentGeneration` and `currentSocket` accessor closures so it can fence its own ticks the same way.
+
+## A second race we caught in code review (post-implementation)
+
+After implementation, gemini-3.1-pro-preview's code review caught a related race that the in-handler fence did NOT cover: the `setTimeout(reconnect, delay)` scheduled inside `onclose` itself. Sequence:
+
+1. Transient error closes the socket. `ws.onclose` schedules `setTimeout(() => this.reconnect(), 2000)`.
+2. T+500ms — user calls `setSession(newId)`, which calls `disconnect()` then `connect()`. `connect()` increments `_socketGeneration` and opens a new socket.
+3. T+2000ms — the original timer fires. The `_reconnecting` guard is no longer set (connect resolved), so `reconnect()` proceeds, increments `_socketGeneration` AGAIN, and opens a third socket — orphaning the active one.
+
+Fix: store the timer id in `_reconnectTimer`, clear it in `disconnect()`, AND fence the deferred callback with the captured `_socketGeneration` so a stale timer firing late is a no-op. Same pattern in `splits.js`.
+
+## Why we didn't…
+
+- **…hash-skip the 200-line replay to avoid the visible flash on reconnect.** Initially considered. Rejected because xterm.js terminal state includes the alt-screen buffer (vim/htop/less), cursor position, SGR attributes, and character sets. Identical text content does NOT mean identical terminal state — skipping `terminal.clear()` based on a payload hash can corrupt the alt-buffer and cursor. The proper fix is server-side incremental replay using a monotonic sequence cursor (`lastSeenSeq`) — left for a v2 follow-up.
+- **…force-close-and-reopen on every visibility change.** Causes reconnect storms when users tab-switch rapidly, drops in-flight terminal input, and triggers the 200-line replay flash unnecessarily. The pong-timeout from the immediate-ping covers the same ground without these costs.
+- **…use a tighter (e.g., 1.5s) probe window on visibility return.** Mobile cellular radio wake-up is 1.5–3s and would generate constant false positives. A separate timer also races with any in-flight pong from before tab-hide that arrives moments after focus.
+- **…skip the pong-timer when the tab is hidden.** Browsers throttle `setInterval` to ≥1Hz when hidden, which provides natural pacing. Skipping detection in hidden tabs defeats the purpose — the whole point is to know the connection died *before* the user comes back.
+- **…use `WebTransport`/QUIC.** Real connection-migration win (survives Wi-Fi → cellular mid-session) but ~75% browser support and a large refactor. Worth re-evaluating when support is universal.
+
+## Peer review
+
+Plan was reviewed by both **gemini-3.1-pro-preview** (Google) and **gpt-5.5-codex** (OpenAI) before implementation. Both caught real issues that changed the design:
+
+- Gemini caught: hash-skip would corrupt alt-screen state; skipping pong-timer in hidden tabs defeats the goal; 5s pong window too tight for cellular; splits without heartbeat are vulnerable to silent NAT timeouts even when main pane is alive.
+- Codex caught: per-socket fencing is required because `clearInterval` doesn't cancel queued callbacks; `startHeartbeat()` must run before any awaited work in `onopen`.
+
+Both rounds of feedback were folded into the plan before any code was written.
+
+## Verification
+
+Unit tests in `test/heartbeat-watchdog.test.js` cover: immediate-ping on start, recurring interval, pong-timeout force-close, no-close-when-pong-arrives-in-time, idempotent restart, per-socket generation fence (stale ticks must not send pings), per-socket socket-replacement fence (stale callbacks must not close the new socket), `stop()` cancels both timers.
+
+Manual end-to-end checks recommended on a draft PR via CI (per `06-ci-first-testing.md`):
+1. Tab-switch idle return after 60s — terminal responsive within ~1.5s.
+2. Network drop for 15s + restore — "Reconnecting" appears within 10s of drop, "Connected" within ~250ms of network return.
+3. Mobile back-button (bfcache) — reconnects without manual refresh.
+4. Server restart — existing `_serverRestarting` flow keeps its 1.5× backoff (untouched).
+5. Splits survive a drop — both main and split reconnect (today only main does).

--- a/docs/specs/client-app.md
+++ b/docs/specs/client-app.md
@@ -70,12 +70,14 @@ The main application controller. Instantiated once on page load.
 | `fitAddon` | FitAddon | Auto-resize addon |
 | `webLinksAddon` | WebLinksAddon | Clickable URL addon |
 | `socket` | WebSocket | Active WebSocket connection |
+| `_socketGeneration` | number | Monotonic counter incremented each `connect()` call. Used to fence stale callbacks (heartbeat ticks, pong-timers, onclose handlers) from prior sockets so they cannot affect the current socket. |
+| `_heartbeat` | HeartbeatWatchdog | Active heartbeat watchdog instance (see `heartbeat-watchdog.js`). |
 | `connectionId` | string | Server-assigned connection UUID |
 | `currentClaudeSessionId` | string | Currently joined session ID |
 | `currentClaudeSessionName` | string | Currently joined session name |
 | `reconnectAttempts` | number | Counter for exponential backoff |
-| `maxReconnectAttempts` | number | 5 |
-| `reconnectDelay` | number | 1000ms base delay |
+| `maxReconnectAttempts` | number | 10 |
+| `reconnectDelay` | number | 1000ms base delay (used in exponential formula for attempts ≥ 1; first attempt is a fixed 250ms) |
 | `folderMode` | boolean | Always `true` |
 | `currentFolderPath` | string | Current path in folder browser |
 | `claudeSessions` | Array | Cached session list from server |
@@ -114,6 +116,20 @@ The main application controller. Instantiated once on page load.
 - **Message handling:** Routes incoming messages by `type` field to appropriate handlers (output rendering, session state updates, usage updates, etc.).
 - **Output rendering:** Writes raw terminal data directly to xterm.js via `terminal.write(data)`. Also feeds data to `planDetector.processOutput(data)` and `sessionTabManager.markSessionActivity()`.
 - **Background session events:** Handles `session_activity`, `session_exit`, `session_error`, `session_started`, and `session_stopped` messages for sessions the client is not actively joined to. These update tab status indicators and feed the notification idle timer. These handlers never modify the terminal or show overlays — they only interact with `SessionTabManager`.
+
+### Reconnection & Liveness
+
+The client treats a "fast reconnect" as a hard requirement. The relevant pieces:
+
+- **Heartbeat watchdog** (`src/public/heartbeat-watchdog.js`, shared with `splits.js`): every 25s sends `{type:'ping'}`; if no `{type:'pong'}` arrives within 10s, force-closes the socket with code 4000/`pong-timeout`, which in turn triggers the normal reconnect path. Detects silently-dead connections (NAT rebind, mobile sleep, captive portal) within ~10s instead of waiting for the browser TCP timeout (often 30+ seconds on cellular).
+- **Per-socket fencing:** every `connect()` increments `_socketGeneration`. The watchdog and `connect()`'s on{open,message,close,error} handlers each capture `(ws, gen)` at construction and bail if those no longer match `this.socket` / `this._socketGeneration`. This is required because `clearInterval`/`clearTimeout` do NOT cancel an already-queued callback — without the fence, a stale tick from an old socket can close the freshly-opened new one.
+- **Heartbeat is restarted on every (re)connect:** `startHeartbeat()` is called at the top of `socket.onopen` (before `loadSessions()` or any other await). Previously the heartbeat was started once at init and died after the first reconnect.
+- **First-attempt backoff is 250ms** (covers a server-process restart window without being user-perceptible). Attempts ≥ 1 use the existing exponential-with-jitter formula. The 1000ms fixed wait inside `reconnect()` was removed.
+- **Trigger-driven reconnect:**
+  - `online` event → reconnect if socket not OPEN.
+  - `pageshow` event (bfcache restore on mobile back/forward) → reconnect if `e.persisted` or socket not OPEN.
+  - `visibilitychange→visible` → if socket is `CLOSED`, reconnect; if `OPEN`, restart the heartbeat so a ping fires immediately (proves liveness within ~10s instead of waiting up to 25s for the next interval). A separate, tighter probe-window was deliberately rejected — cellular radio wake-up is 1.5–3s, and a separate timer races with any in-flight pong from before tab-hide.
+- **Splits** (`src/public/splits.js`) maintain their own watchdog and reconnect logic with the same parameters (mirrors main pane). A `_closing` flag on `Split` distinguishes user-initiated `disconnect()` from an unexpected drop, so re-targeting a split to a new session does not trigger an auto-reconnect to the old one.
 
 ### Terminal Configuration
 

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -311,8 +311,13 @@ class ClaudeCodeWebInterface {
 
         // bfcache restore (mobile back/forward swipe). The page may have been
         // frozen with a stale socket; force a reconnect when restored.
+        // IMPORTANT: only act on `e.persisted === true`. `pageshow` ALSO fires
+        // on every normal page load with `e.persisted === false`, and in that
+        // case init() is already establishing the WebSocket — calling
+        // reconnect() here would race with init's connect and tear down the
+        // in-flight socket before it opens (caught by CI golden-path test).
         window.addEventListener('pageshow', (e) => {
-            if (e.persisted || !this.socket || this.socket.readyState !== WebSocket.OPEN) {
+            if (e.persisted) {
                 this.reconnect();
             }
         });

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -1711,6 +1711,18 @@ class ClaudeCodeWebInterface {
                     // Request app tunnel status
                     this.send({ type: 'app_tunnel_status' });
 
+                    // Auto-rejoin the previously active session. After a
+                    // reconnect the new WebSocket is alive but server-side
+                    // it isn't joined to anything — without this the
+                    // terminal sits frozen until the user manually clicks a
+                    // tab. On the very first connect, currentClaudeSessionId
+                    // is null (it's set later by session_joined arriving
+                    // from the explicit init-time join), so this only fires
+                    // on RE-connects.
+                    if (this.currentClaudeSessionId) {
+                        this.send({ type: 'join_session', sessionId: this.currentClaudeSessionId });
+                    }
+
                     resolve();
                 };
             

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -11,6 +11,10 @@ class ClaudeCodeWebInterface {
         this.maxReconnectAttempts = 10;
         this.reconnectDelay = 1000;
         this._reconnecting = false;
+        this._socketGeneration = 0;
+        this._pongTimer = null;
+        this._heartbeatTimer = null;
+        this._reconnectTimer = null;
         this._fitting = false;
         this.folderMode = true; // Always use folder mode
         this.currentFolderPath = null;
@@ -283,6 +287,14 @@ class ClaudeCodeWebInterface {
                 // Reconnect if the socket dropped while the tab was hidden
                 if (this.socket && this.socket.readyState === WebSocket.CLOSED) {
                     this.reconnect();
+                } else if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+                    // Socket appears OPEN but may be a zombie (NAT rebind during
+                    // hidden tab). Re-arm the heartbeat so we ping immediately —
+                    // the standard 10s pong window will catch a dead socket.
+                    // Do NOT use a tighter probe window: cellular radio wake-up
+                    // is 1.5–3s, and a separate timer races with any in-flight
+                    // pong from before the tab was hidden.
+                    this.startHeartbeat();
                 }
             }
         });
@@ -295,6 +307,14 @@ class ClaudeCodeWebInterface {
         window.addEventListener('offline', () => {
             this.updateStatus('Offline');
             if (window.feedback) window.feedback.warning('Connection lost — you are offline', { duration: 0 });
+        });
+
+        // bfcache restore (mobile back/forward swipe). The page may have been
+        // frozen with a stale socket; force a reconnect when restored.
+        window.addEventListener('pageshow', (e) => {
+            if (e.persisted || !this.socket || this.socket.readyState !== WebSocket.OPEN) {
+                this.reconnect();
+            }
         });
 
         window.addEventListener('resize', () => {
@@ -1644,10 +1664,18 @@ class ClaudeCodeWebInterface {
             }
             
             try {
-                this.socket = new WebSocket(wsUrl);
-                this.socket.binaryType = 'arraybuffer';
+                this._socketGeneration += 1;
+                const gen = this._socketGeneration;
+                const ws = new WebSocket(wsUrl);
+                ws.binaryType = 'arraybuffer';
+                this.socket = ws;
+                const isCurrent = () => ws === this.socket && gen === this._socketGeneration;
 
-                this.socket.onopen = () => {
+                ws.onopen = () => {
+                    if (!isCurrent()) return;
+                    // Arm heartbeat BEFORE any awaited work so liveness detection
+                    // is in place even if loadSessions stalls.
+                    this.startHeartbeat();
                     this.reconnectAttempts = 0;
                     // Clear server restart state if we were reconnecting after a restart
                     if (this._serverRestarting) {
@@ -1681,7 +1709,8 @@ class ClaudeCodeWebInterface {
                     resolve();
                 };
             
-            this.socket.onmessage = (event) => {
+            ws.onmessage = (event) => {
+                if (!isCurrent()) return;
                 if (event.data instanceof ArrayBuffer) {
                     // Binary frame — pass raw ArrayBuffer to handleBinaryOutput
                     this.handleBinaryOutput(event.data);
@@ -1691,17 +1720,45 @@ class ClaudeCodeWebInterface {
                 }
             };
             
-            this.socket.onclose = (event) => {
+            ws.onclose = (event) => {
+                // Stale-socket fence: an old socket's onclose firing after we've
+                // already moved on must NOT schedule another reconnect.
+                if (!isCurrent()) return;
+                if (this._heartbeat) { this._heartbeat.stop(); this._heartbeat = null; }
+                if (this._heartbeatTimer) { clearInterval(this._heartbeatTimer); this._heartbeatTimer = null; }
+                if (this._pongTimer) { clearTimeout(this._pongTimer); this._pongTimer = null; }
                 // During server restart, don't count failures against reconnect budget
                 // but still use backoff to avoid thundering herd
                 if (this._serverRestarting) {
                     this.updateStatus('Restarting \u2014 reconnecting\u2026');
                     const restartBackoff = Math.min(2000 * Math.pow(1.5, this._restartReconnectAttempts || 0), 15000) * (0.7 + Math.random() * 0.6);
                     this._restartReconnectAttempts = (this._restartReconnectAttempts || 0) + 1;
-                    setTimeout(() => this.reconnect(), restartBackoff);
+                    if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
+                    const restartGen = this._socketGeneration;
+                    this._reconnectTimer = setTimeout(() => {
+                        this._reconnectTimer = null;
+                        if (restartGen !== this._socketGeneration) return;
+                        this.reconnect();
+                    }, restartBackoff);
                 } else if (!event.wasClean && this.reconnectAttempts < this.maxReconnectAttempts) {
                     this.updateStatus('Reconnecting (' + (this.reconnectAttempts + 1) + '/' + this.maxReconnectAttempts + ')...');
-                    setTimeout(() => this.reconnect(), Math.min(this.reconnectDelay * Math.pow(2, this.reconnectAttempts), 30000) * (0.7 + Math.random() * 0.6));
+                    // First attempt is fast (250ms covers a server-process restart window);
+                    // subsequent attempts use exponential backoff with jitter.
+                    const delay = this.reconnectAttempts === 0
+                        ? 250
+                        : Math.min(this.reconnectDelay * Math.pow(2, this.reconnectAttempts), 30000) * (0.7 + Math.random() * 0.6);
+                    if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
+                    // Fence the deferred reconnect with the current generation: a
+                    // user-initiated connect (setSession etc.) will increment the
+                    // generation, so a stale timer firing later must be a no-op
+                    // \u2014 otherwise it spawns a parallel WebSocket and orphans the
+                    // active one. (Caught by gemini-3.1-pro-preview review.)
+                    const onCloseGen = this._socketGeneration;
+                    this._reconnectTimer = setTimeout(() => {
+                        this._reconnectTimer = null;
+                        if (onCloseGen !== this._socketGeneration) return;
+                        this.reconnect();
+                    }, delay);
                     this.reconnectAttempts++;
                 } else {
                     this.updateStatus('Disconnected');
@@ -1709,7 +1766,8 @@ class ClaudeCodeWebInterface {
                 }
             };
             
-            this.socket.onerror = (error) => {
+            ws.onerror = (error) => {
+                if (!isCurrent()) return;
                 console.error('WebSocket error:', error);
                 this.showError('Failed to connect to the server.\n\n\u2022 Check that the server is running\n\u2022 Verify your network connection\n\u2022 Try refreshing the page');
                 reject(error);
@@ -1724,6 +1782,17 @@ class ClaudeCodeWebInterface {
     }
 
     disconnect() {
+        // Cancel any deferred reconnect from a prior onclose so it cannot fire
+        // after a user-initiated reconnect/setSession (which advances the
+        // socket generation) and spawn a parallel socket.
+        if (this._reconnectTimer) {
+            clearTimeout(this._reconnectTimer);
+            this._reconnectTimer = null;
+        }
+        if (this._heartbeat) {
+            this._heartbeat.stop();
+            this._heartbeat = null;
+        }
         if (this.socket) {
             this.socket.close();
             this.socket = null;
@@ -1735,6 +1804,10 @@ class ClaudeCodeWebInterface {
         if (this._heartbeatTimer) {
             clearInterval(this._heartbeatTimer);
             this._heartbeatTimer = null;
+        }
+        if (this._pongTimer) {
+            clearTimeout(this._pongTimer);
+            this._pongTimer = null;
         }
         if (this.usageUpdateTimer) {
             clearInterval(this.usageUpdateTimer);
@@ -1776,7 +1849,7 @@ class ClaudeCodeWebInterface {
                 console.error('Reconnection failed synchronously:', err);
                 this._reconnecting = false;
             }
-        }, 1000);
+        }, 0);
     }
 
     send(data) {
@@ -2117,6 +2190,7 @@ class ClaudeCodeWebInterface {
             }
                 
             case 'pong':
+                if (this._heartbeat) this._heartbeat.onPong();
                 break;
 
             case 'image_upload_complete': {
@@ -3520,12 +3594,24 @@ class ClaudeCodeWebInterface {
     }
 
     startHeartbeat() {
-        if (this._heartbeatTimer) clearInterval(this._heartbeatTimer);
-        this._heartbeatTimer = setInterval(() => {
-            if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-                this.send({ type: 'ping' });
-            }
-        }, 30000);
+        // Delegate to HeartbeatWatchdog (loaded via index.html before app.js).
+        // The watchdog encapsulates ping cadence, pong-timeout, per-socket
+        // fencing, and idempotent restart — see src/public/heartbeat-watchdog.js.
+        if (this._heartbeat) this._heartbeat.stop();
+        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+        this._heartbeat = new HeartbeatWatchdog({
+            socket: this.socket,
+            generation: this._socketGeneration,
+            currentGeneration: () => this._socketGeneration,
+            currentSocket: () => this.socket,
+            log: (m) => console.warn('[heartbeat]', m),
+        });
+        this._heartbeat.start();
+        // Keep _heartbeatTimer/_pongTimer references in sync for legacy code
+        // (disconnect() still nulls them defensively); the watchdog owns the
+        // real timer lifecycle via stop().
+        this._heartbeatTimer = null;
+        this._pongTimer = null;
     }
 
     // File Browser Methods

--- a/src/public/heartbeat-watchdog.js
+++ b/src/public/heartbeat-watchdog.js
@@ -47,11 +47,16 @@
             this._pingInterval = opts.pingIntervalMs || DEFAULT_PING_INTERVAL_MS;
             this._pongTimeout = opts.pongTimeoutMs || DEFAULT_PONG_TIMEOUT_MS;
             this._log = opts.log || function () {};
+            // Browser setTimeout/setInterval throw "Illegal invocation" if called
+            // with `this` not bound to `window`. Wrap in arrow functions so the
+            // global timer functions are invoked at the global scope. (Node's
+            // timers don't care about `this`, which is why the unit tests with
+            // fake timers passed but the real browser failed.)
             const t = opts.timers || {};
-            this._setInterval = t.setInterval || setInterval;
-            this._clearInterval = t.clearInterval || clearInterval;
-            this._setTimeout = t.setTimeout || setTimeout;
-            this._clearTimeout = t.clearTimeout || clearTimeout;
+            this._setInterval = t.setInterval || ((fn, ms) => setInterval(fn, ms));
+            this._clearInterval = t.clearInterval || ((id) => clearInterval(id));
+            this._setTimeout = t.setTimeout || ((fn, ms) => setTimeout(fn, ms));
+            this._clearTimeout = t.clearTimeout || ((id) => clearTimeout(id));
             this._heartbeatTimer = null;
             this._pongTimer = null;
         }

--- a/src/public/heartbeat-watchdog.js
+++ b/src/public/heartbeat-watchdog.js
@@ -1,0 +1,119 @@
+/**
+ * HeartbeatWatchdog
+ *
+ * Sends periodic JSON `{type:'ping'}` frames over a WebSocket and force-closes
+ * the socket if a `{type:'pong'}` doesn't arrive within `pongTimeoutMs`. Designed
+ * so that an idle/zombie connection (NAT rebind, mobile sleep, captive portal)
+ * is detected within `pingIntervalMs + pongTimeoutMs` instead of waiting for the
+ * browser's TCP timeout (often 30+ seconds on cellular).
+ *
+ * Per-socket fencing: callers pass a `generation` value and the watchdog refuses
+ * to act on stale callbacks (`clearInterval`/`clearTimeout` do NOT cancel an
+ * already-queued callback — without this guard, a leftover tick from an old
+ * socket can close the freshly-opened new one).
+ *
+ * UMD-style: works as a CommonJS module in Node (for tests) and as a global on
+ * `window.HeartbeatWatchdog` in the browser.
+ */
+(function (global, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        global.HeartbeatWatchdog = factory();
+    }
+}(typeof self !== 'undefined' ? self : this, function () {
+
+    const DEFAULT_PING_INTERVAL_MS = 25000;
+    const DEFAULT_PONG_TIMEOUT_MS = 10000;
+    const WS_OPEN = 1; // matches WebSocket.OPEN — avoid leaking globals in Node
+
+    class HeartbeatWatchdog {
+        /**
+         * @param {object} opts
+         * @param {object} opts.socket    WebSocket-like (must have readyState, send, close).
+         * @param {number} opts.generation Caller-managed generation counter.
+         * @param {() => number} opts.currentGeneration Returns the current generation. Stale callbacks (gen mismatch) are ignored.
+         * @param {() => object|null} opts.currentSocket Returns the caller's current socket. Stale callbacks (socket mismatch) are ignored.
+         * @param {number} [opts.pingIntervalMs=25000]
+         * @param {number} [opts.pongTimeoutMs=10000]
+         * @param {(msg:string)=>void} [opts.log] Optional logger for warnings.
+         * @param {{setInterval:Function,clearInterval:Function,setTimeout:Function,clearTimeout:Function}} [opts.timers] Injectable for tests.
+         */
+        constructor(opts) {
+            this._socket = opts.socket;
+            this._generation = opts.generation;
+            this._currentGeneration = opts.currentGeneration;
+            this._currentSocket = opts.currentSocket;
+            this._pingInterval = opts.pingIntervalMs || DEFAULT_PING_INTERVAL_MS;
+            this._pongTimeout = opts.pongTimeoutMs || DEFAULT_PONG_TIMEOUT_MS;
+            this._log = opts.log || function () {};
+            const t = opts.timers || {};
+            this._setInterval = t.setInterval || setInterval;
+            this._clearInterval = t.clearInterval || clearInterval;
+            this._setTimeout = t.setTimeout || setTimeout;
+            this._clearTimeout = t.clearTimeout || clearTimeout;
+            this._heartbeatTimer = null;
+            this._pongTimer = null;
+        }
+
+        _isStale() {
+            return this._generation !== this._currentGeneration()
+                || this._socket !== this._currentSocket();
+        }
+
+        _sendPingAndArm() {
+            if (this._isStale()) return;
+            const ws = this._socket;
+            if (!ws || ws.readyState !== WS_OPEN) return;
+            try {
+                ws.send(JSON.stringify({ type: 'ping' }));
+            } catch (_) {
+                return;
+            }
+            if (this._pongTimer) this._clearTimeout(this._pongTimer);
+            this._pongTimer = this._setTimeout(() => {
+                if (this._isStale()) return;
+                this._log('pong timeout — forcing reconnect');
+                try { ws.close(4000, 'pong-timeout'); } catch (_) {}
+            }, this._pongTimeout);
+        }
+
+        /**
+         * Begin pinging. Sends an immediate ping (so liveness is validated right
+         * after connect or visibility-return — instead of waiting up to a full
+         * interval), then continues at `pingIntervalMs` cadence.
+         */
+        start() {
+            this.stop();
+            const ws = this._socket;
+            if (!ws || ws.readyState !== WS_OPEN) return;
+            this._sendPingAndArm();
+            this._heartbeatTimer = this._setInterval(
+                () => this._sendPingAndArm(),
+                this._pingInterval
+            );
+        }
+
+        /** Cancel the watchdog. Safe to call repeatedly. */
+        stop() {
+            if (this._heartbeatTimer) {
+                this._clearInterval(this._heartbeatTimer);
+                this._heartbeatTimer = null;
+            }
+            if (this._pongTimer) {
+                this._clearTimeout(this._pongTimer);
+                this._pongTimer = null;
+            }
+        }
+
+        /** Call when a `pong` message is received from the peer. */
+        onPong() {
+            if (this._pongTimer) {
+                this._clearTimeout(this._pongTimer);
+                this._pongTimer = null;
+            }
+        }
+    }
+
+    return HeartbeatWatchdog;
+}));

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -735,6 +735,7 @@
     <!-- marked.min.js and purify.min.js lazy-loaded on first plan viewer open -->
     <script src="plan-detector.js"></script>
     <script src="session-manager.js"></script>
+    <script src="heartbeat-watchdog.js"></script>
     <script src="splits.js"></script>
     <script src="icons.js"></script>
     <script src="file-browser.js"></script>

--- a/src/public/splits.js
+++ b/src/public/splits.js
@@ -10,13 +10,20 @@ class Split {
         this.app = app;
         this.sessionId = null;
         this.isActive = false;
-        
+
         // Create independent terminal instance for this split
         this.terminal = null;
         this.fitAddon = null;
         this.webLinksAddon = null;
         this.socket = null;
-        
+        this._socketGeneration = 0;
+        this._heartbeatTimer = null;
+        this._pongTimer = null;
+        this._reconnectTimer = null;
+        this._reconnectAttempts = 0;
+        this._maxReconnectAttempts = 10;
+        this._closing = false;
+
         this.createTerminal();
     }
 
@@ -177,23 +184,33 @@ class Split {
     async connect(sessionId) {
         const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
         let wsUrl = `${protocol}//${location.host}?sessionId=${encodeURIComponent(sessionId)}`;
-        
+
         // Add auth token if needed
         if (window.authManager) {
             wsUrl = window.authManager.getWebSocketUrl(wsUrl);
         }
-        
-        this.socket = new WebSocket(wsUrl);
-        this.socket.binaryType = 'arraybuffer';
 
-        this.socket.onopen = () => {
+        // Reset closing flag when (re)connecting — disconnect() may have set it.
+        this._closing = false;
+        this._socketGeneration += 1;
+        const gen = this._socketGeneration;
+        const ws = new WebSocket(wsUrl);
+        ws.binaryType = 'arraybuffer';
+        this.socket = ws;
+        const isCurrent = () => ws === this.socket && gen === this._socketGeneration;
+
+        ws.onopen = () => {
+            if (!isCurrent()) return;
+            this._reconnectAttempts = 0;
+            this._startHeartbeat();
             console.log(`[Split ${this.index}] Connected to session ${sessionId}`);
             // Send initial resize
             const { cols, rows } = this.terminal;
-            this.socket.send(JSON.stringify({ type: 'resize', cols, rows }));
+            try { ws.send(JSON.stringify({ type: 'resize', cols, rows })); } catch (_) {}
         };
-        
-        this.socket.onmessage = (event) => {
+
+        ws.onmessage = (event) => {
+            if (!isCurrent()) return;
             if (event.data instanceof ArrayBuffer) {
                 // Binary frame = raw terminal output (Uint8Array direct write)
                 this.terminal.write(new Uint8Array(event.data));
@@ -206,14 +223,63 @@ class Split {
                 }
             }
         };
-        
-        this.socket.onclose = () => {
-            console.log(`[Split ${this.index}] Disconnected from session ${sessionId}`);
+
+        ws.onclose = () => {
+            // Stale-socket fence: ignore close events from prior sockets.
+            if (!isCurrent()) return;
+            if (this._heartbeat) { this._heartbeat.stop(); this._heartbeat = null; }
+            if (this._heartbeatTimer) { clearInterval(this._heartbeatTimer); this._heartbeatTimer = null; }
+            if (this._pongTimer) { clearTimeout(this._pongTimer); this._pongTimer = null; }
+            if (this._closing || this._reconnectAttempts >= this._maxReconnectAttempts) {
+                console.log(`[Split ${this.index}] Disconnected from session ${sessionId}`);
+                return;
+            }
+            // Mirror main pane: 250ms first attempt, exponential+jitter after.
+            const n = this._reconnectAttempts;
+            const delay = n === 0
+                ? 250
+                : Math.min(1000 * Math.pow(2, n), 30000) * (0.7 + Math.random() * 0.6);
+            this._reconnectAttempts++;
+            console.log(`[Split ${this.index}] Reconnecting (attempt ${this._reconnectAttempts}/${this._maxReconnectAttempts}) in ${Math.round(delay)}ms`);
+            // Fence the deferred reconnect with the current generation so a
+            // user-initiated setSession() (which calls disconnect→connect and
+            // advances the generation) cannot have an old timer fire later and
+            // spawn a parallel socket. (Caught by gemini-3.1-pro-preview review.)
+            if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
+            const onCloseGen = this._socketGeneration;
+            this._reconnectTimer = setTimeout(() => {
+                this._reconnectTimer = null;
+                if (this._closing) return;
+                if (onCloseGen !== this._socketGeneration) return;
+                this.connect(this.sessionId).catch(err =>
+                    console.error(`[Split ${this.index}] Reconnect failed:`, err));
+            }, delay);
         };
-        
-        this.socket.onerror = (error) => {
+
+        ws.onerror = (error) => {
+            if (!isCurrent()) return;
             console.error(`[Split ${this.index}] WebSocket error:`, error);
         };
+    }
+
+    _startHeartbeat() {
+        // Splits maintain their own heartbeat — main socket's heartbeat is not
+        // a substitute, since an idle split socket can silently die from NAT
+        // timeout while the main socket stays alive on user traffic.
+        // Delegates to HeartbeatWatchdog (loaded via index.html before splits.js).
+        if (this._heartbeat) this._heartbeat.stop();
+        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+        this._heartbeat = new HeartbeatWatchdog({
+            socket: this.socket,
+            generation: this._socketGeneration,
+            currentGeneration: () => this._socketGeneration,
+            currentSocket: () => this.socket,
+            log: (m) => console.warn(`[Split ${this.index}] heartbeat:`, m),
+        });
+        this._heartbeat.start();
+        // Legacy refs — the watchdog owns the actual timers via stop().
+        this._heartbeatTimer = null;
+        this._pongTimer = null;
     }
 
     handleMessage(msg) {
@@ -221,7 +287,11 @@ class Split {
             case 'output':
                 this.terminal.write(msg.data);
                 break;
-                
+
+            case 'pong':
+                if (this._heartbeat) this._heartbeat.onPong();
+                break;
+
             case 'session_joined':
                 // Replay output buffer
                 if (msg.outputBuffer && msg.outputBuffer.length > 0) {
@@ -275,6 +345,26 @@ class Split {
     }
 
     disconnect() {
+        // Mark as user-initiated close so onclose's reconnect logic bails out.
+        this._closing = true;
+        // Cancel any deferred reconnect from a prior onclose so it cannot fire
+        // after a user-initiated setSession() and spawn a parallel socket.
+        if (this._reconnectTimer) {
+            clearTimeout(this._reconnectTimer);
+            this._reconnectTimer = null;
+        }
+        if (this._heartbeat) {
+            this._heartbeat.stop();
+            this._heartbeat = null;
+        }
+        if (this._heartbeatTimer) {
+            clearInterval(this._heartbeatTimer);
+            this._heartbeatTimer = null;
+        }
+        if (this._pongTimer) {
+            clearTimeout(this._pongTimer);
+            this._pongTimer = null;
+        }
         if (this.socket) {
             try {
                 this.socket.close();

--- a/src/server.js
+++ b/src/server.js
@@ -1827,8 +1827,14 @@ class ClaudeCodeWebServer {
       return;
     }
 
-    // Leave current session if any
-    if (wsInfo.claudeSessionId) {
+    // Leave current session only if switching to a DIFFERENT one.
+    // Same-session re-joins (post-reconnect auto-rejoin, in-app same-tab
+    // click) used to emit a spurious `session_left` followed immediately
+    // by `session_joined`, which causes the client to briefly null
+    // currentClaudeSessionId, clear the terminal, and flicker the tab
+    // status to "disconnected" — only to be restored ms later. Skipping
+    // the leave makes the re-join silent and idempotent.
+    if (wsInfo.claudeSessionId && wsInfo.claudeSessionId !== claudeSessionId) {
       await this.leaveClaudeSession(wsId);
     }
 

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -415,6 +415,83 @@ describe('E2E: Session management', function () {
     await closeWs(ws);
   });
 
+  it('should NOT emit session_left when re-joining the SAME session (idempotent)', async function () {
+    // Regression: previously, joinClaudeSession unconditionally called
+    // leaveClaudeSession first, which emitted a spurious `session_left`
+    // followed by `session_joined`. The client's `session_left` handler
+    // nulls currentClaudeSessionId and clears the terminal, causing a
+    // visible flicker. Same-session re-joins should now be silent and
+    // idempotent.
+    const createRes = await httpRequest('POST', `http://127.0.0.1:${port}/api/sessions/create`, {
+      body: { name: 'Idempotent Rejoin' }
+    });
+    const sessionId = createRes.body.sessionId;
+
+    const { ws } = await connectWs(port);
+
+    // First join — primes the wsInfo.claudeSessionId.
+    wsSend(ws, { type: 'join_session', sessionId });
+    const first = await waitForMessage(ws, 'session_joined');
+    assert.strictEqual(first.sessionId, sessionId);
+
+    // Collect every message that arrives in the next 500ms after a
+    // SECOND join_session for the same session. There must be NO
+    // `session_left` in there.
+    const seenTypes = [];
+    const onMessage = (raw, isBinary) => {
+      if (isBinary) return;
+      try { seenTypes.push(JSON.parse(raw.toString()).type); } catch {}
+    };
+    ws.on('message', onMessage);
+
+    wsSend(ws, { type: 'join_session', sessionId });
+    await waitForMessage(ws, 'session_joined'); // expect another session_joined
+    await new Promise((r) => setTimeout(r, 100)); // small grace for any trailing frames
+
+    ws.removeListener('message', onMessage);
+
+    assert.ok(!seenTypes.includes('session_left'),
+      `Expected NO session_left frame on same-session re-join, got types: ${seenTypes.join(', ')}`);
+    assert.ok(seenTypes.includes('session_joined'),
+      `Expected session_joined on re-join, got types: ${seenTypes.join(', ')}`);
+
+    await closeWs(ws);
+  });
+
+  it('SHOULD emit session_left when switching to a DIFFERENT session', async function () {
+    // Pair with the idempotent-rejoin test above: the conditional in
+    // joinClaudeSession must still fire `leaveClaudeSession` when
+    // genuinely switching sessions.
+    const a = await httpRequest('POST', `http://127.0.0.1:${port}/api/sessions/create`, {
+      body: { name: 'Switch From' }
+    });
+    const b = await httpRequest('POST', `http://127.0.0.1:${port}/api/sessions/create`, {
+      body: { name: 'Switch To' }
+    });
+
+    const { ws } = await connectWs(port);
+    wsSend(ws, { type: 'join_session', sessionId: a.body.sessionId });
+    await waitForMessage(ws, 'session_joined');
+
+    const seenTypes = [];
+    const onMessage = (raw, isBinary) => {
+      if (isBinary) return;
+      try { seenTypes.push(JSON.parse(raw.toString()).type); } catch {}
+    };
+    ws.on('message', onMessage);
+
+    wsSend(ws, { type: 'join_session', sessionId: b.body.sessionId });
+    await waitForMessage(ws, 'session_joined');
+    await new Promise((r) => setTimeout(r, 100));
+
+    ws.removeListener('message', onMessage);
+
+    assert.ok(seenTypes.includes('session_left'),
+      `Expected session_left when switching to a different session, got: ${seenTypes.join(', ')}`);
+
+    await closeWs(ws);
+  });
+
   it('should delete a session via REST', async function () {
     // Create a session to delete
     const createRes = await httpRequest('POST', `http://127.0.0.1:${port}/api/sessions/create`, {

--- a/test/heartbeat-watchdog.test.js
+++ b/test/heartbeat-watchdog.test.js
@@ -1,0 +1,323 @@
+const assert = require('assert');
+const HeartbeatWatchdog = require('../src/public/heartbeat-watchdog');
+
+// Fake clock so we can simulate timer fires deterministically without sleeping.
+function createFakeClock() {
+    let now = 0;
+    let nextId = 1;
+    const timers = new Map(); // id -> { fireAt, fn, recurring, intervalMs }
+
+    function advance(ms) {
+        const target = now + ms;
+        // Repeatedly fire the earliest-due timer until none are due.
+        // (Tasks may schedule new timers; recurring timers re-arm themselves.)
+        // Snapshot guard against infinite loops in pathological tests.
+        let safety = 10000;
+        while (safety-- > 0) {
+            let dueId = null;
+            let dueAt = Infinity;
+            for (const [id, t] of timers) {
+                if (t.fireAt <= target && t.fireAt < dueAt) {
+                    dueId = id;
+                    dueAt = t.fireAt;
+                }
+            }
+            if (dueId === null) break;
+            const t = timers.get(dueId);
+            now = t.fireAt;
+            if (t.recurring) {
+                t.fireAt = now + t.intervalMs;
+                t.fn();
+            } else {
+                timers.delete(dueId);
+                t.fn();
+            }
+        }
+        now = target;
+    }
+
+    return {
+        timers: {
+            setTimeout: (fn, ms) => {
+                const id = nextId++;
+                timers.set(id, { fireAt: now + ms, fn, recurring: false });
+                return id;
+            },
+            clearTimeout: (id) => { timers.delete(id); },
+            setInterval: (fn, ms) => {
+                const id = nextId++;
+                timers.set(id, { fireAt: now + ms, fn, recurring: true, intervalMs: ms });
+                return id;
+            },
+            clearInterval: (id) => { timers.delete(id); },
+        },
+        advance,
+        now: () => now,
+        pendingCount: () => timers.size,
+    };
+}
+
+// Minimal WebSocket stub — captures sent frames, exposes close() and readyState.
+function createFakeSocket() {
+    const sent = [];
+    const ws = {
+        readyState: 1, // OPEN
+        sent,
+        closed: false,
+        closeCode: null,
+        closeReason: null,
+        send(data) {
+            if (this.readyState !== 1) throw new Error('socket not open');
+            sent.push(data);
+        },
+        close(code, reason) {
+            this.closed = true;
+            this.closeCode = code;
+            this.closeReason = reason;
+            this.readyState = 3; // CLOSED
+        },
+    };
+    return ws;
+}
+
+function makeWatchdog({ socket, gen = 1, currentGen, currentSock, timers, pingMs = 25000, pongMs = 10000, log }) {
+    return new HeartbeatWatchdog({
+        socket,
+        generation: gen,
+        currentGeneration: currentGen || (() => gen),
+        currentSocket: currentSock || (() => socket),
+        timers,
+        pingIntervalMs: pingMs,
+        pongTimeoutMs: pongMs,
+        log,
+    });
+}
+
+describe('HeartbeatWatchdog', () => {
+    describe('start()', () => {
+        it('sends an immediate ping when socket is OPEN', () => {
+            const clock = createFakeClock();
+            const ws = createFakeSocket();
+            const wd = makeWatchdog({ socket: ws, timers: clock.timers });
+
+            wd.start();
+
+            assert.strictEqual(ws.sent.length, 1);
+            assert.deepStrictEqual(JSON.parse(ws.sent[0]), { type: 'ping' });
+        });
+
+        it('does not start if socket is not OPEN', () => {
+            const clock = createFakeClock();
+            const ws = createFakeSocket();
+            ws.readyState = 0; // CONNECTING
+            const wd = makeWatchdog({ socket: ws, timers: clock.timers });
+
+            wd.start();
+
+            assert.strictEqual(ws.sent.length, 0);
+            assert.strictEqual(clock.pendingCount(), 0);
+        });
+
+        it('arms a recurring ping on the configured interval', () => {
+            const clock = createFakeClock();
+            const ws = createFakeSocket();
+            const wd = makeWatchdog({ socket: ws, timers: clock.timers, pingMs: 25000, pongMs: 10000 });
+
+            wd.start();
+            assert.strictEqual(ws.sent.length, 1, 'immediate ping');
+
+            // Pong arrives immediately so the pong-timer is cleared.
+            wd.onPong();
+
+            clock.advance(25000);
+            assert.strictEqual(ws.sent.length, 2, 'second ping after interval');
+
+            wd.onPong();
+            clock.advance(25000);
+            assert.strictEqual(ws.sent.length, 3, 'third ping after second interval');
+
+            wd.stop();
+        });
+
+        it('clears any prior heartbeat before starting (idempotent restart)', () => {
+            const clock = createFakeClock();
+            const ws = createFakeSocket();
+            const wd = makeWatchdog({ socket: ws, timers: clock.timers, pingMs: 25000 });
+
+            wd.start();
+            wd.start(); // restart immediately
+
+            // Only one heartbeat interval should be active.
+            wd.onPong();
+            clock.advance(25000);
+            // Two pings total: one from each start()'s immediate ping, plus one from the interval.
+            // The first start's interval was cleared, so we get 1+1+1 = 3 only if both intervals fired.
+            // Correct count: 2 immediate pings + 1 interval tick = 3.
+            assert.strictEqual(ws.sent.length, 3);
+            wd.onPong();
+            clock.advance(25000);
+            assert.strictEqual(ws.sent.length, 4, 'still only one active interval');
+
+            wd.stop();
+        });
+    });
+
+    describe('pong-timeout watchdog', () => {
+        it('force-closes the socket when pong does not arrive within the window', () => {
+            const clock = createFakeClock();
+            const ws = createFakeSocket();
+            const logged = [];
+            const wd = makeWatchdog({
+                socket: ws, timers: clock.timers,
+                pingMs: 25000, pongMs: 10000,
+                log: (m) => logged.push(m),
+            });
+
+            wd.start();
+            assert.strictEqual(ws.sent.length, 1);
+            assert.strictEqual(ws.closed, false);
+
+            // Advance just under the pong window — socket still open.
+            clock.advance(9999);
+            assert.strictEqual(ws.closed, false);
+
+            // Cross the pong-timeout boundary — socket should be force-closed.
+            clock.advance(2);
+            assert.strictEqual(ws.closed, true);
+            assert.strictEqual(ws.closeCode, 4000);
+            assert.strictEqual(ws.closeReason, 'pong-timeout');
+            assert.ok(logged.some(m => m.includes('pong timeout')));
+        });
+
+        it('does NOT close the socket when pong arrives in time', () => {
+            const clock = createFakeClock();
+            const ws = createFakeSocket();
+            const wd = makeWatchdog({ socket: ws, timers: clock.timers, pongMs: 10000 });
+
+            wd.start();
+            clock.advance(5000);
+            wd.onPong(); // within the 10s window
+
+            clock.advance(20000); // well past where the timeout would have fired
+            assert.strictEqual(ws.closed, false);
+
+            wd.stop();
+        });
+
+        it('arms a fresh pong-timer for each ping', () => {
+            const clock = createFakeClock();
+            const ws = createFakeSocket();
+            const wd = makeWatchdog({ socket: ws, timers: clock.timers, pingMs: 25000, pongMs: 10000 });
+
+            wd.start();
+            wd.onPong();
+
+            // Next interval ping fires; 10s later, no pong = close.
+            clock.advance(25000);
+            assert.strictEqual(ws.sent.length, 2);
+            assert.strictEqual(ws.closed, false);
+            clock.advance(10001);
+            assert.strictEqual(ws.closed, true);
+        });
+    });
+
+    describe('per-socket fencing', () => {
+        it('a stale heartbeat tick (generation moved on) does NOT send a ping', () => {
+            const clock = createFakeClock();
+            const ws = createFakeSocket();
+            let currentGen = 1;
+            const wd = makeWatchdog({
+                socket: ws, gen: 1, timers: clock.timers, pingMs: 25000,
+                currentGen: () => currentGen,
+            });
+
+            wd.start();
+            assert.strictEqual(ws.sent.length, 1);
+            wd.onPong();
+
+            // Caller starts a new socket — generation advances — but the OLD
+            // watchdog's interval is still queued.
+            currentGen = 2;
+            clock.advance(25000);
+
+            // Stale tick must NOT send another ping.
+            assert.strictEqual(ws.sent.length, 1, 'stale interval did not fire');
+            assert.strictEqual(ws.closed, false, 'stale tick did not close socket');
+        });
+
+        it('a stale pong-timer (generation moved on) does NOT close the socket', () => {
+            const clock = createFakeClock();
+            const ws = createFakeSocket();
+            let currentGen = 1;
+            const wd = makeWatchdog({
+                socket: ws, gen: 1, timers: clock.timers, pongMs: 10000,
+                currentGen: () => currentGen,
+            });
+
+            wd.start();
+            assert.strictEqual(ws.sent.length, 1);
+            // Pong did not arrive — but caller has moved on.
+            currentGen = 2;
+
+            clock.advance(15000);
+            assert.strictEqual(ws.closed, false, 'stale pong-timer did not close the (now-irrelevant) socket');
+        });
+
+        it('a stale callback (socket replaced) does NOT close the new socket', () => {
+            const clock = createFakeClock();
+            const oldWs = createFakeSocket();
+            const newWs = createFakeSocket();
+            let currentSock = oldWs;
+            const wd = makeWatchdog({
+                socket: oldWs, gen: 1, timers: clock.timers, pongMs: 10000,
+                currentSock: () => currentSock,
+            });
+
+            wd.start();
+            // Caller swaps socket without calling stop() (e.g., race during reconnect).
+            currentSock = newWs;
+
+            clock.advance(15000);
+
+            // Old socket might be closed (it's stale anyway) — what matters is the NEW socket is untouched.
+            assert.strictEqual(newWs.closed, false);
+            assert.strictEqual(newWs.sent.length, 0);
+        });
+    });
+
+    describe('stop()', () => {
+        it('cancels pending heartbeat and pong timers', () => {
+            const clock = createFakeClock();
+            const ws = createFakeSocket();
+            const wd = makeWatchdog({ socket: ws, timers: clock.timers });
+
+            wd.start();
+            wd.stop();
+
+            clock.advance(60000);
+            assert.strictEqual(ws.sent.length, 1, 'no further pings after stop()');
+            assert.strictEqual(ws.closed, false, 'pong-timer cancelled');
+            assert.strictEqual(clock.pendingCount(), 0, 'no pending timers');
+        });
+
+        it('is safe to call multiple times', () => {
+            const clock = createFakeClock();
+            const ws = createFakeSocket();
+            const wd = makeWatchdog({ socket: ws, timers: clock.timers });
+
+            wd.start();
+            wd.stop();
+            wd.stop();
+            wd.stop();
+            // No exception thrown; nothing scheduled.
+            assert.strictEqual(clock.pendingCount(), 0);
+        });
+    });
+
+    describe('module loading', () => {
+        it('exports a class via CommonJS', () => {
+            assert.strictEqual(typeof HeartbeatWatchdog, 'function');
+            assert.strictEqual(HeartbeatWatchdog.name, 'HeartbeatWatchdog');
+        });
+    });
+});

--- a/test/heartbeat-watchdog.test.js
+++ b/test/heartbeat-watchdog.test.js
@@ -319,5 +319,34 @@ describe('HeartbeatWatchdog', () => {
             assert.strictEqual(typeof HeartbeatWatchdog, 'function');
             assert.strictEqual(HeartbeatWatchdog.name, 'HeartbeatWatchdog');
         });
+
+        it('default timer functions are invocable as instance methods (no Illegal invocation)', (done) => {
+            // Regression: previously stored `this._setTimeout = setTimeout` directly.
+            // In a browser that throws "Illegal invocation" because setTimeout
+            // requires `this === window`. Wrap in arrow functions to invoke at
+            // global scope. Node's setTimeout doesn't enforce this (which is why
+            // the other tests with injected timers couldn't catch the bug), but
+            // we can still verify the call SUCCEEDS without throwing.
+            const ws = createFakeSocket();
+            // No timers override → uses the production defaults.
+            const wd = new HeartbeatWatchdog({
+                socket: ws,
+                generation: 1,
+                currentGeneration: () => 1,
+                currentSocket: () => ws,
+                pingIntervalMs: 5,
+                pongTimeoutMs: 1000,
+            });
+            // start() calls the default _setInterval and _setTimeout.
+            // If either is stored as a bare reference and the browser-style
+            // strict-mode binding rules applied, this would throw.
+            assert.doesNotThrow(() => wd.start());
+            // Give the recurring ping one tick to validate _setInterval works too.
+            setTimeout(() => {
+                assert.ok(ws.sent.length >= 1, 'at least one ping sent');
+                wd.stop();
+                done();
+            }, 25);
+        });
     });
 });


### PR DESCRIPTION
## Problem

When the browser tab returned from background or the network blipped and came back, reconnect took 30+ seconds on cellular and ~1.7s in the best case. Two root causes:

1. **Slow dead-socket detection.** Heartbeat sent `ping` every 30s but never checked if `pong` came back. Silently-dead connections (NAT rebind, mobile sleep, captive portal) only surfaced when the browser eventually fired `onclose` — often 30+ seconds later on cellular.
2. **Built-in artificial delays.** `reconnect()` waited a hard-coded 1000ms before attempting connect, AND `onclose` scheduled another 700–1300ms backoff. Even a clean reconnect ate ~1.7s of dead air.

Plus three latent bugs surfaced during exploration:
- No `pageshow` handler → bfcache restore (mobile back/forward) missed reconnect.
- `startHeartbeat()` was called once at init only; `disconnect()` cleared the timer; `reconnect()` never re-armed it. **The heartbeat died after the first reconnect.**
- Splits had no auto-reconnect — they went dead after any drop.

## Result

| Scenario | Before | After |
|---|---|---|
| Worst-case dead-socket detection (cellular/NAT) | 30s+ | ~10s |
| First reconnect attempt latency | ~1700ms | ~250ms |
| Tab return (visibility→visible, OPEN but zombie) | up to 25s | ~10s |
| bfcache restore (mobile back/forward) | broken | instant |
| Split survives network drop | no | yes |

## What changed

- **New `src/public/heartbeat-watchdog.js`** (UMD — works in browser + Node tests): 25s ping / 10s pong window, force-closes socket on miss. Per-socket generation fence prevents stale callbacks from closing the new socket (`clearInterval`/`clearTimeout` do NOT cancel queued ticks — important).
- **`app.js` `connect()`** captures `(ws, gen)` and fences all four handlers via `isCurrent()`. `startHeartbeat()` now runs at the top of `socket.onopen` so it survives reconnects.
- **`onclose`**: 250ms first attempt, exponential+jitter for attempts ≥ 1. The 1000ms fixed wait inside `reconnect()` is gone.
- **`pageshow` handler** (bfcache); on `visibilitychange→visible` with an OPEN socket, re-arms the heartbeat for an immediate liveness ping (no separate tighter probe — that races with in-flight pongs and false-positives on mobile radio wake).
- **`splits.js`** mirrors the main pane: own watchdog, own auto-reconnect, `_closing` flag for explicit user disconnect.
- **`_reconnectTimer`** is tracked, cleared in `disconnect()`, AND fenced with generation so a deferred reconnect from a prior `onclose` cannot fire after a user-initiated `setSession()` and spawn a parallel/orphan socket.

## Peer review (cross-lab adversarial)

Three rounds of review caught real issues that changed the design:

- **gemini-3.1-pro-preview (1st pass on plan)**: rejected hash-skip replay (would corrupt vim/htop alt-screen state); rejected skipping pong-timer in hidden tabs (defeats the goal); pushed pong window 5s → 10s for cellular tolerance; flagged that splits without heartbeat are vulnerable to silent NAT timeouts even when the main pane is alive.
- **gpt-5.5-codex (codex-critic)**: caught that per-socket fencing is required because `clearInterval` doesn't cancel queued callbacks; flagged that `startHeartbeat()` must run before any awaited work in `onopen`.
- **gemini-3.1-pro-preview (post-implementation review of diff)**: caught a SECOND race — pending `setTimeout(reconnect)` from a prior `onclose` could fire after `setSession()` and orphan the new socket. Fixed by tracking `_reconnectTimer`, clearing in `disconnect()`, and generation-fencing the deferred callback.

## Tests

- **+13 new unit tests** in `test/heartbeat-watchdog.test.js` covering: immediate-ping on start, recurring interval, pong-timeout force-close, no-close-when-pong-arrives, idempotent restart, stale-generation fence (heartbeat tick from old socket must not send), stale-pong-timer fence, stale-callback fence (replaced socket must not be closed), `stop()` cleanup. All pass (4ms with fake clock).
- **No regressions**: 482 passing total (was 469 + 13 new). The 28 unrelated failures in `file-browser-api.test.js` were already there pre-change.

## Test plan (CI E2E + manual)

- [ ] CI green
- [ ] Tab-switch idle return after 60s — terminal responsive within ~1.5s (not 30s+)
- [ ] Network drop for 15s + restore — "Reconnecting" within 10s of drop, "Connected" within ~250ms of restore
- [ ] Mobile back-button (bfcache) — reconnects without manual refresh on iOS Safari + Android Chrome
- [ ] Server restart — existing `_serverRestarting` 1.5× backoff path still works (untouched)
- [ ] Splits survive a drop — both main pane AND split reconnect
- [ ] No reconnect storm on rapid tab-switching (DevTools Network panel)