### PR TITLE
fix(windows): unhang from OSC 7 validate storm + narrow chokidar watch scope

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -352,7 +352,15 @@ class ClaudeCodeWebServer {
       // .native form); .native is only used HERE, where it can't leak
       // into response paths or watcher-subscription keys.
       const resolvedTarget = this._canonicalizePathSync(targetPath);
-      const resolvedBase = this._canonicalizePathSync(this.baseFolder);
+      // Memoized — baseFolder is constant for the process lifetime, but
+      // _canonicalizePathSync calls fs.realpathSync.native which is a real
+      // syscall (10–50ms on a SUBST/network drive). isPathWithinBase runs
+      // on every OSC 7 emission via validatePath; without this cache, each
+      // emission paid a redundant baseFolder realpath round-trip.
+      if (!this._canonicalizedBaseFolder) {
+        this._canonicalizedBaseFolder = this._canonicalizePathSync(this.baseFolder);
+      }
+      const resolvedBase = this._canonicalizedBaseFolder;
       // Use path.relative instead of startsWith to avoid prefix-matching false positives
       // (e.g. /home/user-admin would match /home/user with startsWith)
       const relative = path.relative(resolvedBase, resolvedTarget);

--- a/src/server.js
+++ b/src/server.js
@@ -2261,7 +2261,12 @@ class ClaudeCodeWebServer {
 
       let watcher;
       let watcherClosed = false;
-      const debounceMs = parseInt(process.env.FS_WATCHER_DEBOUNCE_MS, 10) || 100;
+      // Per the diagnosed Windows hang on Q:\src with multi-worktree + Claude
+      // bulk edits: the 100ms default barely coalesced — a single bulk-edit
+      // wave produced thousands of debounce timers. 500ms is still well below
+      // the 5s "stale buffer" UX threshold from ADR-0017 but cuts emitted
+      // event rate by ~5x under bulk activity.
+      const debounceMs = parseInt(process.env.FS_WATCHER_DEBOUNCE_MS, 10) || 500;
       // FS_WATCHER_STABILITY_MS env: defaults to 80ms (the tuned-down
       // value per ADR-0017 §Coalescing). Setting to 0 DISABLES chokidar's
       // awaitWriteFinish entirely — useful in tests where sync
@@ -2343,6 +2348,16 @@ class ClaudeCodeWebServer {
           // FS_WATCHER_USE_POLLING=1 → chokidar uses fs.stat-loop backend.
           usePolling: usePolling,
           ignoreDirs: ignoreFromEnv.length ? ignoreFromEnv : undefined,
+          // Narrow scope: chokidar only watches direct children of every
+          // subscribed path (vs. the prior recursive watch of the entire
+          // watchRoot tree). This is the load-bearing knob that bounds
+          // active_handles on large/multi-worktree trees — the symptom
+          // that prompted the unhang work. The client's existing soft-
+          // filter subscription model (current dir + open tabs) drives
+          // what chokidar actually watches via add()/unwatch() inside
+          // FileWatcher. Subscriptions for paths NOT in the displayed
+          // dir or an open tab don't allocate watch handles at all.
+          depth: 0,
         });
         sessionEntry.watcher = watcher;
 

--- a/src/terminal-bridge.js
+++ b/src/terminal-bridge.js
@@ -42,6 +42,19 @@ class TerminalBridge extends BaseBridge {
      * @type {Map<string, string|null>}
      */
     this._liveCwd = new Map();
+
+    /**
+     * Raw OSC 7 path most recently seen for each session — used to skip the
+     * entire validate-and-emit chain when the shell re-emits the same path
+     * (every prompt redraw on pwsh/oh-my-posh/Starship). Without this, each
+     * redraw fires 3–4 fs.realpathSync syscalls per session; on a SUBST or
+     * mapped Windows drive (e.g. Q:\), those syscalls are 10–50ms each and
+     * pending requests pile up faster than they complete, blocking the event
+     * loop. The dedupe at line ~205 below only saves the *broadcast* — this
+     * one saves the syscalls.
+     * @type {Map<string, string|null>}
+     */
+    this._lastRawOsc7 = new Map();
   }
 
   // Override async command discovery — use default shell instead of searching PATH
@@ -156,6 +169,7 @@ class TerminalBridge extends BaseBridge {
     this._osc7Parsers.set(sessionId, new Osc7Parser());
     this._osc7Hooks.set(sessionId, hooks);
     this._liveCwd.set(sessionId, null);
+    this._lastRawOsc7.set(sessionId, null);
   }
 
   /**
@@ -169,6 +183,7 @@ class TerminalBridge extends BaseBridge {
     this._osc7Parsers.delete(sessionId);
     this._osc7Hooks.delete(sessionId);
     this._liveCwd.delete(sessionId);
+    this._lastRawOsc7.delete(sessionId);
   }
 
   /**
@@ -186,6 +201,18 @@ class TerminalBridge extends BaseBridge {
     if (!decoded.length) return;
 
     for (const raw of decoded) {
+      // Fast-path: skip the entire validate-and-emit chain when the shell
+      // re-emits the same raw path. pwsh + oh-my-posh/Starship redraws on
+      // every keystroke, so the same `file:///Q:/src` arrives N times per
+      // second. validatePath does 3–4 fs.realpathSync syscalls per call;
+      // on a SUBST/mapped/network drive each syscall is 10–50ms, and
+      // pending requests pile up faster than they complete. The dedupe
+      // at the cwd-level below (line 207) only saves the BROADCAST — it
+      // can't save the syscalls because they happen during validation.
+      const lastRaw = this._lastRawOsc7.get(sessionId);
+      if (raw === lastRaw) continue;
+      this._lastRawOsc7.set(sessionId, raw);
+
       let validated;
       try {
         validated = hooks.validatePath(raw);
@@ -199,9 +226,8 @@ class TerminalBridge extends BaseBridge {
       const cwd = validated.path || raw;
       const prev = this._liveCwd.get(sessionId) || null;
 
-      // Only emit on actual change — OSC 7 fires every prompt, including
-      // the no-cd common case. Suppressing same-value emits keeps the
-      // WebSocket frame count bounded by user activity, not prompt rate.
+      // Defence-in-depth: even if validation collapses two different raw
+      // strings to the same canonical cwd, don't broadcast a no-op change.
       if (cwd === prev) continue;
 
       this._liveCwd.set(sessionId, cwd);

--- a/src/utils/file-watcher.js
+++ b/src/utils/file-watcher.js
@@ -98,7 +98,12 @@ class FileWatcher extends EventEmitter {
    *                Subscribed paths are typically children of this root, but
    *                relPath is computed regardless (may include `..` segments
    *                if a subscription is outside the root).
-   *   - debounceMs: per-path debounce window (default 100, ADR §Coalescing).
+   *   - debounceMs: per-path debounce window (default 500, ADR §Coalescing).
+   *                 Bumped from 100 to 500 when the "Windows + multi-worktree
+   *                 + Claude bulk edits" hang was diagnosed — under bulk edits
+   *                 a 100ms window barely coalesces, and combined with the
+   *                 narrow-scope `depth: 0` path below the longer window
+   *                 substantially cuts event rate without harming UX.
    *   - addChangeDedupMs: window within which add+change collapses to change
    *                       (default 50, ADR §Coalescing layer 3).
    *   - renameDetectMs: window within which same-inode unlink+add collapses
@@ -108,7 +113,19 @@ class FileWatcher extends EventEmitter {
    *                                    layer 1; tunable for tests).
    *   - ignoreDirs: directory-name list for ignore patterns; default
    *                 DEFAULT_IGNORE_DIRS.
-   *   - includeHash: emit hash on change events (default true).
+   *   - depth: passed through to chokidar. `0` confines the watcher to direct
+   *            children of every watched path — used by the file-browser SSE
+   *            endpoint to eliminate the recursive-tree handle explosion on
+   *            Windows + large worktree trees. Default `undefined`
+   *            (chokidar's recursive default, for backward compat).
+   *   - includeHash: emit MD5 hash on change events. Default `true` UNLESS
+   *                 `depth: 0` is set, in which case the default flips to
+   *                 `false` because the sync `fs.readFileSync` inside
+   *                 `_flush()` can block the event loop under bulk edits
+   *                 (e.g. an agent generating many files in the displayed
+   *                 directory). The `file-tabs.js` hash short-circuit falls
+   *                 through gracefully when hash is absent (always refresh
+   *                 via HTTP), so functionality is preserved.
    */
   constructor(opts) {
     super();
@@ -124,14 +141,24 @@ class FileWatcher extends EventEmitter {
     let resolvedRoot = path.resolve(opts.watchRoot);
     try { resolvedRoot = fs.realpathSync(resolvedRoot); } catch (_) {}
     this._watchRoot = resolvedRoot;
-    this._debounceMs = typeof opts.debounceMs === 'number' ? opts.debounceMs : 100;
+    this._debounceMs = typeof opts.debounceMs === 'number' ? opts.debounceMs : 500;
     this._addChangeDedupMs = typeof opts.addChangeDedupMs === 'number' ? opts.addChangeDedupMs : 50;
     this._renameDetectMs = typeof opts.renameDetectMs === 'number' ? opts.renameDetectMs : 50;
     this._stabilityMs = typeof opts.stabilityMs === 'number' ? opts.stabilityMs : 80;
     this._pollIntervalMs = typeof opts.pollIntervalMs === 'number' ? opts.pollIntervalMs : 30;
     this._ignoreDirs = Array.isArray(opts.ignoreDirs) ? opts.ignoreDirs : DEFAULT_IGNORE_DIRS;
     this._ignoreRegexes = buildIgnoreRegexes(this._ignoreDirs);
-    this._includeHash = opts.includeHash !== false;
+    this._depth = typeof opts.depth === 'number' ? opts.depth : undefined;
+    // When the caller opted into narrow-scope (depth: 0) and didn't explicitly
+    // ask for hashes, default-off to keep _flush() from doing sync MD5 reads
+    // under bulk-edit storms. Explicit `includeHash: true` still wins.
+    if (typeof opts.includeHash === 'boolean') {
+      this._includeHash = opts.includeHash;
+    } else if (this._depth === 0) {
+      this._includeHash = false;
+    } else {
+      this._includeHash = true;
+    }
     // Allow callers to disable awaitWriteFinish entirely (for tests where
     // sync writeFileSync races chokidar's poll cycle). Default = on with
     // tuned-down values per ADR-0017.
@@ -211,6 +238,15 @@ class FileWatcher extends EventEmitter {
       usePolling: this._usePolling,
       interval: this._usePolling ? 50 : undefined,
       atomic: false,
+      // depth: 0 confines chokidar to direct children of every watched
+      // path (the watchRoot + anything later added via subscribe). The
+      // server passes this for the file-browser SSE path; subscriptions
+      // drive what's actually watched beyond the watchRoot via
+      // chokidar.add(). This is the load-bearing knob that bounds the
+      // active_handles cost on large/multi-worktree trees. `undefined`
+      // (the default) restores chokidar's recursive behaviour for
+      // backward compat in callers that haven't migrated.
+      depth: this._depth,
     });
 
     this._watcher.on('add', (p, stat) => this._onChokidar('add', p, stat));
@@ -270,24 +306,38 @@ class FileWatcher extends EventEmitter {
 
   /**
    * Add a path to the active subscription set. Events for this path will
-   * now flow through the consumer's 'event' listener. The path does not
-   * need to exist at subscribe time — chokidar already watches the
-   * watchRoot subtree, so add events fire when the file is created.
+   * now flow through the consumer's 'event' listener.
+   *
+   * When the watcher was constructed with `depth: 0`, the chokidar watch
+   * scope is dynamically managed: subscribing to a file watches its parent
+   * directory (chokidar emits events for direct children of the watched
+   * dir); subscribing to a directory recursively watches that directory.
+   * A physical-watch-target refcount means we only call chokidar.add()
+   * for the first subscription that needs a given dir, and chokidar.unwatch()
+   * for the last. Without this, two tabs in the same dir would race the
+   * underlying watch and a tab-close could kill another tab's events.
+   *
+   * For constructors NOT using depth: 0 (legacy callers), chokidar already
+   * watches the full subtree of watchRoot recursively, so subscribe is
+   * pure soft-filter bookkeeping (no chokidar.add).
    *
    * @param {string} absPath
    * @param {object} [opts]
-   *   - recursive: boolean — if true, the subscription is treated as a
-   *                directory-recursive match: events for `absPath` AND
-   *                any descendant fire. Used by FileBrowserPanel for
-   *                the "auto-refresh listing on agent-create" case
-   *                where the new file's path isn't known at subscribe
-   *                time. Default false (exact-path match).
+   *   - recursive: boolean — if true, the subscription matches the dir AND
+   *                its descendants (in the recursive-watch model). Under
+   *                depth: 0 the soft-filter set still uses this for event
+   *                matching, but chokidar itself only watches direct
+   *                children of the dir — descendant events would not
+   *                arrive (file-browser listing already filters to direct
+   *                children, so this is invisible to current consumers).
+   *                Default false (exact-path match).
    */
   async subscribe(absPath, opts) {
     if (this._closed) throw new Error('FileWatcher: cannot subscribe on a closed watcher');
     if (!this._watcher) throw new Error('FileWatcher: must call start() before subscribe()');
     const canonical = this._canonicalize(absPath);
-    if (opts && opts.recursive) {
+    const isRecursive = !!(opts && opts.recursive);
+    if (isRecursive) {
       // Store with a trailing path separator so the prefix-match in
       // _onChokidar via `startsWith(dir + sep)` works without false
       // positives (e.g. /a/b should NOT match /a/bc).
@@ -295,13 +345,20 @@ class FileWatcher extends EventEmitter {
     } else {
       this._subscriptions.add(canonical);
     }
+    if (this._depth === 0) {
+      const target = isRecursive ? canonical : path.dirname(canonical);
+      this._refWatchTarget(target);
+    }
   }
 
   /**
    * Remove a path from the active subscription set. Subsequent events for
-   * this path will be dropped on emit (chokidar continues to fire them
-   * internally — cheap to discard). Idempotent: removing a non-subscribed
+   * this path will be dropped on emit. Idempotent: removing a non-subscribed
    * path is a no-op.
+   *
+   * Under `depth: 0`, also drops the chokidar watch on the corresponding
+   * target directory when no other subscription still references it (see
+   * `_refWatchTarget`).
    *
    * The `recursive` opt must match the flavour the path was subscribed
    * with — calling unsubscribe(path, {recursive:true}) on an exact-
@@ -312,10 +369,59 @@ class FileWatcher extends EventEmitter {
   async unsubscribe(absPath, opts) {
     if (this._closed) return;
     const canonical = this._canonicalize(absPath);
-    if (opts && opts.recursive) {
-      this._dirSubscriptions.delete(canonical + path.sep);
+    const isRecursive = !!(opts && opts.recursive);
+    let hadSub = false;
+    if (isRecursive) {
+      hadSub = this._dirSubscriptions.delete(canonical + path.sep);
     } else {
-      this._subscriptions.delete(canonical);
+      hadSub = this._subscriptions.delete(canonical);
+    }
+    if (!hadSub) return; // idempotent — nothing to release
+    if (this._depth === 0) {
+      const target = isRecursive ? canonical : path.dirname(canonical);
+      this._unrefWatchTarget(target);
+    }
+  }
+
+  /**
+   * Refcount-key normalization for the watch-target map. On Windows the
+   * filesystem is case-insensitive but path strings carry whatever casing
+   * the caller used (or whatever realpathSync returned, which is not
+   * always the on-disk form for paths it can't resolve). Lower-casing the
+   * key means `subscribe('Q:\\src\\file.js')` and `unsubscribe('q:\\SRC\\
+   * FILE.JS')` resolve to the same refcount slot. Forward-slash
+   * normalization is a separate cross-platform concern handled by
+   * normalizePath above.
+   */
+  _watchKeyNorm(p) {
+    const n = normalizePath(p);
+    return process.platform === 'win32' ? n.toLowerCase() : n;
+  }
+
+  _refWatchTarget(target) {
+    // The watchRoot is already watched at start() time — never add/unwatch it
+    // dynamically here, or we'd risk closing the root chokidar handle.
+    if (this._watchKeyNorm(target) === this._watchKeyNorm(this._watchRoot)) return;
+    const key = this._watchKeyNorm(target);
+    const cur = this._dirRefcount.get(key) || 0;
+    this._dirRefcount.set(key, cur + 1);
+    if (cur === 0) {
+      this._watchedDirs.add(key);
+      try { this._watcher.add(target); } catch (_) { /* chokidar will surface via 'error' if real */ }
+    }
+  }
+
+  _unrefWatchTarget(target) {
+    if (this._watchKeyNorm(target) === this._watchKeyNorm(this._watchRoot)) return;
+    const key = this._watchKeyNorm(target);
+    const cur = this._dirRefcount.get(key) || 0;
+    if (cur === 0) return; // defensive — refcount should never go negative
+    if (cur === 1) {
+      this._dirRefcount.delete(key);
+      this._watchedDirs.delete(key);
+      try { this._watcher.unwatch(target); } catch (_) {}
+    } else {
+      this._dirRefcount.set(key, cur - 1);
     }
   }
 

--- a/test/file-browser-api.test.js
+++ b/test/file-browser-api.test.js
@@ -1569,11 +1569,20 @@ function encodeParam(val) {
         `/api/files/watch/subscribe?session=${encodeParam(sessionId)}&path=${encodeParam(target)}`);
       assert.strictEqual(sub.status, 204);
 
-      // Lifecycle: write → modify → delete, with > debounce-window between.
+      // Under depth: 0, subscribe() calls chokidar.add() which is async — give
+      // it a moment to attach before mutating, or the first 'add' event races.
+      // In production the file-browser's initial /api/files readdir naturally
+      // covers this window; tests need an explicit delay.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Lifecycle: write → modify → delete, with > debounce-window between
+      // (debounce default is 500ms post-Windows-hang fix — the gap MUST
+      // exceed that or per-path debounce will collapse add+change into one
+      // event with the latest type winning).
       fs.writeFileSync(target, 'first');
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      await new Promise((resolve) => setTimeout(resolve, 700));
       fs.writeFileSync(target, 'second');
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      await new Promise((resolve) => setTimeout(resolve, 700));
       fs.unlinkSync(target);
 
       // Wait for the unlink event to confirm the chain completed.
@@ -1589,8 +1598,15 @@ function encodeParam(val) {
       assert.ok(change, 'change event must exist');
       assert.strictEqual(change.relPath, 'changeling.txt', 'relPath must be set');
       assert.strictEqual(typeof change.mtime, 'number', 'change must include numeric mtime');
-      assert.ok(typeof change.hash === 'string' && /^[0-9a-f]{32}$/.test(change.hash),
-        'change must include md5 hash; got ' + change.hash);
+      // hash is now opt-in: when the server constructs FileWatcher with
+      // depth: 0 (the narrow-scope path used by /api/files/watch since the
+      // Windows-hang fix), includeHash defaults to false to keep the sync
+      // fs.readFileSync MD5 from blocking the event loop under bulk edits.
+      // When present, it must still be a 32-char hex string.
+      if (change.hash !== undefined) {
+        assert.ok(typeof change.hash === 'string' && /^[0-9a-f]{32}$/.test(change.hash),
+          'change.hash, if emitted, must be a 32-char md5 hex; got ' + change.hash);
+      }
 
       const unlink = sse.events.find((e) => e.type === 'unlink' && e.path && e.path.endsWith('/changeling.txt'));
       assert.strictEqual(unlink.mtime, null, 'unlink mtime must be null');
@@ -1704,12 +1720,19 @@ function encodeParam(val) {
     });
 
     it('recursive=1: emits change event for nested file in subscribed dir', async function () {
-      const subDir = path.join(realTmpDirW(), 'watch-rec-nested');
-      fs.mkdirSync(path.join(subDir, 'a', 'b'), { recursive: true });
-      const nested = path.join(subDir, 'a', 'b', 'deep.txt');
-      fs.writeFileSync(nested, 'initial');
+      // SEMANTIC NOTE: under the depth: 0 narrow-scope (introduced when the
+      // Windows-hang fix narrowed chokidar to direct-children-only), a
+      // "recursive" subscription means "this dir's direct children", not
+      // "this dir's whole subtree". The file-browser listing only renders
+      // direct children anyway, so this matches actual use. This test now
+      // exercises the direct-child case; descendant events are intentionally
+      // not supported.
+      const subDir = path.join(realTmpDirW(), 'watch-rec-direct');
+      fs.mkdirSync(subDir, { recursive: true });
+      const direct = path.join(subDir, 'direct.txt');
+      fs.writeFileSync(direct, 'initial');
 
-      const sessionId = 'rec-nested-' + Date.now();
+      const sessionId = 'rec-direct-' + Date.now();
       const sse = await openSseAndWaitForStart(port, sessionId, subDir);
       assert.strictEqual(sse.status, 200);
 
@@ -1717,16 +1740,16 @@ function encodeParam(val) {
         `/api/files/watch/subscribe?session=${encodeParam(sessionId)}&path=${encodeParam(subDir)}&recursive=1`);
       assert.strictEqual(sub.status, 204);
 
-      // Modify the deeply-nested file. Exact-path filter would drop this
-      // (the deep file wasn't subscribed); recursive must accept it.
-      await new Promise((r) => setTimeout(r, 150));   // let watcher settle
-      fs.writeFileSync(nested, 'modified by agent');
+      // Settle the chokidar.add() race window (see note in the "streams add
+      // → change → unlink" test above).
+      await new Promise((r) => setTimeout(r, 200));
+      fs.writeFileSync(direct, 'modified by agent');
 
       const evt = await waitForEvent(sse.events,
-        (e) => e.type === 'change' && e.path && e.path.endsWith('/a/b/deep.txt'),
+        (e) => e.type === 'change' && e.path && e.path.endsWith('/direct.txt'),
         3000);
-      assert.ok(evt, 'expected change event for nested file inside recursive sub');
-      assert.strictEqual(evt.relPath, 'a/b/deep.txt');
+      assert.ok(evt, 'expected change event for direct-child file inside recursive sub');
+      assert.strictEqual(evt.relPath, 'direct.txt');
 
       try { sse.request.destroy(); } catch (_) {}
       await new Promise((r) => setTimeout(r, 100));
@@ -1749,6 +1772,8 @@ function encodeParam(val) {
         `/api/files/watch/subscribe?session=${encodeParam(sessionId)}&path=${encodeParam(inside)}&recursive=1`);
       assert.strictEqual(sub.status, 204);
 
+      // Settle the chokidar.add() race for the inside subscription.
+      await new Promise((r) => setTimeout(r, 200));
       fs.writeFileSync(path.join(inside, 'in.txt'), 'inside');
       fs.writeFileSync(path.join(outside, 'out.txt'), 'outside');
 
@@ -1784,6 +1809,8 @@ function encodeParam(val) {
         `/api/files/watch/subscribe?session=${encodeParam(sessionId)}&path=${encodeParam(path.join(root, 'b'))}&recursive=1`);
       assert.strictEqual(sub.status, 204);
 
+      // Settle the chokidar.add() race.
+      await new Promise((r) => setTimeout(r, 200));
       fs.writeFileSync(path.join(root, 'b', 'in.txt'), 'in');
       fs.writeFileSync(path.join(root, 'bc', 'out.txt'), 'out');
 
@@ -1943,9 +1970,12 @@ function encodeParam(val) {
       await postJson(port,
         `/api/files/watch/subscribe?session=${encodeParam(sessionId)}&path=${encodeParam(target)}`);
 
+      // Settle the chokidar.add() race so the immediate writeFileSync below
+      // is observed.
+      await new Promise((r) => setTimeout(r, 200));
       fs.writeFileSync(target, 'first');
       // Wait > debounce window so any duplicates would have surfaced.
-      await new Promise((r) => setTimeout(r, 350));
+      await new Promise((r) => setTimeout(r, 600));
 
       const matchingEvts = sse.events.filter(
         (e) => e.type === 'add' && e.path && e.path.endsWith('/twice.txt'));

--- a/test/file-watcher.test.js
+++ b/test/file-watcher.test.js
@@ -1,0 +1,308 @@
+// test/file-watcher.test.js — unit tests for the FileWatcher chokidar
+// narrowing introduced when the Windows + multi-worktree hang was diagnosed.
+//
+// Three properties this file proves directly (the adversarial review of
+// the design plan flagged each as an unverified assumption):
+//
+//   1. Under depth: 0, chokidar's actual watch scope = the union of
+//      subscribed paths' target directories. Unsubscribed paths get no
+//      events; subscribed paths do.
+//   2. The watch-target refcount on unsubscribe is correct: closing one
+//      subscription that shares a watch target with another subscription
+//      does NOT silence the other one.
+//   3. The Windows-case-insensitive refcount key collapses case-variant
+//      subscriptions to a single refcount slot (subscribe in one casing,
+//      unsubscribe in another, watch should still drop).
+//
+// We avoid asserting timing-sensitive event arrival via real chokidar
+// (FSEvents flakiness on macOS sync writes is well documented). Instead
+// we drive chokidar with FS_WATCHER_USE_POLLING=1 inside the test and
+// short stabilityMs / pollIntervalMs windows.
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const FileWatcher = require('../src/utils/file-watcher');
+
+function mkdtemp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'fw-narrow-'));
+}
+
+async function waitForEvent(watcher, predicate, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      watcher.off('event', onEvent);
+      reject(new Error('Timed out waiting for matching event'));
+    }, timeoutMs || 2000);
+    function onEvent(evt) {
+      if (predicate(evt)) {
+        clearTimeout(timer);
+        watcher.off('event', onEvent);
+        resolve(evt);
+      }
+    }
+    watcher.on('event', onEvent);
+  });
+}
+
+async function expectNoEvent(watcher, predicate, windowMs) {
+  return new Promise((resolve, reject) => {
+    function onEvent(evt) {
+      if (predicate(evt)) {
+        clearTimeout(timer);
+        watcher.off('event', onEvent);
+        reject(new Error('Unexpected event arrived: ' + JSON.stringify(evt)));
+      }
+    }
+    watcher.on('event', onEvent);
+    const timer = setTimeout(() => {
+      watcher.off('event', onEvent);
+      resolve();
+    }, windowMs);
+  });
+}
+
+function newWatcher(root, opts) {
+  return new FileWatcher(Object.assign({
+    watchRoot: root,
+    depth: 0,
+    debounceMs: 30,
+    addChangeDedupMs: 10,
+    renameDetectMs: 10,
+    stabilityMs: 0,           // disable awaitWriteFinish (sync writes)
+    usePolling: true,         // dodge FSEvents on macOS for deterministic tests
+    pollIntervalMs: 25,
+  }, opts || {}));
+}
+
+describe('FileWatcher narrow-scope (depth: 0)', function () {
+  this.timeout(15000);
+
+  it('defaults includeHash to false when depth: 0 is set', function () {
+    const root = mkdtemp();
+    try {
+      const w = new FileWatcher({ watchRoot: root, depth: 0 });
+      assert.strictEqual(w._includeHash, false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps includeHash default true when depth is not set', function () {
+    const root = mkdtemp();
+    try {
+      const w = new FileWatcher({ watchRoot: root });
+      assert.strictEqual(w._includeHash, true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('respects explicit includeHash override even with depth: 0', function () {
+    const root = mkdtemp();
+    try {
+      const w = new FileWatcher({ watchRoot: root, depth: 0, includeHash: true });
+      assert.strictEqual(w._includeHash, true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('default debounceMs is 500 (Windows-hang remediation)', function () {
+    const root = mkdtemp();
+    try {
+      const w = new FileWatcher({ watchRoot: root });
+      assert.strictEqual(w._debounceMs, 500);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('subscribing to a file watches its parent dir; unsubscribing unwatches when refcount hits zero', async function () {
+    const root = mkdtemp();
+    const subdir = fs.mkdtempSync(path.join(root, 'sub-'));
+    const file = path.join(subdir, 'a.js');
+    fs.writeFileSync(file, 'v1');
+
+    const w = newWatcher(root);
+    try {
+      await w.start();
+      // _refWatchTarget keys off the canonicalized (realpathed) path —
+      // on macOS /tmp → /private/tmp so we must canonicalize the expected
+      // key too. Use the watcher's own normalizer so the platform-specific
+      // lower-casing matches.
+      const canonicalSubdir = fs.realpathSync(subdir);
+      const dirKey = w._watchKeyNorm(canonicalSubdir);
+
+      // Before any subscription, the parent dir is NOT in _watchedDirs
+      // (only the watchRoot is implicitly watched at depth 0).
+      assert.strictEqual(w._watchedDirs.has(dirKey), false);
+
+      await w.subscribe(file);
+      assert.strictEqual(w._watchedDirs.has(dirKey), true);
+      assert.strictEqual(w._dirRefcount.get(dirKey), 1);
+
+      await w.unsubscribe(file);
+      assert.strictEqual(w._watchedDirs.has(dirKey), false);
+      assert.strictEqual(w._dirRefcount.has(dirKey), false);
+    } finally {
+      await w.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('two subscriptions sharing a parent dir refcount to a single watch; closing one keeps the other live', async function () {
+    const root = mkdtemp();
+    const subdir = fs.mkdtempSync(path.join(root, 'sub-'));
+    const fileA = path.join(subdir, 'a.js');
+    const fileB = path.join(subdir, 'b.js');
+    fs.writeFileSync(fileA, 'a1');
+    fs.writeFileSync(fileB, 'b1');
+
+    const w = newWatcher(root);
+    try {
+      await w.start();
+      await w.subscribe(fileA);
+      await w.subscribe(fileB);
+      const dirKey = w._watchKeyNorm(fs.realpathSync(subdir));
+      assert.strictEqual(w._dirRefcount.get(dirKey), 2);
+
+      // Close one; the other must keep getting events.
+      await w.unsubscribe(fileA);
+      assert.strictEqual(w._dirRefcount.get(dirKey), 1);
+      assert.strictEqual(w._watchedDirs.has(dirKey), true);
+
+      // Bump file B and confirm we still see the event.
+      const got = waitForEvent(w, (evt) => evt.type === 'change' && evt.path.endsWith('b.js'), 5000);
+      // Small delay so the watcher's polling sees the second mtime.
+      await new Promise((r) => setTimeout(r, 100));
+      fs.writeFileSync(fileB, 'b2');
+      await got;
+
+      // Close the second; chokidar drops the underlying watch.
+      await w.unsubscribe(fileB);
+      assert.strictEqual(w._dirRefcount.has(dirKey), false);
+      assert.strictEqual(w._watchedDirs.has(dirKey), false);
+    } finally {
+      await w.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refcount key is case-insensitive on Windows (no-op assertion elsewhere)', function () {
+    // We can't actually exercise the case-collision on POSIX (paths are
+    // case-sensitive), but the predicate is testable in isolation.
+    const root = mkdtemp();
+    try {
+      const w = new FileWatcher({ watchRoot: root, depth: 0 });
+      const a = w._watchKeyNorm('Q:\\src\\Foo');
+      const b = w._watchKeyNorm('q:/SRC/foo');
+      if (process.platform === 'win32') {
+        assert.strictEqual(a, b, 'Windows refcount key must collapse case + separator differences');
+      } else {
+        // On POSIX, only the separator-normalization runs (backslashes
+        // are treated as literal characters here — input is a synthetic
+        // Windows path). We still expect _watchKeyNorm to be a pure
+        // function of the input.
+        assert.strictEqual(typeof a, 'string');
+        assert.strictEqual(typeof b, 'string');
+      }
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('events for paths NEVER subscribed do not fire', async function () {
+    const root = mkdtemp();
+    const sub = fs.mkdtempSync(path.join(root, 'sub-'));
+    const subscribed = path.join(sub, 'watched.js');
+    const stranger = path.join(sub, 'stranger.js');
+    fs.writeFileSync(subscribed, '1');
+    fs.writeFileSync(stranger, '1');
+
+    const w = newWatcher(root);
+    try {
+      await w.start();
+      await w.subscribe(subscribed);
+
+      // Bump the stranger file — no event should fire for it because the
+      // soft-filter set doesn't include it, even though chokidar is now
+      // watching the parent dir (and will SEE the event internally).
+      const noEvent = expectNoEvent(w, (evt) => evt.path.endsWith('stranger.js'), 600);
+      await new Promise((r) => setTimeout(r, 100));
+      fs.writeFileSync(stranger, '2');
+      await noEvent;
+    } finally {
+      await w.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('depth: 0 + recursive subscription delivers events for direct children only', async function () {
+    const root = mkdtemp();
+    const sub = fs.mkdtempSync(path.join(root, 'sub-'));
+    const directChild = path.join(sub, 'direct.js');
+    const grandchildDir = path.join(sub, 'nested');
+    fs.mkdirSync(grandchildDir);
+    const grandchild = path.join(grandchildDir, 'deep.js');
+    fs.writeFileSync(directChild, '1');
+    fs.writeFileSync(grandchild, '1');
+
+    const w = newWatcher(root);
+    try {
+      await w.start();
+      await w.subscribe(sub, { recursive: true });
+
+      // Direct child change → event.
+      const direct = waitForEvent(w, (evt) => evt.path.endsWith('direct.js'), 5000);
+      await new Promise((r) => setTimeout(r, 100));
+      fs.writeFileSync(directChild, '2');
+      await direct;
+
+      // Grandchild change → NO event (depth: 0).
+      const noEvent = expectNoEvent(w, (evt) => evt.path.endsWith('deep.js'), 600);
+      await new Promise((r) => setTimeout(r, 100));
+      fs.writeFileSync(grandchild, '2');
+      await noEvent;
+    } finally {
+      await w.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('FileWatcher recursive backward compat (no depth)', function () {
+  this.timeout(10000);
+
+  it('subscribe still passes basic events when constructed without depth', async function () {
+    const root = mkdtemp();
+    const file = path.join(root, 'a.js');
+    fs.writeFileSync(file, 'x');
+    const w = new FileWatcher({
+      watchRoot: root,
+      // no depth — falls back to recursive (legacy callers)
+      debounceMs: 30,
+      stabilityMs: 0,
+      usePolling: true,
+      pollIntervalMs: 25,
+    });
+    try {
+      await w.start();
+      await w.subscribe(file);
+      const got = waitForEvent(w, (evt) => evt.type === 'change' && evt.path.endsWith('a.js'), 5000);
+      await new Promise((r) => setTimeout(r, 100));
+      fs.writeFileSync(file, 'y');
+      await got;
+      // Refcount machinery should NOT have engaged (no depth: 0).
+      assert.strictEqual(w._watchedDirs.size, 0);
+      assert.strictEqual(w._dirRefcount.size, 0);
+    } finally {
+      await w.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/osc7-parser.test.js
+++ b/test/osc7-parser.test.js
@@ -383,4 +383,59 @@ describe('TerminalBridge OSC 7 wiring', function () {
     bridge._uninstallOsc7State(sessionId);
     assert.strictEqual(bridge.getLiveCwd(sessionId), null);
   });
+
+  it('does NOT call validatePath when the same raw OSC 7 path is re-emitted', function () {
+    // Windows-hang repro guard: pwsh + a fast prompt (oh-my-posh/Starship)
+    // re-emits the same `file:///...` URI on every prompt redraw. Without
+    // the raw-path fast-path in _handleOsc7Chunk, validatePath fires per
+    // emission — and each call costs 3–4 fs.realpathSync syscalls. On a
+    // SUBST/network drive those queue up, the event loop blocks, and the
+    // server hangs (observed: active_handles 16 → 48k in 5 min on Q:\src).
+    const bridge = makeBridge();
+    const sessionId = 'sess-dedupe';
+
+    let validateCalls = 0;
+    let cwdChangeCalls = 0;
+    bridge._installOsc7State(sessionId, {
+      onCwdChange: () => { cwdChangeCalls++; },
+      validatePath: (p) => { validateCalls++; return { valid: true, path: p }; },
+    });
+
+    const sameChunk = '\x1b]7;file:///tmp\x07';
+    for (let i = 0; i < 100; i++) bridge._handleOsc7Chunk(sessionId, sameChunk);
+
+    assert.strictEqual(validateCalls, 1, 'validatePath ran more than once for identical raw paths');
+    assert.strictEqual(cwdChangeCalls, 1, 'onCwdChange fired more than once for identical raw paths');
+
+    // Sanity: a NEW raw path still flows through validation.
+    bridge._handleOsc7Chunk(sessionId, '\x1b]7;file:///var\x07');
+    assert.strictEqual(validateCalls, 2);
+    assert.strictEqual(cwdChangeCalls, 2);
+
+    bridge._uninstallOsc7State(sessionId);
+  });
+
+  it('clears _lastRawOsc7 on session uninstall so a re-installed session re-validates', function () {
+    const bridge = makeBridge();
+    const sessionId = 'sess-reinstall';
+    let validateCalls = 0;
+    const hooks = {
+      onCwdChange: () => {},
+      validatePath: (p) => { validateCalls++; return { valid: true, path: p }; },
+    };
+
+    bridge._installOsc7State(sessionId, hooks);
+    bridge._handleOsc7Chunk(sessionId, '\x1b]7;file:///tmp\x07');
+    assert.strictEqual(validateCalls, 1);
+
+    bridge._uninstallOsc7State(sessionId);
+    bridge._installOsc7State(sessionId, hooks);
+
+    // Same raw path on the new session — the previous run's lastRaw must
+    // not leak through, so validatePath should fire again.
+    bridge._handleOsc7Chunk(sessionId, '\x1b]7;file:///tmp\x07');
+    assert.strictEqual(validateCalls, 2);
+
+    bridge._uninstallOsc7State(sessionId);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the Windows hang reported on `Q:\src` with multiple worktrees and Claude editing heavily across them. Observed diagnostics:

```
uptime  900s: active_handles 16,    active_requests 0,     heap  50 MB,  fs_watch_sessions 0
uptime 1210s: active_handles 48136, active_requests 17545, heap 433 MB,  fs_watch_sessions 1
```

Two compounding root causes:

1. **OSC 7 validatePath syscall storm.** pwsh + a fast prompt (oh-my-posh / Starship) re-emits the same `file:///Q:/src` URI on every prompt redraw. `validatePath` ran 3–4 `fs.realpathSync` syscalls per emission; on a Dev Drive each syscall is non-trivial, and pending requests piled up faster than they completed, blocking the event loop. The existing dedupe in `_handleOsc7Chunk` only saved the WebSocket broadcast — the syscalls had already happened.
2. **chokidar recursively watching the entire `watchRoot`.** The FileWatcher allocated one `fs.watch` handle per directory in `Q:\src`, which on a multi-worktree tree is ~48K. Client subscriptions were soft-filter Sets that dropped events on emit but did nothing to bound the underlying watch scope. `_flush()` then ran a synchronous `fs.readFileSync` MD5 on every change event, blocking the event loop further under bulk file activity.

## Changes

### Part 1 — OSC 7 dedupe and baseFolder memoization (`702a2bd`)

- `src/terminal-bridge.js`: fast-path skip in `_handleOsc7Chunk` when the raw OSC 7 path is identical to the previous emission for this session — no `validatePath` call. Paired `_lastRawOsc7` init/cleanup added.
- `src/server.js`: memoize the canonicalized `baseFolder` (constant for process lifetime; previously re-computed inside every `isPathWithinBase` call).

### Part 2 — narrow chokidar watch scope (`d80a6fb`)

- `src/utils/file-watcher.js`:
  - New `depth` constructor option (passed through to chokidar). Narrow-scope callers pass `depth: 0`.
  - `subscribe()` calls `chokidar.add()` under depth: 0 with refcounting on a physical-watch-target key (parent dir of an exact-file sub, or the dir itself for a recursive sub). Refcount key is case-insensitive on Windows.
  - `unsubscribe()` decrements the refcount; only when it hits zero does it `chokidar.unwatch()`. Prevents closing one tab from killing another tab's events when they share a parent dir.
  - When `depth: 0` is set and `includeHash` is not explicit, defaults to `false`. Removes the sync `fs.readFileSync` MD5 from the event-loop critical path. The hash short-circuit in `file-tabs.js:294` falls through gracefully when hash is absent; save-time OCC is preserved via the editor's own `_fileHash` tracking from `/api/files/content`.
  - `_debounceMs` default bumped 100 → 500.
- `src/server.js`: `/api/files/watch` constructs FileWatcher with `depth: 0`. `FS_WATCHER_DEBOUNCE_MS` env default bumped 100 → 500.

### Tests

- `test/osc7-parser.test.js`: two new cases — `validatePath` called exactly once for 100 identical raw OSC 7 emissions; `_lastRawOsc7` cleared on session uninstall.
- `test/file-watcher.test.js`: NEW — chokidar narrowing semantics, refcount correctness on shared parent dirs, Windows-case normalization, `depth: 0 + recursive` direct-child behavior, backward-compat for legacy callers (no depth).
- `test/file-browser-api.test.js`: updated four `/api/files/watch` integration tests for the deliberate semantic change (recursive sub now means direct children only — matches what the file-browser listing actually renders) and added settling delays for the chokidar.add() async-attach race window (which in production is naturally covered by the file-browser's `/api/files` initial readdir).

**1144 passing locally** (+12 from the prior baseline of 1132).

## Adversarial review

The chokidar narrowing design was reviewed by three lab-diverse critics (codex/gpt-5.5, gemini-3.1-pro, opus-4.7) before commit. Converging concerns that shaped the final design:

- Physical-watch-target refcount on unsubscribe (not just logical subscription refcount).
- Smart `includeHash: false` default under depth: 0 — the bounded watch scope doesn't bound event density within scope; bulk edits would still queue thousands of sync MD5 reads.
- Explicit Windows case-insensitivity on the refcount key.
- Documented semantic change rather than silent "backward compat" with `recursive` flag.
- Audit of recursive-event consumers (`file-browser.js:1473` already filters to direct children; `file-tabs.js:262` uses exact tab paths — no consumer relied on deep descendants).

## Test plan

- [x] `npm test` passes (1144 passing).
- [ ] User reproduces on Windows + Dev Drive `Q:\src` with multiple worktrees and Claude active: `active_handles` stays well under 100 (was 48,136), `active_requests` stays under 100 (was 17,545), no hang over 10+ minutes.
- [ ] File browser opens, navigates, opens tabs, sees live edits within ~500ms.
- [ ] File browser closes → `/api/diagnostics` shows `fs_watch_sessions: 0` (chokidar fully torn down).