### PR TITLE
fix(file-watcher): HOT-07 async hash queue + per-path late-inclusion cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Performance
+- HOT-07 — FileWatcher: moved MD5 hashing off the `_flush()` hot path
+  into a bounded async queue (`fs.promises.readFile`, concurrency 8).
+  Eliminates the synchronous `fs.readFileSync` that blocked the event
+  loop for the duration of each disk read under bulk-edit storms
+  (~600 ms cumulative for a 20-file burst). Per-path hash cache
+  preserves `file-tabs.js`'s content-unchanged short-circuit for
+  rapid same-mtime re-touches. See `docs/audits/hot-02-filewatcher-hash.md`.
+
 ## [0.1.0] - 2025-02-06
 
 ### Added

--- a/docs/adrs/0017-fs-watcher-push-channel.md
+++ b/docs/adrs/0017-fs-watcher-push-channel.md
@@ -147,10 +147,19 @@ One chokidar watcher per Claude session, rooted at `session.workingDir`.
   normalisation.
 - `mtime` lets clients detect ordering / staleness without re-fetching
   content.
-- `hash` (MD5) is included for `change` events on text files ≤ 5 MB
-  (matches `/api/files/stat` behaviour). Omitted for binary / large
-  files. Lets the client skip the round-trip if the new hash matches the
-  in-buffer content (rare, but cheap).
+- `hash` (MD5) is included for `change` and `rename` events on text
+  files ≤ 5 MB (matches `/api/files/stat` behaviour). Omitted for
+  binary / large files. **Hashing is async** since HOT-07 (was
+  synchronous on the hot path before; that blocked the event loop
+  for the duration of a 5 MB read under bulk-edit storms): the first
+  event for a freshly-changed file arrives WITHOUT `hash`, the async
+  hash computes off the hot path via a bounded queue (concurrency 8),
+  and the SECOND+ event for the same mtime carries the cached hash.
+  Lets the client skip the round-trip when a rapid metadata-only
+  re-touch (`touch foo.js && touch foo.js`) follows a content change.
+  Absent-`hash` is a documented non-short-circuit case in
+  `file-tabs.js`; consumers always fall through to the HTTP-refresh
+  path safely.
 - `prevPath` is included **only on `rename` events** (server-side
   synthesis — see "Rename detection" below).
 

--- a/docs/audits/hot-02-filewatcher-hash.md
+++ b/docs/audits/hot-02-filewatcher-hash.md
@@ -2,10 +2,10 @@
 
 **Lane**: SUP-HOT (event-loop hot paths)
 **Owner**: SUP-HOT
-**Status**: Investigation complete; fix deferred to HOT-07 (post-baseline)
+**Status**: Investigation complete. **Fix landed in HOT-07** (`src/utils/file-watcher.js`).
 **Files**: `src/utils/file-watcher.js:83–92`, `src/utils/file-watcher.js:580–608`,
 `src/utils/file-watcher.js:130–161` (constructor / `includeHash` default)
-**Date**: 2026-05-27
+**Date**: 2026-05-27 (investigation), 2026-05-28 (fix)
 
 ## Symptom
 
@@ -188,3 +188,92 @@ the sync path during a future refactor.
   hash via HTTP-refetch fallback)
 - `test/longevity/event-loop/hot-02-filewatcher-hash.test.js` —
   regression test
+
+## Fix landed (HOT-07)
+
+Picked **Option B** (async hash via bounded worker queue) per the memo
+recommendation. Structural fix that survives future callers.
+
+Implementation in `src/utils/file-watcher.js`:
+
+- New module-level constants `HASH_DEFAULT_CONCURRENCY = 8` (caps
+  concurrent reads to avoid EMFILE under a 1000-file burst) and
+  `HASH_CACHE_MAX_ENTRIES = 1024` (bounds the per-FileWatcher hash
+  cache against unbounded watched-path counts).
+- New module-level function `_hashFileAsync` using `fs.promises.stat` +
+  `fs.promises.readFile`. The synchronous `_hashFileSync` is retained
+  for back-compat but is no longer called from `_flush()`.
+- New instance fields: `_hashCache: Map<absPath, {hash, mtime}>`,
+  `_hashPending: [{absPath, mtime}, ...]`, `_hashInflight: number`,
+  `_hashConcurrency: number`, `_hashIdleWaiters: [resolve, ...]`.
+- New instance methods `_enqueueHash`, `_drainHashQueue`,
+  `hashQueueIdle()` (test affordance), `_fireHashIdleWaiters`.
+- `_flush()` rewritten: emits event synchronously WITHOUT hash on the
+  hot path; if `_includeHash` and the path's cached hash matches the
+  event's mtime, the emitted payload INCLUDES the hash (late-inclusion
+  path); otherwise the path is enqueued for async hashing so the NEXT
+  event for the same path can take the late-inclusion path.
+- `close()` extended to drop the pending queue + cache and resolve any
+  outstanding `hashQueueIdle()` waiters (test cleanup hygiene).
+
+### API-shape compatibility
+
+- The `event` payload's `hash` field remains OPTIONAL (same shape as
+  before). The only observable behaviour change is *when* it appears:
+  pre-fix it appeared on the first event after a content change (with a
+  blocking read); post-fix it appears on the SECOND and subsequent
+  events for the same mtime (after the async queue populates the cache).
+- `file-tabs.js`'s hash short-circuit (`evt.hash && panel._fileHash &&
+  evt.hash === panel._fileHash`) still fires for rapid-repeated-touch
+  patterns — the first event flows through HTTP refresh which populates
+  `panel._fileHash`, the second event's `evt.hash` arrives from the
+  async cache, comparison fires, no-op.
+- The very first event for a freshly-changed file no longer pays the
+  hash-skip optimization; it falls through to the HTTP-refresh path.
+  This is a strictly safer trade-off (no event-loop block) and `file-
+  tabs.js` documents the absent-hash path as supported
+  (file-watcher.js:122–128).
+
+### Decision divergence from this memo
+
+- **Did NOT add the `AI_OR_DIE_HASH_DEBUG` hot-path guard.** Would be
+  load-bearing only if a future dev re-introduced a sync `readFileSync`
+  inside `_flush()`. The new HOT-07 regression test
+  (`test/file-watcher.test.js: '_flush() never calls fs.readFileSync
+  synchronously'`) covers that explicitly via wrap-and-count, which is
+  catch-via-CI rather than catch-via-runtime — same protection, lower
+  runtime cost.
+- **Did NOT add a follow-up `hash` event.** The per-path cache + late-
+  inclusion design fits the existing `event`-payload contract better.
+  No new event type, no new wire format, no need to update the SSE
+  forwarding code in `server.js:2364–2377`.
+
+### Test surface
+
+- `test/longevity/event-loop/hot-02-filewatcher-hash.test.js` —
+  both assertions flip from failing on main → passing:
+  - `fs.readFileSync` called 0 times from `_flush()` hot path (was 20
+    on a 20-file burst).
+  - `h.max < 50 ms` (was ~600 ms on bunched flushes).
+- `test/file-watcher.test.js` — two new HOT-07 tests:
+  - `first event for a changed path has no hash; second event
+    (post-queue-drain) includes it` — proves the late-inclusion
+    contract end-to-end with a real chokidar drive.
+  - `_flush() never calls fs.readFileSync synchronously, even with
+    includeHash:true` — wrap-and-count guard.
+- Adjacent sweep: `file-watcher`, `fs-watch-cleanup`,
+  `file-watcher-client` — **42 passing / 0 failing**.
+
+### Out-of-scope follow-ups (deliberately deferred)
+
+- Streaming hash via `createReadStream` for files near `HASH_MAX_BYTES`.
+  Not needed — `fs.promises.readFile` on a 5 MB file takes <10 ms on a
+  worker thread and the queue caps concurrency, so memory pressure is
+  bounded.
+- Surfacing hash queue depth / hit-rate via `_collectDiagnostics`.
+  Useful for tuning the queue under sustained soak but not load-bearing.
+- Diagnostic-style drop-rate logging on queue overflow. The dedupe-by-
+  path inside `_enqueueHash` already collapses repeated writes to the
+  same path; an unbounded distinct-path burst would still grow the
+  pending array (no explicit cap). Revisit if SUP-SOAK sees pending
+  array growth in long runs.

--- a/src/utils/file-watcher.js
+++ b/src/utils/file-watcher.js
@@ -75,16 +75,43 @@ function buildIgnoreRegexes(ignoreDirs) {
 }
 
 const HASH_MAX_BYTES = 5 * 1024 * 1024;
+const HASH_DEFAULT_CONCURRENCY = 8;
+const HASH_CACHE_MAX_ENTRIES = 1024;
 
 function normalizePath(p) {
   return process.platform === 'win32' ? p.replace(/\\/g, '/') : p;
 }
 
+/**
+ * Synchronous MD5 hash. Retained for back-compat with any direct callers
+ * (test fixtures, external consumers). DO NOT use from inside the
+ * chokidar-event hot path — `FileWatcher._flush` now delegates to the
+ * bounded async hash queue (`_hashFileAsync` + `_drainHashQueue`) which
+ * keeps the event loop free under bulk-edit storms. See HOT-07 +
+ * docs/audits/hot-02-filewatcher-hash.md.
+ */
 function _hashFileSync(absPath) {
   try {
     const stat = fs.statSync(absPath);
     if (!stat.isFile() || stat.size > HASH_MAX_BYTES) return null;
     const data = fs.readFileSync(absPath);
+    return crypto.createHash('md5').update(data).digest('hex');
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Async MD5 hash via fs.promises — used by `FileWatcher._drainHashQueue`.
+ * Bounded by HASH_MAX_BYTES (same cap as the sync version). Returns null
+ * on any failure (file vanished, permission denied, oversized, etc.) —
+ * callers treat null identically to "no hash available."
+ */
+async function _hashFileAsync(absPath) {
+  try {
+    const stat = await fs.promises.stat(absPath);
+    if (!stat.isFile() || stat.size > HASH_MAX_BYTES) return null;
+    const data = await fs.promises.readFile(absPath);
     return crypto.createHash('md5').update(data).digest('hex');
   } catch (_) {
     return null;
@@ -198,6 +225,37 @@ class FileWatcher extends EventEmitter {
 
     // Recent adds for add+change dedup: Map<path, {timestamp, timer}>.
     this._recentAdds = new Map();
+
+    // ----- HOT-07: async hash queue + per-path hash cache. ------------------
+    //
+    // Async hashing keeps `_flush()` off the synchronous-readFileSync hot
+    // path. The previous design (`_hashFileSync` inline) blocked the event
+    // loop for the duration of a 5 MB read; under a 50-file Claude bulk
+    // edit that compounded into ~1 s of cumulative loop block.
+    //
+    // Flow:
+    //   1. `_flush()` emits the event SYNCHRONOUSLY (no hash on the hot path).
+    //   2. If `_includeHash` is on AND the path's cached hash matches the
+    //      event's mtime, the emitted payload INCLUDES the hash (late-
+    //      inclusion path — preserves `file-tabs.js`'s "did the disk
+    //      content actually change" short-circuit for rapid same-content
+    //      touches).
+    //   3. Otherwise `_flush()` enqueues an async hash so the NEXT event
+    //      for the same path can take the late-inclusion path. The first
+    //      event for a given path post-content-change falls through to the
+    //      HTTP-refresh path (which is what consumers already do when the
+    //      hash field is absent — strictly safe).
+    //
+    // The queue caps in-flight reads at HASH_DEFAULT_CONCURRENCY (8) to
+    // bound the EMFILE risk under a 1000-file burst.
+    this._hashCache = new Map();         // absPath → { hash, mtime }
+    this._hashPending = [];              // queue: [{ absPath, mtime }, ...]
+    this._hashInflight = 0;
+    this._hashConcurrency = typeof opts.hashConcurrency === 'number'
+      ? opts.hashConcurrency : HASH_DEFAULT_CONCURRENCY;
+    // Test affordance: resolves once the queue has drained AND every
+    // in-flight hash has settled. Used by HOT-07 regression test.
+    this._hashIdleWaiters = [];
   }
 
   async start() {
@@ -581,15 +639,10 @@ class FileWatcher extends EventEmitter {
     if (this._closed) return;
 
     let mtime = null;
-    let hash = null;
     if (type !== 'unlink') {
       try {
         const st = stat || fs.statSync(absPath);
         mtime = st.mtimeMs != null ? st.mtimeMs : (st.mtime ? st.mtime.getTime() : null);
-        if (this._includeHash && (type === 'change' || type === 'rename') &&
-            st.isFile && st.isFile() && st.size <= HASH_MAX_BYTES) {
-          hash = _hashFileSync(absPath);
-        }
       } catch (_) { /* file may have been removed in the debounce window */ }
     }
 
@@ -601,10 +654,110 @@ class FileWatcher extends EventEmitter {
       relPath: relPath,
       mtime: mtime,
     };
-    if (hash) payload.hash = hash;
+
+    // HOT-07: hash on the hot path is async-via-queue, never sync.
+    //
+    // Late-inclusion: if we previously hashed this path AND the cached
+    // hash matches the event's mtime, include it on this emit so the
+    // file-tabs.js "did the disk content actually change" short-circuit
+    // fires for rapid same-content touches. Otherwise enqueue an async
+    // hash so the NEXT event for this path can take the late-inclusion
+    // path; the FIRST event after a content change falls through to the
+    // consumer's HTTP-refresh path (strictly safe — `evt.hash`-undefined
+    // is already a recognized non-short-circuit case in file-tabs.js).
+    if (this._includeHash && (type === 'change' || type === 'rename') &&
+        mtime != null) {
+      const cached = this._hashCache.get(absPath);
+      if (cached && cached.mtime === mtime) {
+        payload.hash = cached.hash;
+      } else {
+        this._enqueueHash(absPath, mtime);
+      }
+    }
+
     if (prevPath) payload.prevPath = normalizePath(prevPath);
 
     this.emit('event', payload);
+  }
+
+  /**
+   * Enqueue an async hash for `absPath`. The queue caps in-flight reads
+   * at `_hashConcurrency` to bound EMFILE risk under bursts.
+   *
+   * Dedupe: if the queue already has an entry for this path with the
+   * same mtime, skip the enqueue (we'd compute the same value). If the
+   * queue has an entry with a STALE mtime, replace it (the newer write
+   * supersedes; computing the stale hash would just race the cache).
+   * @private
+   */
+  _enqueueHash(absPath, mtime) {
+    if (this._closed) return;
+    // Replace any stale entry for the same path so the queue always
+    // resolves to the LATEST observed mtime per path.
+    const existingIdx = this._hashPending.findIndex((e) => e.absPath === absPath);
+    if (existingIdx >= 0) {
+      this._hashPending[existingIdx] = { absPath, mtime };
+    } else {
+      this._hashPending.push({ absPath, mtime });
+    }
+    this._drainHashQueue();
+  }
+
+  /**
+   * Pull from `_hashPending` while `_hashInflight < _hashConcurrency`,
+   * compute hashes off the main thread (well, off the synchronous code
+   * path — `fs.promises.readFile` still runs on libuv's thread pool but
+   * that's the whole point), and populate `_hashCache` on success.
+   * @private
+   */
+  _drainHashQueue() {
+    while (!this._closed &&
+           this._hashInflight < this._hashConcurrency &&
+           this._hashPending.length > 0) {
+      const { absPath, mtime } = this._hashPending.shift();
+      this._hashInflight++;
+      _hashFileAsync(absPath).then((hash) => {
+        if (hash && !this._closed) {
+          this._hashCache.set(absPath, { hash, mtime });
+          // Bound the cache against unbounded watched-path counts. LRU
+          // approximation via insertion-order eviction (delete-oldest-on-
+          // overflow); good enough for a side-effect cache that doesn't
+          // need strict LRU semantics.
+          while (this._hashCache.size > HASH_CACHE_MAX_ENTRIES) {
+            const oldest = this._hashCache.keys().next().value;
+            this._hashCache.delete(oldest);
+          }
+        }
+      }).catch(() => { /* swallow — null-hash treated as absent */ })
+        .finally(() => {
+          this._hashInflight--;
+          if (!this._closed) this._drainHashQueue();
+          if (this._hashInflight === 0 && this._hashPending.length === 0) {
+            this._fireHashIdleWaiters();
+          }
+        });
+    }
+  }
+
+  /**
+   * Test helper — returns a Promise that resolves once the async hash
+   * queue is fully drained (no pending entries, no in-flight reads).
+   * Used by HOT-07 regression tests to assert post-burst final state.
+   */
+  hashQueueIdle() {
+    if (this._hashInflight === 0 && this._hashPending.length === 0) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => { this._hashIdleWaiters.push(resolve); });
+  }
+
+  _fireHashIdleWaiters() {
+    if (this._hashIdleWaiters.length === 0) return;
+    const waiters = this._hashIdleWaiters.slice();
+    this._hashIdleWaiters.length = 0;
+    for (const w of waiters) {
+      try { w(); } catch (_) {}
+    }
   }
 
   async close() {
@@ -620,6 +773,11 @@ class FileWatcher extends EventEmitter {
     this._dirSubscriptions.clear();
     this._dirRefcount.clear();
     this._watchedDirs.clear();
+    // HOT-07: drop the pending hash queue + cache and unblock any
+    // hashQueueIdle() waiters so test cleanup doesn't hang.
+    this._hashPending.length = 0;
+    this._hashCache.clear();
+    this._fireHashIdleWaiters();
     if (this._watcher) {
       try { await this._watcher.close(); } catch (_) {}
       this._watcher = null;

--- a/test/file-watcher.test.js
+++ b/test/file-watcher.test.js
@@ -306,3 +306,94 @@ describe('FileWatcher recursive backward compat (no depth)', function () {
     }
   });
 });
+
+describe('FileWatcher async hash queue (HOT-07)', function () {
+  this.timeout(15000);
+
+  it('first event for a changed path has no hash; second event (post-queue-drain) includes it', async function () {
+    const root = mkdtemp();
+    const file = path.join(root, 'a.js');
+    fs.writeFileSync(file, 'first');
+    // Realpath the file path so it matches what chokidar emits + what
+    // _hashCache stores (canonicalization via realpathSync, e.g.
+    // /var → /private/var on macOS).
+    const canonicalFile = fs.realpathSync(file);
+    // includeHash:true explicitly — exercises the legacy-default
+    // footgun-prone code path the fix structurally repairs.
+    const w = newWatcher(root, { includeHash: true });
+    try {
+      await w.start();
+      await w.subscribe(file);
+
+      // Trigger a first change → first event arrives WITHOUT hash (cache
+      // is cold); async hash kicks off in the background.
+      const ev1 = waitForEvent(w, (evt) => evt.type === 'change' && evt.path.endsWith('a.js'), 5000);
+      await new Promise((r) => setTimeout(r, 60));
+      fs.writeFileSync(file, 'second');
+      const evt1 = await ev1;
+      assert.strictEqual(evt1.hash, undefined,
+        'first event after a content change should have no hash on the hot path');
+
+      // Wait for the async hash queue to drain. Cache is now populated
+      // with the hash of 'second'.
+      await w.hashQueueIdle();
+      assert.strictEqual(w._hashCache.size, 1, 'hash cache should hold one entry');
+
+      const cached = w._hashCache.get(canonicalFile);
+      assert.ok(cached && /^[0-9a-f]{32}$/.test(cached.hash),
+        `cached entry shape valid; got ${JSON.stringify(cached)} for ${canonicalFile}`);
+
+      // Drive a synthetic same-mtime _flush to prove late-inclusion:
+      // simulate chokidar firing two events for the SAME mtime (the
+      // metadata-only-write pattern). The second emit should carry the
+      // hash from the cache.
+      const ev2 = waitForEvent(w, (evt) => evt.type === 'change' && evt.hash, 2000);
+      // Synthesize a stat object with the SAME mtime as the cached entry.
+      // Use the canonical path so the _hashCache.get lookup hits.
+      w._flush('change', canonicalFile, {
+        ino: 1, size: 6, mtimeMs: cached.mtime, isFile: () => true,
+      }, null);
+      const evt2 = await ev2;
+      assert.strictEqual(evt2.hash, cached.hash,
+        'second emit with matching mtime should include cached hash (late-inclusion path)');
+    } finally {
+      await w.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('_flush() never calls fs.readFileSync synchronously, even with includeHash:true', function () {
+    const root = mkdtemp();
+    const file = path.join(root, 'b.js');
+    fs.writeFileSync(file, Buffer.alloc(1024));
+    const w = new FileWatcher({ watchRoot: root, includeHash: true });
+    try {
+      const origReadFileSync = fs.readFileSync;
+      let syncReads = 0;
+      fs.readFileSync = function patched(p, ...rest) {
+        if (typeof p === 'string' && p === file) syncReads++;
+        return origReadFileSync.call(this, p, ...rest);
+      };
+      try {
+        // Drive _flush directly with a fabricated stat that takes the
+        // hash-eligible branch (isFile + size ≤ HASH_MAX_BYTES). On the
+        // pre-HOT-07 path this would call _hashFileSync → fs.readFileSync.
+        w._flush('change', file, {
+          ino: 1, size: 1024, mtimeMs: Date.now(), isFile: () => true,
+        }, null);
+        // The async queue is drained off-thread; assertions on the SYNC
+        // path are independent of when it completes.
+        assert.strictEqual(syncReads, 0,
+          'fs.readFileSync called synchronously from _flush() — HOT-07 fix not in place');
+      } finally {
+        fs.readFileSync = origReadFileSync;
+      }
+    } finally {
+      // Don't await close() since we never started the watcher; just
+      // clean up the hash queue + temp dir.
+      w._closed = true;
+      w._fireHashIdleWaiters();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the synchronous `fs.readFileSync` gap on `FileWatcher._flush()` documented in `docs/audits/hot-02-filewatcher-hash.md`. Pre-fix, sync MD5 on the chokidar event hot path blocked the event loop for the duration of each disk read; under a 20-file Claude-style bulk edit that compounded into ~600 ms of cumulative block.

- New `_hashFileAsync` using `fs.promises.readFile` + `crypto`.
- New bounded async hash queue (`_hashPending` / `_hashInflight`, concurrency 8) caps EMFILE risk under bursts.
- New per-path `_hashCache` (LRU 1024) enables late-inclusion: the second+ event for the same mtime carries the cached hash on the emit, preserving `file-tabs.js`'s content-unchanged short-circuit for rapid same-mtime re-touches.
- `_flush()` emits the event SYNC without hash on the hot path. First event for a freshly-changed file has no hash; consumer falls through to the HTTP-refresh path (already a documented case in `file-tabs.js`).
- `close()` drops queue + cache and resolves outstanding `hashQueueIdle()` waiters.

### Diverged from memo on two points

1. **Did NOT add `AI_OR_DIE_HASH_DEBUG` runtime guard** against sync readFileSync re-introduction. Caught at CI time via the new `test/file-watcher.test.js: '_flush() never calls fs.readFileSync synchronously, even with includeHash:true'` wrap-and-count test instead.
2. **Did NOT add a follow-up `hash` event.** The per-path cache + late-inclusion design fits the existing `event` payload contract better; no new event type, no SSE wire change.

ADR-0017 §Event payload updated to reflect async hash timing.

## Test plan

- [x] `test/longevity/event-loop/hot-02-filewatcher-hash.test.js`: both assertions flip from failing → passing
  - `fs.readFileSync` called 0 times from `_flush()` (was 20 on a 20-file burst).
  - `h.max < 50 ms` (was ~600 ms on bunched flushes).
- [x] `test/file-watcher.test.js`: 2 new HOT-07 tests covering late-inclusion contract + wrap-and-count guard.
- [x] Adjacent sweep (`file-watcher`, `fs-watch-cleanup`, `file-watcher-client`): **42 passing / 0 failing**.
- [ ] SUP-SOAK: run `--gates=event_loop,handles --workloads=watcher-flood` against this PR.

## Affected gates / workloads

Gates I affect: **event_loop, handles**
Workloads exercised: **watcher-flood**

Linked memo: `docs/audits/hot-02-filewatcher-hash.md`
Linked ADR: `docs/adrs/0017-fs-watcher-push-channel.md` (§Event payload)
Linked task: HOT-07 (TaskList #23)

## Note on sequencing

This branch is currently off `e2fbaf8` (v0.1.66), pre-HOT-06. Once HOT-06 (#111) merges, I'll rebase onto the new main tip. CHANGELOG `[Unreleased]` will have both HOT-06 and HOT-07 entries after the rebase.