### PR TITLE
feat: iOS PWA safe-area (Dynamic Island + all overlays), arrow tooltips, general file upload

### DIFF
--- a/docs/history/general-file-upload-attach-and-paste.md
+++ b/docs/history/general-file-upload-attach-and-paste.md
@@ -1,0 +1,53 @@
+# General file upload via attach button + paste (not just drag-drop)
+
+## Problem
+General (non-image) file upload to the CLI agent only worked via **drag-and-drop**.
+The other two attachment surfaces were image-only:
+- The **attach button** (`#attachImageBtn`) and context-menu **"Attach Image…"** opened an `image/*`-filtered picker.
+- **Paste** (OS paste event + context-menu "Paste Image") only detected `image/*` in the clipboard.
+
+So a user could *drop* a PDF and have the agent read it via the injected `@<path>`,
+but the same file rejected from the attach button and paste — an inconsistent UX.
+
+## Fix
+Routed every non-drop surface through the **existing** generic pipeline instead of
+duplicating it:
+
+- `generic-drop-handler.js` now surfaces its internal drop dispatcher as a public
+  **`dispatchFiles(fileList)`** on the handler return object, and exports a
+  **`triggerFilePicker(onFiles, { multiple })`** (a `<input type="file">` with no
+  `accept` filter).
+- `app.js` gained **`_attachFiles(files)`**, which partitions client-side: image
+  files take the **unchanged** preview → `image_upload` path; everything else goes
+  to `dispatchFiles` (upload to `.claude-attachments/` + `@<path>` inject). The
+  attach button and context-menu "Attach File…" open the generic picker → `_attachFiles`.
+- `image-handler.js`'s paste listener keeps image precedence; *after* the image
+  branch declines, non-image clipboard files surface via a new
+  `options.onFilesPaste` → `_attachFiles`. New `collectNonImageFiles` helper.
+- UI relabeled "Attach Image" → **"Attach File"**. The async-clipboard "Paste Image"
+  context item stays image-only (the Clipboard API can't retrieve arbitrary files;
+  the OS Ctrl+V path is the non-image route).
+
+## Hard constraint honored: no image regression
+Image upload, paste, and the preview modal are byte-identical — image code paths
+were not modified; all non-image handling is a strictly additive fall-through.
+
+## Windows-first hardening (folded in)
+Because this productizes arbitrary-file upload, `sanitizeFileName`
+(`src/utils/file-utils.js`) — the one server chokepoint all uploads pass through —
+was hardened for the primary deployment target (Windows 11): strip NTFS-forbidden
+`< > : " | ? *` (the `:` neutralizes Alternate Data Streams), trim trailing
+dot/space, and prefix reserved device names (`CON`/`PRN`/`AUX`/`NUL`/`COM1-9`/`LPT1-9`)
+with `_`.
+
+## Deferred (separate follow-up)
+Cross-CLI `@<path>` injection: the reference is hardcoded Claude-native `@`-syntax;
+Gemini/Codex/terminal sessions receive it verbatim and it is unverified whether they
+interpret it. The bridge already tracks `session.agent`, so a future change can
+branch the injection form.
+
+## Lesson
+When a feature has multiple entry surfaces (drop / button / paste), factor the
+core pipeline into one reusable entry point and have every surface call it — three
+hand-written copies drift. The image flow stayed safe precisely because the new
+non-image handling was layered *after* it, never inside it.

--- a/docs/history/pwa-safe-area-overlays.md
+++ b/docs/history/pwa-safe-area-overlays.md
@@ -1,0 +1,56 @@
+# PWA safe-area: expanding the Dynamic Island fix to all fixed overlays
+
+## Problem
+The initial Dynamic Island fix padded only **3 in-flow surfaces** (`.session-tabs-bar`,
+`.file-browser-header`, `.mobile-menu`). Every **out-of-flow** overlay
+(`position:fixed`/`absolute`) was anchored to physical screen edges with no
+safe-area offset, so in an installed iOS PWA they collided with the Dynamic
+Island (top) and home indicator (bottom). Reported surfaces: the **settings
+popup** (title + close button under the island), toasts, banners, the extra-keys
+bar, and other full-screen modals. Pixel-geometry measurement on iPhone 16
+(393×852) confirmed 5 colliding surfaces.
+
+Note: this app is **vanilla JS, not React** — and it wouldn't matter if it were.
+PWA safe-area handling is pure CSS/viewport behavior (`env(safe-area-inset-*)`),
+not framework magic. Layout only reclaims the island/home-indicator space where
+the CSS consumes the insets; only 3 selectors did, so everything else ignored the
+taller standalone viewport.
+
+## Fix
+Systemic, in one place — `src/public/components/safe-area.css` (loaded last),
+all rules gated behind `html.pwa-standalone`:
+- **Modal overlays** (settings/session/plan/folder-browser/shortcuts/image-preview):
+  pad the overlay so the flex-centered `.modal-content` insets out of both zones;
+  clamp `.modal-content` `max-height` to `calc(100dvh - sa-top - sa-bottom - 40px)`.
+- **Top-anchored** toast/banner/notif-prompt/find-panel: offset by `+var(--sa-top)`.
+- **Bottom-anchored** extra-keys bar / input overlay: lift by `var(--sa-bottom)`.
+- Tokens `--sa-top`/`--sa-bottom` added to `tokens.css` (var → env → 0 fallback);
+  six pre-existing `env(safe-area-inset-bottom)` bottom-bar sites converted to the
+  token (behavior-preserving since the token falls back to `env()`).
+- `app.js` polyfill extended to populate `--safe-area-inset-bottom` too, and
+  hardened (from review): **self-gates to standalone** (so the `orientationchange`
+  path can't push fake insets into a non-PWA iOS tab) and only applies the
+  fallback on **tall notch-class** devices (aspect > 2), so iPhone SE / iPad don't
+  gain a phantom inset.
+
+## Self-test harness
+`scripts/pwa-safearea-validate.js` — a Playwright harness that drives a real dev
+server at **iPhone 16 (393×852)** and **desktop PWA (1280×800)**, forces
+`html.pwa-standalone` + the `--safe-area-inset-*` variables, reveals every fixed
+surface (modals, toast, banner, extra-keys bar), draws island/home-indicator
+guides, and asserts each surface's *effective content edges* (rect ± padding)
+clear the safe zones — exit non-zero on any collision. Before: 5 collisions on
+iPhone 16. After: 18/18 surfaces clear on both viewports.
+
+Run: `node scripts/pwa-safearea-validate.js` (self-starts a server on :11611).
+
+## Caveat
+Headless Chromium reports `env(safe-area-inset-*) === 0`, so the harness forces
+the CSS *variables* directly (which is exactly what the app's polyfill sets on
+device). It validates CSS consumption, not the polyfill's own device detection —
+that logic is covered by review only.
+
+## Lesson
+A safe-area fix must reach every out-of-flow surface, not just the visible main
+chrome. Centralize the inset rules + tokens so new overlays inherit the behavior,
+and gate everything behind the standalone class so non-PWA layouts never move.

--- a/docs/specs/file-browser.md
+++ b/docs/specs/file-browser.md
@@ -1083,7 +1083,7 @@ When uploading a file that already exists:
 
 ## Generic file drop
 
-A page-wide drop target that accepts **any** file MIME type (not just images). Cross-link with [`image-paste.md`](image-paste.md) — the image flow is unchanged; this section adds the generic flow that runs alongside it.
+A page-wide attachment pipeline that accepts **any** file MIME type (not just images), reachable from **four surfaces**: drag-drop, the attach button, the context-menu "Attach File…" item, and OS paste of files. Cross-link with [`image-paste.md`](image-paste.md) — the image flow is unchanged; this section adds the generic flow that runs alongside it.
 
 ### Dispatcher
 
@@ -1096,11 +1096,20 @@ A page-wide drop target that accepts **any** file MIME type (not just images). C
 
 `image-handler.js` is **not renamed** — the image flow just shipped, the rename buys nothing functional, and adversarial review (codex) flagged the rename as unjustified blast radius. The new code lives in a sibling module `generic-drop-handler.js` that exports an `attachGenericDropHandler` and an internal `_isImageMime(file)` helper used by the dispatcher.
 
+### Non-drop surfaces (attach button + paste)
+
+The same partition→upload→inject pipeline is reused — never duplicated — by the non-drop surfaces:
+
+- `attachGenericDropHandler(...)` returns a **`dispatchFiles(fileList)`** method (the internal drop dispatcher, surfaced) so any caller can feed it files and get identical routing (image → preview modal, non-image → upload + `@<path>`, same `MAX_FILES_PER_DROP` cap).
+- The module also exports **`triggerFilePicker(onFiles, { multiple })`** — a hidden `<input type="file">` with **no `accept` filter** (any file type).
+- `app.js` `_attachFiles(files)` partitions client-side: image files (via `imageHandler.isAcceptedImageType`) take the **existing, unchanged** image preview → `image_upload` path; everything else goes to `dispatchFiles`. The **attach button** and **context-menu "Attach File…"** open `triggerFilePicker` → `_attachFiles`.
+- **Paste:** `attachImageHandler`'s paste listener keeps image precedence; *after* the image branch declines, non-image files in `clipboardData` (e.g. a file copied from the OS file manager) are surfaced via `options.onFilesPaste(files)` → `_attachFiles`. Plain text paste is untouched. (The async-clipboard context-menu "Paste Image" stays image-only — the Clipboard API cannot retrieve arbitrary files; the OS Ctrl+V path above is the non-image route.)
+
 ### Generic upload pipeline
 
 For each non-image file dropped:
 
-1. Upload to `path.join(session.workingDir, '.claude-attachments', '<uuid>-<sanitized-basename>')` via the existing `POST /api/files/upload` (which already enforces base64 JSON, 10 MB cap, blocked-extension list, sanitization, and `validatePath()`).
+1. Upload to `path.join(session.workingDir, '.claude-attachments', '<uuid>-<sanitized-basename>')` via the existing `POST /api/files/upload` (which already enforces base64 JSON, 10 MB cap, blocked-extension list, sanitization, and `validatePath()`). The basename passes through `sanitizeFileName` (`src/utils/file-utils.js`), which is **Windows-hardened** (primary deployment target): it strips path separators, control chars, and the NTFS-forbidden set `< > : " | ? *` (the `:` also neutralizes Alternate Data Streams), trims trailing dot/space, and prefixes reserved device names (`CON`, `PRN`, `AUX`, `NUL`, `COM1-9`, `LPT1-9`) with `_`.
 2. On 201, inject **`@<absolute-path>`** into the terminal as bracketed paste — Claude's native file reference syntax. Avoids shell-quoting hazards entirely. Codex/Gemini bridges accept the same `@<path>` form (or can branch on `bridgeType` for variant syntaxes if those CLIs diverge in future).
 3. On per-file failure, surface a toast with the basename + the server's error code (size / blocked / 4xx).
 

--- a/docs/specs/image-paste.md
+++ b/docs/specs/image-paste.md
@@ -38,9 +38,9 @@ A standalone module that attaches to the terminal container and intercepts image
 
 | Source | Trigger | Notes |
 |--------|---------|-------|
-| Clipboard paste | `paste` event on `document` | Filters for `image/*` MIME types from `clipboardData.items` |
+| Clipboard paste | `paste` event on `document` | Filters for `image/*` MIME types from `clipboardData.items`. Non-image files in the clipboard fall through to the [Generic file drop](file-browser.md#generic-file-drop) pipeline via `options.onFilesPaste`. |
 | Drag and drop | `drop` event on terminal container | Filters for `image/*` files from `dataTransfer.files`. The shared `drop` dispatcher routes non-image MIMEs to [Generic file drop](file-browser.md#generic-file-drop) instead. |
-| File picker | Click on "Attach Image" button or context menu item | Opens a hidden `<input type="file" accept="image/*">` |
+| File picker | Click on "Attach File" button or context-menu item | Opens a hidden `<input type="file">` (no `accept` filter — any file type). Picked images keep this preview-modal flow; non-images route to [Generic file drop](file-browser.md#generic-file-drop). |
 
 #### Preview Modal
 

--- a/scripts/pwa-safearea-validate.js
+++ b/scripts/pwa-safearea-validate.js
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+// scripts/pwa-safearea-validate.js
+//
+// Standalone-PWA safe-area validation harness for iPhone 16 + desktop PWA.
+//
+// Verifies that fixed/absolute overlays (modals, toasts, banners, bottom bars)
+// clear the iOS Dynamic-Island top inset and the home-indicator bottom inset
+// when the app runs as an installed PWA. Drives a REAL dev server with
+// Playwright, forces the standalone state the app reaches on device
+// (`html.pwa-standalone` + the `--safe-area-inset-*` CSS variables the app's
+// own polyfill sets), then measures each surface's geometry and screenshots it.
+//
+// Why a forced variable and not real env(): headless Chromium always reports
+// env(safe-area-inset-*) === 0, so it cannot reproduce a notch. The app's
+// polyfill exposes the inset as a CSS *variable* (--safe-area-inset-top/bottom)
+// precisely so it works around the WebKit `env()===0` bug — and a variable we
+// CAN force here. Any surface that still reads raw env() shows 0 (no movement),
+// which is itself the failing signal.
+//
+// Usage:
+//   node scripts/pwa-safearea-validate.js            # self-starts the server
+//   BASE=http://127.0.0.1:11611 node scripts/...     # use a server you started
+//   KEEP_SHOTS=1 ...                                 # keep screenshots on pass
+//
+// Exit code 0 = all surfaces clear the safe areas; 1 = at least one collision.
+
+const path = require('path');
+const fs = require('fs');
+const { spawn } = require('child_process');
+const http = require('http');
+
+const REPO = path.resolve(__dirname, '..');
+const { chromium, devices } = require(path.join(REPO, 'node_modules/@playwright/test'));
+
+const PORT = Number(process.env.PORT || 11611);
+const BASE = process.env.BASE || `http://127.0.0.1:${PORT}`;
+const SELF_SERVE = !process.env.BASE;
+const OUT = process.env.OUT || '/tmp/pwa-safearea-shots';
+fs.mkdirSync(OUT, { recursive: true });
+
+// iPhone 16 = 393x852 logical, Dynamic Island (top inset 59), home indicator 34.
+// Desktop PWA = standalone window, NO notch/home-indicator → insets 0 (the fix
+// must NOT push content down here; this viewport is the no-regression guard).
+const VIEWPORTS = [
+  { name: 'iphone16-393x852', width: 393, height: 852, top: 59, bottom: 34, mobile: true },
+  { name: 'desktop-pwa-1280x800', width: 1280, height: 800, top: 0, bottom: 0, mobile: false },
+];
+
+// Each surface: how to reveal it + how it is anchored. `anchor`:
+//   'top'    → rect.top must be >= safeTop
+//   'bottom' → rect.bottom must be <= height - safeBottom
+//   'modal'  → measure .modal-content; top >= safeTop AND bottom <= h - safeBottom
+const SURFACES = [
+  { sel: '.session-tabs-bar', anchor: 'top', reveal: null, label: 'tab bar (already fixed)' },
+  { sel: '#settingsModal .modal-content', anchor: 'modal', reveal: { id: 'settingsModal' }, label: 'settings modal' },
+  { sel: '#planModal .modal-content', anchor: 'modal', reveal: { id: 'planModal' }, label: 'plan modal' },
+  { sel: '#shortcutsModal .modal-content', anchor: 'modal', reveal: { id: 'shortcutsModal' }, label: 'shortcuts modal' },
+  { sel: '#newSessionModal .modal-content', anchor: 'modal', reveal: { id: 'newSessionModal' }, label: 'new-session modal' },
+  { sel: '#folderBrowserModal .modal-content', anchor: 'modal', reveal: { id: 'folderBrowserModal' }, label: 'folder-browser modal' },
+  { sel: '.toast-container', anchor: 'top', reveal: { toast: true }, label: 'toast container' },
+  { sel: '.__test-banner', anchor: 'top', reveal: { banner: true }, label: 'top banner' },
+  { sel: '.extra-keys-bar', anchor: 'bottom', reveal: { extraKeys: true }, label: 'extra-keys bar' },
+];
+
+function waitForServer(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    (function ping() {
+      const req = http.get(url, (res) => { res.destroy(); resolve(); });
+      req.on('error', () => {
+        if (Date.now() > deadline) return reject(new Error('server did not start'));
+        setTimeout(ping, 300);
+      });
+    })();
+  });
+}
+
+function forceStandalone(top, bottom) {
+  return (args) => {
+    const r = document.documentElement;
+    r.classList.add('pwa-standalone');
+    r.style.setProperty('--safe-area-inset-top', args.top + 'px');
+    r.style.setProperty('--safe-area-inset-bottom', args.bottom + 'px');
+    // Translucent guides so screenshots make collisions obvious.
+    const guide = (id, css) => {
+      let d = document.getElementById(id);
+      if (!d) { d = document.createElement('div'); d.id = id; document.body.appendChild(d); }
+      d.style.cssText = css;
+    };
+    if (args.top) {
+      guide('__island', `position:fixed;top:0;left:0;right:0;height:${args.top}px;`
+        + 'background:rgba(255,0,0,.30);z-index:2147483647;pointer-events:none;border-bottom:1px solid red;');
+    }
+    if (args.bottom) {
+      guide('__home', `position:fixed;bottom:0;left:0;right:0;height:${args.bottom}px;`
+        + 'background:rgba(0,80,255,.30);z-index:2147483647;pointer-events:none;border-top:1px solid blue;');
+    }
+  };
+}
+
+async function reveal(page, r) {
+  if (!r) return;
+  await page.evaluate((rev) => {
+    if (rev.id) {
+      const m = document.getElementById(rev.id);
+      if (m) m.classList.add('active');
+    }
+    if (rev.toast) {
+      let c = document.querySelector('.toast-container');
+      if (!c) { c = document.createElement('div'); c.className = 'toast-container'; document.body.appendChild(c); }
+      c.innerHTML = '<div class="toast toast--info" style="background:#222;color:#fff;padding:10px 14px;border-radius:8px;border:1px solid #555;">Toast — clears island?</div>';
+    }
+    if (rev.banner) {
+      let b = document.querySelector('.__test-banner');
+      if (!b) {
+        b = document.createElement('div');
+        b.className = 'banner-base __test-banner';
+        b.textContent = 'Top banner';
+        document.body.appendChild(b);
+      }
+      // .banner-base hides via translateY(-100%); .visible slides it in.
+      b.classList.add('visible');
+    }
+    if (rev.extraKeys) {
+      let e = document.querySelector('.extra-keys-bar');
+      if (!e) { e = document.createElement('div'); e.className = 'extra-keys-bar'; e.style.minHeight = '40px'; document.body.appendChild(e); }
+      e.classList.add('visible');
+    }
+  }, r);
+  await page.waitForTimeout(150);
+}
+
+async function hide(page, r) {
+  if (!r || !r.id) return;
+  await page.evaluate((id) => { const m = document.getElementById(id); if (m) m.classList.remove('active'); }, r.id);
+}
+
+async function run() {
+  let server = null;
+  if (SELF_SERVE) {
+    console.log(`Starting dev server on :${PORT} …`);
+    server = spawn('node', [path.join(REPO, 'bin/ai-or-die.js'), '--port', String(PORT), '--disable-auth'], {
+      cwd: REPO, stdio: ['ignore', 'ignore', 'inherit'],
+    });
+    await waitForServer(BASE, 30000);
+  }
+
+  const browser = await chromium.launch();
+  const failures = [];
+  let totalChecked = 0;
+
+  try {
+    for (const vp of VIEWPORTS) {
+      console.log(`\n=== ${vp.name}  (island top=${vp.top}, home bottom=${vp.bottom}) ===`);
+      const ctx = await browser.newContext({
+        ...(vp.mobile ? devices['iPhone 13'] : {}),
+        viewport: { width: vp.width, height: vp.height },
+        colorScheme: 'dark',
+      });
+      const page = await ctx.newPage();
+      page.on('pageerror', (e) => console.log('  [pageerror]', e.message));
+      await page.goto(BASE, { waitUntil: 'domcontentloaded' });
+      await page.waitForTimeout(1500);
+      await page.evaluate(forceStandalone(vp.top, vp.bottom), { top: vp.top, bottom: vp.bottom });
+      await page.waitForTimeout(300);
+      await page.screenshot({ path: `${OUT}/${vp.name}-00-main.png` });
+
+      for (const s of SURFACES) {
+        await reveal(page, s.reveal);
+        const measureSel = s.anchor === 'modal' ? s.sel : s.sel;
+        const res = await page.evaluate((sel) => {
+          const el = document.querySelector(sel);
+          if (!el) return { found: false };
+          const cs = getComputedStyle(el);
+          const visible = cs.display !== 'none' && cs.visibility !== 'hidden' && el.getBoundingClientRect().height > 0;
+          const r = el.getBoundingClientRect();
+          // Effective CONTENT edges: a surface may clear the safe area by being
+          // pushed down (offset) OR by internal padding (the tab bar fills from
+          // y=0 but pads its content down). Account for padding so both fix
+          // styles validate; padding only ever makes the check stricter, so it
+          // never passes a real collision.
+          return {
+            found: true, visible, position: cs.position,
+            top: Math.round(r.top), bottom: Math.round(r.bottom), height: Math.round(r.height),
+            padTop: Math.round(parseFloat(cs.paddingTop) || 0),
+            padBottom: Math.round(parseFloat(cs.paddingBottom) || 0),
+          };
+        }, measureSel);
+
+        if (!res.found || !res.visible) {
+          console.log(`  – ${s.label}: not visible (skipped)`);
+          await hide(page, s.reveal);
+          continue;
+        }
+        await page.screenshot({ path: `${OUT}/${vp.name}-${s.label.replace(/\W+/g, '_')}.png` });
+        totalChecked++;
+
+        const safeTop = vp.top, safeBottom = vp.height - vp.bottom;
+        const effTop = res.top + res.padTop;
+        const effBottom = res.bottom - res.padBottom;
+        let bad = null;
+        if ((s.anchor === 'top' || s.anchor === 'modal') && effTop < safeTop) {
+          bad = `content top=${effTop} < island ${safeTop}`;
+        }
+        if ((s.anchor === 'bottom' || s.anchor === 'modal') && effBottom > safeBottom) {
+          bad = (bad ? bad + '; ' : '') + `content bottom=${effBottom} > ${safeBottom}`;
+        }
+        if (bad) {
+          console.log(`  ✗ ${s.label}: COLLIDE (${bad})`);
+          failures.push(`[${vp.name}] ${s.label}: ${bad}`);
+        } else {
+          console.log(`  ✓ ${s.label}: clear (top=${effTop} bottom=${effBottom})`);
+        }
+        await hide(page, s.reveal);
+      }
+      await ctx.close();
+    }
+  } finally {
+    await browser.close();
+    if (server) server.kill('SIGTERM');
+  }
+
+  console.log(`\n${'─'.repeat(60)}`);
+  if (failures.length) {
+    console.log(`FAIL — ${failures.length}/${totalChecked} surface(s) collide:`);
+    failures.forEach((f) => console.log('  • ' + f));
+    console.log(`Screenshots: ${OUT}`);
+    process.exit(1);
+  }
+  console.log(`PASS — all ${totalChecked} checked surfaces clear the safe areas.`);
+  console.log(`Screenshots: ${OUT}`);
+  if (!process.env.KEEP_SHOTS) console.log('(set KEEP_SHOTS=1 to always keep screenshots)');
+}
+
+run().catch((e) => { console.error(e); process.exit(2); });

--- a/scripts/pwa-safearea-validate.js
+++ b/scripts/pwa-safearea-validate.js
@@ -57,7 +57,10 @@ const SURFACES = [
   { sel: '#planModal .modal-content', anchor: 'modal', reveal: { id: 'planModal' }, label: 'plan modal' },
   { sel: '#shortcutsModal .modal-content', anchor: 'modal', reveal: { id: 'shortcutsModal' }, label: 'shortcuts modal' },
   { sel: '#newSessionModal .modal-content', anchor: 'modal', reveal: { id: 'newSessionModal' }, label: 'new-session modal' },
+  { sel: '#mobileSessionsModal .modal-content', anchor: 'modal', reveal: { id: 'mobileSessionsModal' }, label: 'mobile-sessions modal' },
   { sel: '#folderBrowserModal .modal-content', anchor: 'modal', reveal: { id: 'folderBrowserModal' }, label: 'folder-browser modal' },
+  { sel: '.file-browser-panel', anchor: 'bottom', reveal: { panel: true }, label: 'file-browser panel' },
+  { sel: '.terminal-overlay .overlay-content', anchor: 'modal', reveal: { overlay: true }, label: 'terminal overlay' },
   { sel: '.toast-container', anchor: 'top', reveal: { toast: true }, label: 'toast container' },
   { sel: '.__test-banner', anchor: 'top', reveal: { banner: true }, label: 'top banner' },
   { sel: '.extra-keys-bar', anchor: 'bottom', reveal: { extraKeys: true }, label: 'extra-keys bar' },
@@ -126,6 +129,24 @@ async function reveal(page, r) {
       let e = document.querySelector('.extra-keys-bar');
       if (!e) { e = document.createElement('div'); e.className = 'extra-keys-bar'; e.style.minHeight = '40px'; document.body.appendChild(e); }
       e.classList.add('visible');
+    }
+    if (rev.panel) {
+      const p = document.querySelector('.file-browser-panel');
+      if (p) {
+        p.classList.add('open', 'visible', 'active');
+        p.style.transform = 'none';
+        p.style.display = 'flex';
+      }
+    }
+    if (rev.overlay) {
+      let o = document.querySelector('.terminal-overlay');
+      if (!o) {
+        o = document.createElement('div');
+        o.className = 'terminal-overlay';
+        o.innerHTML = '<div class="overlay-content"><h2>Reconnecting…</h2><p>Connection lost — attempting to restore your session.</p></div>';
+        document.body.appendChild(o);
+      }
+      o.style.display = 'flex';
     }
   }, r);
   await page.waitForTimeout(150);

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -692,7 +692,12 @@ class ClaudeCodeWebInterface {
                                 caption: imageData.caption || ''
                             });
                         }
-                    }
+                    },
+                    // Non-image files pasted from a file manager (clipboardData
+                    // carries File objects) — route through the generic pipeline.
+                    // Fires only AFTER the image branch declines, so image paste
+                    // precedence is unchanged.
+                    onFilesPaste: (files) => this._attachFiles(files)
                 }
             );
         }
@@ -1093,9 +1098,20 @@ class ClaudeCodeWebInterface {
             }, 3000);
         };
 
-        // Attach Image button
+        // Attach File button (id is historical: attachImageBtn). Opens a picker
+        // for ANY file type — images go through the preview flow, other files
+        // upload to .claude-attachments/ and inject `@<path>`.
         const attachBtn = document.getElementById('attachImageBtn');
-        if (attachBtn && window.imageHandler) {
+        if (attachBtn && window.genericDropHandler
+                && typeof window.genericDropHandler.triggerFilePicker === 'function') {
+            attachBtn.addEventListener('click', () => {
+                window.genericDropHandler.triggerFilePicker(
+                    (files) => this._attachFiles(files),
+                    { multiple: true }
+                );
+            });
+        } else if (attachBtn && window.imageHandler) {
+            // Fallback: generic handler unavailable — keep the legacy image-only picker.
             attachBtn.addEventListener('click', () => {
                 window.imageHandler.triggerFilePicker((imageData) => {
                     this._pendingImageCaption = imageData.caption;
@@ -3421,7 +3437,7 @@ class ClaudeCodeWebInterface {
                             }
                         } else {
                             if (activeTerminal) {
-                                activeTerminal.write('\r\n\x1b[33mImage paste requires HTTPS. Use Attach Image instead.\x1b[0m\r\n');
+                                activeTerminal.write('\r\n\x1b[33mImage paste requires HTTPS. Use Attach File instead.\x1b[0m\r\n');
                             }
                         }
                     } catch (err) {
@@ -3430,8 +3446,15 @@ class ClaudeCodeWebInterface {
                     break;
                 }
                 case 'attachImage': {
-                    const attachSocket = activeSocket;
-                    if (window.imageHandler) {
+                    // Generalized to any file type (action id is historical).
+                    if (window.genericDropHandler
+                            && typeof window.genericDropHandler.triggerFilePicker === 'function') {
+                        window.genericDropHandler.triggerFilePicker(
+                            (files) => this._attachFiles(files),
+                            { multiple: true }
+                        );
+                    } else if (window.imageHandler) {
+                        const attachSocket = activeSocket;
                         window.imageHandler.triggerFilePicker((imageData) => {
                             this._pendingImageCaption = imageData.caption;
                             const msg = JSON.stringify({
@@ -3660,6 +3683,58 @@ class ClaudeCodeWebInterface {
             || window.matchMedia('(display-mode: minimal-ui)').matches
             || window.matchMedia('(display-mode: fullscreen)').matches
             || navigator.standalone === true;
+    }
+
+    // Shared attachment router for the non-drop surfaces (attach button,
+    // context-menu, paste). Partitions the selected files: anything that passes
+    // the image allowlist goes through the EXISTING image preview → image_upload
+    // path (unchanged), everything else is routed to the generic drop pipeline
+    // (upload to .claude-attachments/ + `@<path>` injection). Drag-and-drop does
+    // NOT use this — it already partitions internally in generic-drop-handler.
+    _attachFiles(files) {
+        if (!files) return;
+        const list = Array.prototype.slice.call(files);
+        if (!list.length) return;
+        const ih = window.imageHandler;
+        const isImg = (f) => !!(ih && typeof ih.isAcceptedImageType === 'function'
+            && ih.isAcceptedImageType(f.type));
+        const images = list.filter(isImg);
+        const others = list.filter((f) => !isImg(f));
+
+        // Capture the socket at attach-initiation time. The image preview modal
+        // is async (user-driven); the active session/socket can change while it
+        // is open. Sending on a captured target avoids the upload landing on a
+        // different session (mirrors the context-menu's existing capture).
+        const targetSocket = this.socket;
+
+        // Images: reuse the existing single-preview flow. The modal handles one
+        // image at a time, so if several images are selected we attach the first
+        // and tell the user rather than silently dropping the rest.
+        if (images.length && ih && typeof ih.showImagePreview === 'function') {
+            if (images.length > 1 && window.feedback && typeof window.feedback.info === 'function') {
+                window.feedback.info('Only the first image is attached — attach images one at a time.');
+            }
+            ih.showImagePreview(images[0], (imageData) => {
+                this._pendingImageCaption = imageData.caption;
+                if (targetSocket && targetSocket.readyState === WebSocket.OPEN) {
+                    targetSocket.send(JSON.stringify({
+                        type: 'image_upload',
+                        base64: imageData.base64,
+                        mimeType: imageData.mimeType,
+                        fileName: imageData.fileName || 'attached-image.png',
+                        caption: imageData.caption || ''
+                    }));
+                }
+            });
+        }
+
+        // Non-images: shared generic pipeline (upload + @path inject).
+        if (others.length && this._genericDropHandler
+                && typeof this._genericDropHandler.dispatchFiles === 'function') {
+            this._genericDropHandler.dispatchFiles(others);
+        } else if (others.length && window.feedback && typeof window.feedback.error === 'function') {
+            window.feedback.error('File upload is not available right now.');
+        }
     }
 
     _setupPwaStandaloneListener() {

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -194,6 +194,7 @@ class ClaudeCodeWebInterface {
         this.setupTerminal();
         this._setupExtraKeys();
         this._setupOrientationHandler();
+        this._setupPwaStandaloneListener();
         this.setupUI();
         if (this.voiceInputConfig) this.setupVoiceInput();
         this.setupPlanDetector();
@@ -827,6 +828,7 @@ class ClaudeCodeWebInterface {
         const handleOrientationChange = () => {
             setTimeout(() => {
                 this.fitTerminal();
+                this._polyfillSafeAreaInsetTop();
                 // Re-evaluate keyboard state
                 if (window.visualViewport && this._keyboardOpen !== undefined) {
                     const heightDiff = window.innerHeight - window.visualViewport.height;
@@ -3658,6 +3660,55 @@ class ClaudeCodeWebInterface {
             || window.matchMedia('(display-mode: minimal-ui)').matches
             || window.matchMedia('(display-mode: fullscreen)').matches
             || navigator.standalone === true;
+    }
+
+    _setupPwaStandaloneListener() {
+        const apply = () => {
+            const standalone = this._isInstalledPWA();
+            document.documentElement.classList.toggle('pwa-standalone', standalone);
+            if (standalone) this._polyfillSafeAreaInsetTop();
+        };
+        apply();
+        try {
+            const queries = [
+                '(display-mode: standalone)',
+                '(display-mode: fullscreen)',
+                '(display-mode: minimal-ui)',
+                '(display-mode: window-controls-overlay)',
+            ];
+            queries.forEach((q) => {
+                const mql = window.matchMedia(q);
+                if (mql.addEventListener) mql.addEventListener('change', apply);
+                else if (mql.addListener) mql.addListener(apply);
+            });
+        } catch (_) { /* ignore */ }
+    }
+
+    _polyfillSafeAreaInsetTop() {
+        // WebKit bug: env(safe-area-inset-top) sometimes returns 0px in iOS PWA
+        // standalone on Dynamic Island / notched devices in portrait. Probe the
+        // actual value; if zero on iOS *in portrait*, substitute 59px (current
+        // Dynamic Island default). Landscape legitimately reports 0 (status bar
+        // hidden, cutouts move to the sides) — do NOT force a fallback there or
+        // the bar gets a persistent 59px gap.
+        if (!document.body) return;
+        const probe = document.createElement('div');
+        probe.style.cssText = 'position:fixed;top:0;left:0;width:1px;height:env(safe-area-inset-top);pointer-events:none;visibility:hidden;';
+        document.body.appendChild(probe);
+        const measured = probe.offsetHeight;
+        document.body.removeChild(probe);
+
+        const root = document.documentElement;
+        if (measured > 0) {
+            root.style.setProperty('--safe-area-inset-top', measured + 'px');
+            return;
+        }
+        const isPortrait = window.matchMedia('(orientation: portrait)').matches;
+        if (isPortrait && this._isIOS()) {
+            root.style.setProperty('--safe-area-inset-top', '59px');
+        } else {
+            root.style.removeProperty('--safe-area-inset-top');
+        }
     }
 
     _isIOS() {

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -833,7 +833,7 @@ class ClaudeCodeWebInterface {
         const handleOrientationChange = () => {
             setTimeout(() => {
                 this.fitTerminal();
-                this._polyfillSafeAreaInsetTop();
+                this._polyfillSafeAreaInsets();
                 // Re-evaluate keyboard state
                 if (window.visualViewport && this._keyboardOpen !== undefined) {
                     const heightDiff = window.innerHeight - window.visualViewport.height;
@@ -3741,7 +3741,7 @@ class ClaudeCodeWebInterface {
         const apply = () => {
             const standalone = this._isInstalledPWA();
             document.documentElement.classList.toggle('pwa-standalone', standalone);
-            if (standalone) this._polyfillSafeAreaInsetTop();
+            if (standalone) this._polyfillSafeAreaInsets();
         };
         apply();
         try {
@@ -3759,31 +3759,64 @@ class ClaudeCodeWebInterface {
         } catch (_) { /* ignore */ }
     }
 
-    _polyfillSafeAreaInsetTop() {
-        // WebKit bug: env(safe-area-inset-top) sometimes returns 0px in iOS PWA
-        // standalone on Dynamic Island / notched devices in portrait. Probe the
-        // actual value; if zero on iOS *in portrait*, substitute 59px (current
-        // Dynamic Island default). Landscape legitimately reports 0 (status bar
-        // hidden, cutouts move to the sides) — do NOT force a fallback there or
-        // the bar gets a persistent 59px gap.
+    _polyfillSafeAreaInsets() {
+        // WebKit bug: env(safe-area-inset-top|bottom) sometimes returns 0px in
+        // iOS PWA standalone on Dynamic Island / notched devices. Probe the
+        // actual env() value per axis; if zero on a notch-class iOS device in
+        // portrait, substitute the known defaults (59px island, 34px home
+        // indicator). Results are exposed as the --safe-area-inset-* variables
+        // that tokens.css (--sa-top/--sa-bottom) and the gated rules consume.
         if (!document.body) return;
-        const probe = document.createElement('div');
-        probe.style.cssText = 'position:fixed;top:0;left:0;width:1px;height:env(safe-area-inset-top);pointer-events:none;visibility:hidden;';
-        document.body.appendChild(probe);
-        const measured = probe.offsetHeight;
-        document.body.removeChild(probe);
 
         const root = document.documentElement;
-        if (measured > 0) {
-            root.style.setProperty('--safe-area-inset-top', measured + 'px');
+
+        // Only ever set fake insets in installed-PWA standalone mode. In a
+        // normal browser tab env() is authoritative (and legitimately 0 at the
+        // top), so forcing a fallback there would push content down for no
+        // reason — and the converted `var(--sa-*)` consumers are ungated, so a
+        // stray value WOULD change non-PWA layout. Clear and bail when not PWA.
+        if (!this._isInstalledPWA()) {
+            root.style.removeProperty('--safe-area-inset-top');
+            root.style.removeProperty('--safe-area-inset-bottom');
             return;
         }
+
+        const measure = (axis) => {
+            const probe = document.createElement('div');
+            probe.style.cssText = 'position:fixed;left:0;width:1px;pointer-events:none;visibility:hidden;'
+                + (axis === 'top' ? 'top:0;' : 'bottom:0;')
+                + 'height:env(safe-area-inset-' + axis + ');';
+            document.body.appendChild(probe);
+            const px = probe.offsetHeight;
+            document.body.removeChild(probe);
+            return px;
+        };
+
         const isPortrait = window.matchMedia('(orientation: portrait)').matches;
-        if (isPortrait && this._isIOS()) {
-            root.style.setProperty('--safe-area-inset-top', '59px');
-        } else {
-            root.style.removeProperty('--safe-area-inset-top');
-        }
+        // Notch / Dynamic-Island iPhones are tall (aspect > 2); home-button
+        // iPhones (SE, 8) are ~1.78 and iPads ~1.33. Only those tall devices
+        // have a top cutout + bottom home indicator, so only they get the
+        // fallback when env() reports a (buggy) 0. This keeps the SE/iPad from
+        // gaining a phantom inset.
+        const longSide = Math.max(window.innerWidth, window.innerHeight);
+        const shortSide = Math.min(window.innerWidth, window.innerHeight);
+        const tall = shortSide > 0 && (longSide / shortSide) > 2;
+        const notchClass = isPortrait && this._isIOS() && tall;
+
+        const apply = (axis, fallback) => {
+            const measured = measure(axis);
+            const prop = '--safe-area-inset-' + axis;
+            if (measured > 0) {
+                root.style.setProperty(prop, measured + 'px');
+            } else if (notchClass) {
+                root.style.setProperty(prop, fallback);
+            } else {
+                root.style.removeProperty(prop);
+            }
+        };
+
+        apply('top', '59px');
+        apply('bottom', '34px');
     }
 
     _isIOS() {

--- a/src/public/components/bottom-nav.css
+++ b/src/public/components/bottom-nav.css
@@ -8,7 +8,7 @@
     background: var(--surface-secondary);
     border-top: 1px solid var(--border-default);
     padding: 0 8px;
-    padding-bottom: env(safe-area-inset-bottom, 0);
+    padding-bottom: var(--sa-bottom);
     z-index: var(--z-sticky);
     align-items: center;
     justify-content: space-around;

--- a/src/public/components/buttons.css
+++ b/src/public/components/buttons.css
@@ -145,7 +145,9 @@
     position: fixed;
     bottom: 80px;
     right: 20px;
-    z-index: var(--z-modal);
+    /* Below the modal layer (--z-modal=400) so this floating control does not
+       paint over open dialogs; still above terminal content. */
+    z-index: var(--z-sticky);
     display: none;
     flex-direction: column;
     gap: 10px;

--- a/src/public/components/buttons.css
+++ b/src/public/components/buttons.css
@@ -264,7 +264,7 @@
 
 @media (max-width: 820px) {
     .install-btn {
-        bottom: calc(52px + 20px + env(safe-area-inset-bottom, 0px));
+        bottom: calc(52px + 20px + var(--sa-bottom));
     }
 }
 

--- a/src/public/components/menus.css
+++ b/src/public/components/menus.css
@@ -75,7 +75,7 @@
         right: 0;
         top: auto;
         border-radius: 12px 12px 0 0;
-        padding-bottom: env(safe-area-inset-bottom, 0);
+        padding-bottom: var(--sa-bottom);
         min-width: 100%;
         max-width: 100%;
         z-index: var(--z-modal);

--- a/src/public/components/safe-area.css
+++ b/src/public/components/safe-area.css
@@ -24,7 +24,8 @@ html.pwa-standalone .session-modal,
 html.pwa-standalone .plan-modal,
 html.pwa-standalone .folder-browser-modal,
 html.pwa-standalone .shortcuts-modal,
-html.pwa-standalone .image-preview-modal {
+html.pwa-standalone .image-preview-modal,
+html.pwa-standalone .terminal-overlay {
     box-sizing: border-box;
     padding-top: var(--sa-top);
     padding-bottom: var(--sa-bottom);
@@ -34,6 +35,14 @@ html.pwa-standalone .image-preview-modal {
    can't overflow back up into the island. dvh tracks the live viewport. */
 html.pwa-standalone .modal-content {
     max-height: calc(100dvh - var(--sa-top) - var(--sa-bottom) - 40px);
+}
+
+/* Full-height slide-in side panel (file browser). Its header already gets the
+   top inset via mobile.css; pad the bottom so the file list clears the home
+   indicator. box-sizing keeps the panel viewport-height. */
+html.pwa-standalone .file-browser-panel {
+    box-sizing: border-box;
+    padding-bottom: var(--sa-bottom);
 }
 
 /* --- Top-anchored transient surfaces ---------------------------------------- */

--- a/src/public/components/safe-area.css
+++ b/src/public/components/safe-area.css
@@ -1,0 +1,59 @@
+/* safe-area.css — PWA standalone safe-area insets for fixed/absolute overlays.
+
+   The Dynamic Island fix in mobile.css covers the in-flow surfaces (tab bar,
+   file-browser header, mobile menu). Out-of-flow overlays (modals, toasts,
+   banners, bottom bars) are anchored to physical screen edges and inherit none
+   of that compensation, so they collide with the iOS Dynamic Island (top) and
+   home indicator (bottom) when launched as an installed PWA. This file applies
+   the insets to those surfaces, in ONE place.
+
+   Everything is gated behind `html.pwa-standalone` (set by the early-paint
+   script + matchMedia listener in app.js) so normal browser-tab and
+   desktop-non-PWA layouts are completely unaffected. Tokens --sa-top/--sa-bottom
+   come from tokens.css and are populated by app.js's _polyfillSafeAreaInsets()
+   (which works around the WebKit env()===0 bug), falling back to env() then 0.
+
+   Loaded LAST so these rules win regardless of source order. */
+
+/* --- Full-screen modal overlays ---------------------------------------------
+   Pad the overlay itself so the flex-centered .modal-content is inset out of
+   both the island and the home indicator. box-sizing keeps the overlay
+   full-viewport while the padding shrinks the centering box. */
+html.pwa-standalone .settings-modal,
+html.pwa-standalone .session-modal,
+html.pwa-standalone .plan-modal,
+html.pwa-standalone .folder-browser-modal,
+html.pwa-standalone .shortcuts-modal,
+html.pwa-standalone .image-preview-modal {
+    box-sizing: border-box;
+    padding-top: var(--sa-top);
+    padding-bottom: var(--sa-bottom);
+}
+
+/* Clamp modal content to the padded area so a tall modal (e.g. Settings)
+   can't overflow back up into the island. dvh tracks the live viewport. */
+html.pwa-standalone .modal-content {
+    max-height: calc(100dvh - var(--sa-top) - var(--sa-bottom) - 40px);
+}
+
+/* --- Top-anchored transient surfaces ---------------------------------------- */
+html.pwa-standalone .toast-container {
+    top: calc(52px + var(--sa-top));
+}
+html.pwa-standalone .banner-base {
+    padding-top: calc(8px + var(--sa-top));
+}
+html.pwa-standalone .notif-permission-prompt {
+    top: calc(60px + var(--sa-top));
+}
+html.pwa-standalone .fb-find-panel {
+    top: calc(80px + var(--sa-top));
+}
+
+/* --- Bottom-anchored bars: lift above the home indicator -------------------- */
+html.pwa-standalone .extra-keys-bar {
+    bottom: var(--sa-bottom);
+}
+html.pwa-standalone .input-overlay {
+    bottom: calc(16px + var(--sa-bottom));
+}

--- a/src/public/extra-keys.js
+++ b/src/public/extra-keys.js
@@ -28,11 +28,11 @@ class ExtraKeys {
       { label: 'End', data: '\x1b[F' },
       { label: 'PgUp', data: '\x1b[5~' },
       { label: 'PgDn', data: '\x1b[6~' },
-      { label: '\u2190', data: '\x1b[D', aria: 'Left arrow' },
-      { label: '\u2192', data: '\x1b[C', aria: 'Right arrow' },
-      { label: '\u2191', data: '\x1b[A', aria: 'Up arrow' },
-      { label: '\u2193', data: '\x1b[B', aria: 'Down arrow' },
-      { label: '\u21E9', dismiss: true, aria: 'Dismiss keyboard' },
+      { label: '\u2190', data: '\x1b[D', aria: 'Left arrow', title: 'Left arrow' },
+      { label: '\u2192', data: '\x1b[C', aria: 'Right arrow', title: 'Right arrow' },
+      { label: '\u2191', data: '\x1b[A', aria: 'Up arrow', title: 'Up arrow' },
+      { label: '\u2193', data: '\x1b[B', aria: 'Down arrow', title: 'Down arrow' },
+      { label: '\u21E9', dismiss: true, aria: 'Dismiss keyboard', title: 'Dismiss keyboard' },
     ];
 
     const row2Keys = [
@@ -86,13 +86,13 @@ class ExtraKeys {
       btn.className = 'extra-key';
       btn.textContent = key.label;
       btn.setAttribute('aria-label', key.aria || key.label);
+      if (key.title) btn.setAttribute('title', key.title);
 
       if (key.dismiss) {
         btn.classList.add('extra-key-dismiss');
         btn.addEventListener('click', () => this._dismiss());
       } else if (key.handler) {
         btn.classList.add('extra-key-clipboard');
-        if (key.title) btn.setAttribute('title', key.title);
         btn.addEventListener('click', () => {
           if (key.handler === 'copy') {
             this._handleCopy();

--- a/src/public/generic-drop-handler.js
+++ b/src/public/generic-drop-handler.js
@@ -365,7 +365,41 @@
     return {
       cancelInFlight: cancelInFlight,
       destroy: destroy,
+      // Public entry point so non-drop surfaces (attach button, paste) can
+      // route a FileList/array of File objects through the EXACT same pipeline:
+      // image/* → onImageDrop, everything else → upload + @path inject, with the
+      // same MAX_FILES_PER_DROP cap and bounded-parallel queue.
+      dispatchFiles: dispatchDrop,
     };
+  }
+
+  // ---------------------------------------------------------------------------
+  // triggerFilePicker — open a hidden <input type="file"> with NO accept filter
+  // (any file type), used by the attach button / context menu. Mirrors
+  // image-handler.js's picker minus the image-only constraint. Resolves the
+  // selected files via the onFiles callback. Browser-only.
+  // ---------------------------------------------------------------------------
+  function triggerFilePicker(onFiles, opts) {
+    if (typeof document === 'undefined') return;
+    opts = opts || {};
+    var input = document.createElement('input');
+    input.type = 'file';
+    if (opts.multiple) input.multiple = true;
+    input.style.display = 'none';
+
+    function cleanup() {
+      if (input.parentNode) input.parentNode.removeChild(input);
+    }
+    input.addEventListener('change', function () {
+      var files = input.files ? Array.prototype.slice.call(input.files) : [];
+      if (files.length && typeof onFiles === 'function') onFiles(files);
+      cleanup();
+    });
+    // Safety net: if the dialog is cancelled, no change fires — sweep the
+    // detached node shortly after to avoid leaking it.
+    document.body.appendChild(input);
+    input.click();
+    setTimeout(cleanup, 60000);
   }
 
   // ---------------------------------------------------------------------------
@@ -374,6 +408,7 @@
 
   var exportsObj = {
     attachGenericDropHandler: attachGenericDropHandler,
+    triggerFilePicker: triggerFilePicker,
     isImageMime: isImageMime,
     sanitizeBasename: sanitizeBasename,
     buildAtPathInjection: buildAtPathInjection,

--- a/src/public/image-handler.js
+++ b/src/public/image-handler.js
@@ -115,6 +115,45 @@ function detectImageInClipboard(clipboardData) {
   return null;
 }
 
+/**
+ * Collect NON-image File objects from a paste clipboard (files copied from a
+ * file manager surface as clipboardData.files / items with kind === 'file').
+ * Accepted image types are excluded — those go through the image preview flow.
+ * Used by onPaste's fall-through so non-image paste reaches the generic upload
+ * pipeline. Returns [] when there are no such files (normal text paste).
+ *
+ * @param {DataTransfer} clipboardData
+ * @returns {File[]}
+ */
+function collectNonImageFiles(clipboardData) {
+  var out = [];
+  if (!clipboardData) return out;
+
+  if (clipboardData.files && clipboardData.files.length > 0) {
+    for (var i = 0; i < clipboardData.files.length; i++) {
+      var f = clipboardData.files[i];
+      if (f && !isAcceptedImageType(f.type)) out.push(f);
+    }
+    // `files` is the authoritative FileList when present; `items` mirrors the
+    // same files (plus non-file entries), so scanning both would double-count.
+    // Fall back to `items` ONLY when `files` yielded nothing — same precedence
+    // as detectImageInClipboard above.
+    if (out.length) return out;
+  }
+
+  if (clipboardData.items && clipboardData.items.length > 0) {
+    for (var j = 0; j < clipboardData.items.length; j++) {
+      var item = clipboardData.items[j];
+      if (item.kind === 'file' && !isAcceptedImageType(item.type)) {
+        var asFile = item.getAsFile();
+        if (asFile) out.push(asFile);
+      }
+    }
+  }
+
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // Blob → base64
 // ---------------------------------------------------------------------------
@@ -504,6 +543,20 @@ function attachImageHandler(terminal, containerEl, options) {
           e.preventDefault();
           e.stopPropagation();
           showImagePreview(image, options.onImageReady);
+          return;
+        }
+        // No image — if non-image files were pasted (e.g. copied from a file
+        // manager) and a handler is wired, route them to the generic pipeline.
+        // Purely additive: when there are no such files this is a no-op and the
+        // normal text paste proceeds untouched.
+        if (typeof options.onFilesPaste === 'function') {
+          var nonImageFiles = collectNonImageFiles(e.clipboardData);
+          if (nonImageFiles.length) {
+            e.preventDefault();
+            e.stopPropagation();
+            options.onFilesPaste(nonImageFiles);
+            return;
+          }
         }
         // No image found — let the normal text paste proceed
       }
@@ -636,6 +689,7 @@ var imageHandlerExports = {
   mimeToExtension: mimeToExtension,
   formatFileSize: formatFileSize,
   detectImageInClipboard: detectImageInClipboard,
+  collectNonImageFiles: collectNonImageFiles,
   blobToBase64: blobToBase64,
   showImagePreview: showImagePreview,
   triggerFilePicker: triggerFilePicker,

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -42,6 +42,24 @@
         } catch (_) { /* ignore */ }
       })();
     </script>
+
+    <!-- Detect PWA standalone mode before first paint so safe-area-top rules can apply
+         without a layout-shift flash. Class lives on <html> because <body> isn't parsed yet. -->
+    <script>
+      (function() {
+        try {
+          var mm = window.matchMedia;
+          var isStandalone = (mm && (
+              mm('(display-mode: standalone)').matches
+              || mm('(display-mode: fullscreen)').matches
+              || mm('(display-mode: minimal-ui)').matches
+              || mm('(display-mode: window-controls-overlay)').matches
+            ))
+            || navigator.standalone === true;
+          if (isStandalone) document.documentElement.classList.add('pwa-standalone');
+        } catch (_) { /* ignore */ }
+      })();
+    </script>
     <link rel="preload" href="fonts/MesloLGSNerdFont-Regular.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="fonts/MesloLGSNerdFont-Bold.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="stylesheet" href="fonts.css">

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -161,7 +161,7 @@
                             <line x1="9" y1="14" x2="15" y2="14"/>
                         </svg>
                     </button>
-                    <button class="tab-attach-image" id="attachImageBtn" title="Attach Image" aria-label="Attach image">
+                    <button class="tab-attach-image" id="attachImageBtn" title="Attach File" aria-label="Attach file">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                              stroke="currentColor" stroke-width="2">
                             <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
@@ -310,7 +310,7 @@
                 <div class="ctx-sep" role="separator"></div>
                 <div class="ctx-item" data-action="attachImage" role="menuitem" tabindex="-1">
                     <span class="ctx-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></span>
-                    <span>Attach Image...</span>
+                    <span>Attach File...</span>
                 </div>
                 <div class="ctx-sep" role="separator"></div>
                 <div class="ctx-item" data-action="selectAll" role="menuitem" tabindex="-1">

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -86,6 +86,8 @@
     <link rel="stylesheet" href="components/extra-keys.css">
     <link rel="stylesheet" href="mobile.css">
     <link rel="stylesheet" href="style.css">
+    <!-- Loaded last: PWA standalone safe-area overrides win over component CSS. -->
+    <link rel="stylesheet" href="components/safe-area.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>

--- a/src/public/mobile.css
+++ b/src/public/mobile.css
@@ -34,7 +34,7 @@
         padding-top: var(--safe-area-inset-top, env(safe-area-inset-top));
     }
     .mode-switcher {
-        bottom: max(80px, calc(80px + env(safe-area-inset-bottom)));
+        bottom: max(80px, calc(80px + var(--sa-bottom)));
         right: max(20px, env(safe-area-inset-right));
     }
 }
@@ -205,12 +205,12 @@
 
     /* Account for bottom nav height */
     #app {
-        padding-bottom: calc(52px + env(safe-area-inset-bottom, 0px));
+        padding-bottom: calc(52px + var(--sa-bottom));
     }
 
     /* Move mode switcher above bottom nav */
     .mode-switcher {
-        bottom: calc(62px + env(safe-area-inset-bottom, 0px));
+        bottom: calc(62px + var(--sa-bottom));
     }
 }
 

--- a/src/public/mobile.css
+++ b/src/public/mobile.css
@@ -2,14 +2,36 @@
    Component-level responsive styles belong in their respective component CSS files.
    This file contains ONLY cross-cutting mobile concerns that span multiple components. */
 
-/* Safe area insets for notched devices (iPhone X+, etc.) */
+/* Safe area insets for notched devices (iPhone X+, etc.)
+   Top-axis padding is gated to PWA standalone mode (html.pwa-standalone) because
+   apple-mobile-web-app-status-bar-style="black-translucent" only causes the
+   Dynamic Island / status-bar collision when launched from the home screen.
+   In normal mobile-Safari/Edge tab mode the browser chrome already occupies that
+   space, so adding padding-top there would visibly push content down for no gain.
+   The CSS variable --safe-area-inset-top is populated by a JS polyfill in app.js
+   to work around the known WebKit bug where env(safe-area-inset-top) sometimes
+   returns 0px in iOS PWA standalone; env() is kept as the secondary fallback. */
 @supports (padding: env(safe-area-inset-top)) {
     .session-tabs-bar {
         padding-left: max(10px, env(safe-area-inset-left));
         padding-right: max(10px, env(safe-area-inset-right));
     }
+    html.pwa-standalone .session-tabs-bar {
+        padding-top: var(--safe-area-inset-top, env(safe-area-inset-top));
+    }
+    html.pwa-standalone .file-browser-panel .file-browser-header {
+        padding-top: var(--safe-area-inset-top, env(safe-area-inset-top));
+    }
+    /* Baseline (any env()-capable browser) preserves the long-standing menu
+       inset; in tab mode env(safe-area-inset-top) is 0 so this is a no-op,
+       but it guards against any non-PWA notched case the standalone rule
+       below wouldn't cover. The standalone rule wins by specificity and
+       routes through the JS-populated --safe-area-inset-top variable. */
     .mobile-menu {
         padding-top: env(safe-area-inset-top);
+    }
+    html.pwa-standalone .mobile-menu {
+        padding-top: var(--safe-area-inset-top, env(safe-area-inset-top));
     }
     .mode-switcher {
         bottom: max(80px, calc(80px + env(safe-area-inset-bottom)));

--- a/src/public/tokens.css
+++ b/src/public/tokens.css
@@ -127,6 +127,17 @@
   --z-input-overlay: 550;
   --z-auth: 9999;
   --z-max: 9999;
+
+  /* --- Safe-area insets (PWA standalone / notched devices) ---
+     Consumed by fixed/absolute overlays so they clear the iOS Dynamic Island
+     (top) and home indicator (bottom). The JS polyfill in app.js sets
+     --safe-area-inset-top/-bottom as VARIABLES to work around the WebKit bug
+     where env(safe-area-inset-*) returns 0px in iOS standalone; we fall back to
+     env() then 0. In normal (non-standalone) mode these resolve to 0, and the
+     consuming rules are gated behind html.pwa-standalone anyway, so there is no
+     effect on browser-tab or desktop-non-PWA layouts. */
+  --sa-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  --sa-bottom: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
 }
 
 /* ============================================================

--- a/src/utils/file-utils.js
+++ b/src/utils/file-utils.js
@@ -132,17 +132,31 @@ function sanitizeFileName(name) {
     throw new Error('File name is required');
   }
 
-  // Strip path separators, null bytes, and control characters
+  // Strip path separators, null bytes, and control characters. Windows-first
+  // (primary deployment target): also strip the characters NTFS forbids in a
+  // file name — `< > : " | ? *`. Stripping ':' additionally neutralizes NTFS
+  // Alternate Data Streams (`name:stream`) and any stray drive-letter colon.
   let sanitized = name
     .replace(/[/\\]/g, '')
+    .replace(/[<>:"|?*]/g, '')
     .replace(/\0/g, '')
     .replace(/[\x01-\x1f\x7f]/g, '');
 
-  // Trim whitespace and dots from start/end
+  // Trim whitespace and dots from start/end (also covers Windows' rule that a
+  // file name may not end in a dot or space).
   sanitized = sanitized.replace(/^[\s.]+|[\s.]+$/g, '');
 
   if (!sanitized) {
     throw new Error('File name is empty after sanitization');
+  }
+
+  // Windows reserved device names (CON, PRN, AUX, NUL, COM1-9, LPT1-9) are
+  // illegal as a file's base name regardless of extension — `COM1.tar.gz` is
+  // still the COM1 device. Windows matches on the stem before the first dot,
+  // case-insensitively. Prefix with '_' to neutralize while staying readable.
+  const stem = sanitized.split('.')[0];
+  if (/^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i.test(stem)) {
+    sanitized = '_' + sanitized;
   }
 
   if (sanitized.length > 255) {

--- a/test/extra-keys-tooltips.test.js
+++ b/test/extra-keys-tooltips.test.js
@@ -1,0 +1,89 @@
+// test/extra-keys-tooltips.test.js — verifies the mobile extra-keys bar renders
+// `title` tooltip attributes on every key that declares one (arrow keys, the
+// dismiss key, and the clipboard keys), not just the clipboard keys.
+//
+// Regression guard for the iOS PWA polish: arrow buttons (←↑↓→) previously
+// carried `aria-label` only, so iPad trackpad / external-keyboard users got no
+// hover tooltip. The fix hoists the `title` application in `_buildRow` so it
+// applies to all key types.
+//
+// Skips automatically when jsdom isn't installed so the unit suite still runs
+// where the dev dependency wasn't fetched.
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const assert = require('assert');
+
+let JSDOM = null;
+try { JSDOM = require('jsdom').JSDOM; } catch (_) { /* will skip below */ }
+
+const EXTRA_KEYS_SRC = path.join(__dirname, '..', 'src', 'public', 'extra-keys.js');
+
+(JSDOM ? describe : describe.skip)('extra-keys.js tooltips (JSDOM)', function () {
+  this.timeout(15000);
+
+  let window, document, ExtraKeys;
+
+  beforeEach(function () {
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+      url: 'http://localhost/',
+      pretendToBeVisual: true,
+      runScripts: 'outside-only',
+    });
+    window = dom.window;
+    document = window.document;
+    // The class registers itself on `window` and uses the global `document`
+    // for element creation; expose both so the IIFE-style module loads cleanly.
+    global.window = window;
+    global.document = document;
+    window.eval(fs.readFileSync(EXTRA_KEYS_SRC, 'utf8'));
+    ExtraKeys = window.ExtraKeys;
+  });
+
+  afterEach(function () {
+    delete global.window;
+    delete global.document;
+  });
+
+  function buildBar() {
+    const ek = new ExtraKeys({ app: { sendInput() {} } });
+    return ek.container;
+  }
+
+  function buttonByLabel(container, label) {
+    return Array.from(container.querySelectorAll('button.extra-key'))
+      .find((b) => b.textContent === label);
+  }
+
+  it('renders title tooltips on every arrow key', function () {
+    const container = buildBar();
+    const expected = {
+      '←': 'Left arrow',
+      '→': 'Right arrow',
+      '↑': 'Up arrow',
+      '↓': 'Down arrow',
+    };
+    for (const [label, title] of Object.entries(expected)) {
+      const btn = buttonByLabel(container, label);
+      assert.ok(btn, `arrow button "${label}" should exist`);
+      assert.strictEqual(btn.getAttribute('title'), title,
+        `arrow button "${label}" should have title="${title}"`);
+    }
+  });
+
+  it('renders a title tooltip on the dismiss key', function () {
+    const container = buildBar();
+    const btn = buttonByLabel(container, '⇩');
+    assert.ok(btn, 'dismiss button should exist');
+    assert.strictEqual(btn.getAttribute('title'), 'Dismiss keyboard');
+  });
+
+  it('keeps aria-label alongside title (accessibility not regressed)', function () {
+    const container = buildBar();
+    const btn = buttonByLabel(container, '←');
+    assert.strictEqual(btn.getAttribute('aria-label'), 'Left arrow');
+    assert.strictEqual(btn.getAttribute('title'), 'Left arrow');
+  });
+});

--- a/test/file-utils-sanitize-windows.test.js
+++ b/test/file-utils-sanitize-windows.test.js
@@ -1,0 +1,77 @@
+// test/file-utils-sanitize-windows.test.js — Windows-first hardening of
+// sanitizeFileName(). Uploads land on the server filesystem (primary deployment
+// target: Windows 11), so the one chokepoint all uploads pass through
+// (src/server.js → sanitizeFileName) must neutralize names that are illegal or
+// dangerous on NTFS: reserved device names, Alternate Data Streams (`:`),
+// Windows-forbidden characters, and trailing dot/space.
+
+'use strict';
+
+const assert = require('assert');
+const { sanitizeFileName } = require('../src/utils/file-utils');
+
+describe('sanitizeFileName — Windows hardening', function () {
+  describe('reserved device names', function () {
+    const reserved = ['CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM9', 'LPT1', 'LPT9'];
+
+    reserved.forEach((name) => {
+      it(`neutralizes bare "${name}"`, function () {
+        assert.strictEqual(sanitizeFileName(name), '_' + name);
+      });
+      it(`neutralizes "${name}" with an extension`, function () {
+        assert.strictEqual(sanitizeFileName(name + '.txt'), '_' + name + '.txt');
+      });
+    });
+
+    it('is case-insensitive', function () {
+      assert.strictEqual(sanitizeFileName('con.txt'), '_con.txt');
+      assert.strictEqual(sanitizeFileName('Aux'), '_Aux');
+    });
+
+    it('matches the stem before the FIRST dot (COM1.tar.gz is still COM1)', function () {
+      assert.strictEqual(sanitizeFileName('COM1.tar.gz'), '_COM1.tar.gz');
+    });
+
+    it('does NOT touch names that merely start with a reserved prefix', function () {
+      assert.strictEqual(sanitizeFileName('console.log'), 'console.log');
+      assert.strictEqual(sanitizeFileName('communication.md'), 'communication.md');
+      assert.strictEqual(sanitizeFileName('com10.txt'), 'com10.txt'); // only COM1-9
+      assert.strictEqual(sanitizeFileName('nullable.js'), 'nullable.js');
+    });
+  });
+
+  describe('NTFS Alternate Data Streams + forbidden chars', function () {
+    it('strips the colon that introduces an ADS', function () {
+      assert.strictEqual(sanitizeFileName('report.pdf:evil.exe'), 'report.pdfevil.exe');
+    });
+    it('strips Windows-forbidden characters < > : " | ? *', function () {
+      assert.strictEqual(sanitizeFileName('a<b>c:d"e|f?g*h.txt'), 'abcdefgh.txt');
+    });
+  });
+
+  describe('trailing dot / space (illegal on Windows)', function () {
+    it('trims a trailing dot', function () {
+      assert.strictEqual(sanitizeFileName('report.'), 'report');
+    });
+    it('trims trailing spaces', function () {
+      assert.strictEqual(sanitizeFileName('report.txt   '), 'report.txt');
+    });
+  });
+
+  describe('regressions — existing behavior preserved', function () {
+    it('leaves ordinary names untouched', function () {
+      assert.strictEqual(sanitizeFileName('notes.md'), 'notes.md');
+      assert.strictEqual(sanitizeFileName('my-file_v2.tar.gz'), 'my-file_v2.tar.gz');
+    });
+    it('still strips path separators', function () {
+      assert.strictEqual(sanitizeFileName('a/b\\c.txt'), 'abc.txt');
+    });
+    it('still throws on empty / non-string input', function () {
+      assert.throws(() => sanitizeFileName(''), /File name is required/);
+      assert.throws(() => sanitizeFileName(null), /File name is required/);
+    });
+    it('throws when nothing survives sanitization', function () {
+      assert.throws(() => sanitizeFileName(':::'), /empty after sanitization/);
+    });
+  });
+});

--- a/test/generic-drop-handler.test.js
+++ b/test/generic-drop-handler.test.js
@@ -429,4 +429,112 @@ describe('generic-drop-handler.js (pure helpers)', function () {
       });
     });
   });
+
+  // -------------------------------------------------------------------------
+  // dispatchFiles — the public entry point that non-drop surfaces (attach
+  // button, paste) feed. Must route through the exact same partition + upload
+  // + @path injection pipeline as a drop, so behavior can't diverge.
+  // -------------------------------------------------------------------------
+  describe('dispatchFiles (public entry point)', function () {
+    it('is exposed on the handler return object', function () {
+      var handler = attachGenericDropHandler({
+        containerEl: container,
+        getWorkingDir: function () { return '/Users/foo'; },
+        onImageDrop: function () {},
+        uploadImpl: function () { return Promise.resolve({ ok: true, status: 201 }); },
+        injectAtPath: function () {},
+      });
+      assert.strictEqual(typeof handler.dispatchFiles, 'function');
+    });
+
+    it('routes non-image files to upload + @path injection', function (done) {
+      var injects = [];
+      var handler = attachGenericDropHandler({
+        containerEl: container,
+        getWorkingDir: function () { return '/Users/foo'; },
+        onImageDrop: function () {},
+        uploadImpl: function (target) {
+          return Promise.resolve({
+            ok: true, status: 201,
+            json: function () { return Promise.resolve({ path: target }); },
+          });
+        },
+        injectAtPath: function (atPath) { injects.push(atPath); },
+      });
+      handler.dispatchFiles([makeFile('notes.txt', 'text/plain')]);
+      var tries = 0;
+      (function wait() {
+        if (injects.length || tries++ > 50) {
+          try {
+            assert.strictEqual(injects.length, 1, 'one @path injected');
+            assert.strictEqual(injects[0].indexOf('@'), 0, 'starts with @: ' + injects[0]);
+            done();
+          } catch (e) { done(e); }
+          return;
+        }
+        setImmediate(wait);
+      })();
+    });
+
+    it('routes image files to the image hook, not upload', function () {
+      var imageCalls = [];
+      var uploadCalls = 0;
+      var handler = attachGenericDropHandler({
+        containerEl: container,
+        getWorkingDir: function () { return '/Users/foo'; },
+        onImageDrop: function (files) { imageCalls.push(files); },
+        uploadImpl: function () { uploadCalls++; return Promise.resolve({ ok: true, status: 201 }); },
+        injectAtPath: function () {},
+      });
+      handler.dispatchFiles([makeFile('cat.png', 'image/png')]);
+      assert.strictEqual(imageCalls.length, 1, 'image hook fired');
+      assert.strictEqual(uploadCalls, 0, 'image must not upload via generic path');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // triggerFilePicker — the attach button / context-menu picker. Must accept
+  // ANY file type (no `accept` filter) so non-image files can be attached.
+  // -------------------------------------------------------------------------
+  describe('triggerFilePicker', function () {
+    it('opens a file input with NO accept filter and multiple when asked', function () {
+      var created = null;
+      var origCreate = document.createElement.bind(document);
+      document.createElement = function (tag) {
+        var el = origCreate(tag);
+        if (tag === 'input') created = el;
+        return el;
+      };
+      try {
+        window.genericDropHandler.triggerFilePicker(function () {}, { multiple: true });
+      } finally {
+        document.createElement = origCreate;
+      }
+      assert.ok(created, 'an <input> was created');
+      assert.strictEqual(created.type, 'file');
+      assert.strictEqual(created.getAttribute('accept'), null, 'no accept filter — any file type');
+      assert.strictEqual(created.multiple, true, 'multiple enabled');
+    });
+
+    it('invokes onFiles with the selected files', function () {
+      var origCreate = document.createElement.bind(document);
+      var input = null;
+      document.createElement = function (tag) {
+        var el = origCreate(tag);
+        if (tag === 'input') input = el;
+        return el;
+      };
+      var received = null;
+      try {
+        window.genericDropHandler.triggerFilePicker(function (files) { received = files; });
+      } finally {
+        document.createElement = origCreate;
+      }
+      // Simulate a selection: define files then fire change.
+      Object.defineProperty(input, 'files', { value: [makeFile('a.bin', 'application/octet-stream')], configurable: true });
+      input.dispatchEvent(new window.Event('change'));
+      assert.ok(received && received.length === 1, 'onFiles received the selection');
+      assert.strictEqual(received[0].name, 'a.bin');
+    });
+  });
 });

--- a/test/image-handler.test.js
+++ b/test/image-handler.test.js
@@ -5,6 +5,7 @@ const {
   mimeToExtension,
   formatFileSize,
   detectImageInClipboard,
+  collectNonImageFiles,
   IMAGE_MAX_SIZE_BYTES,
   ACCEPTED_MIME_TYPES
 } = require('../src/public/image-handler');
@@ -246,6 +247,49 @@ describe('image-handler pure functions', function () {
   describe('IMAGE_MAX_SIZE_BYTES', function () {
     it('should be 4 MB', function () {
       assert.strictEqual(IMAGE_MAX_SIZE_BYTES, 4 * 1024 * 1024);
+    });
+  });
+
+  // collectNonImageFiles powers the paste fall-through: after an image paste is
+  // declined, NON-image files (copied from a file manager) are routed to the
+  // generic upload pipeline. It must NOT pick up accepted image types (those
+  // keep their existing preview path) and must be empty for a plain text paste.
+  describe('collectNonImageFiles', function () {
+    it('returns non-image files from clipboardData.files', function () {
+      const out = collectNonImageFiles(mockClipboardDataWithFiles([
+        mockFile('application/pdf'),
+        mockFile('text/plain'),
+      ]));
+      assert.strictEqual(out.length, 2);
+    });
+
+    it('excludes accepted image types (they keep the preview path)', function () {
+      const out = collectNonImageFiles(mockClipboardDataWithFiles([
+        mockFile('image/png'),
+        mockFile('application/zip'),
+      ]));
+      assert.strictEqual(out.length, 1);
+      assert.strictEqual(out[0].type, 'application/zip');
+    });
+
+    it('falls back to items (kind === "file") when files is empty', function () {
+      const out = collectNonImageFiles(mockClipboardDataWithItems([
+        mockItem('application/json'),
+      ]));
+      assert.strictEqual(out.length, 1);
+      assert.strictEqual(out[0].type, 'application/json');
+    });
+
+    it('returns [] for a plain text paste (no files)', function () {
+      assert.deepStrictEqual(collectNonImageFiles({ files: [], items: [] }), []);
+      assert.deepStrictEqual(collectNonImageFiles(null), []);
+    });
+
+    it('does not pull image items via the items fallback', function () {
+      const out = collectNonImageFiles(mockClipboardDataWithItems([
+        mockItem('image/jpeg'),
+      ]));
+      assert.strictEqual(out.length, 0);
     });
   });
 });


### PR DESCRIPTION
Three improvements bundled per request.

## 1. iOS PWA safe-area — Dynamic Island + every fixed overlay

- **Main chrome:** `.session-tabs-bar`, file-browser header, and `.mobile-menu` clear the Dynamic Island in standalone mode (early-paint head script + `matchMedia` listener; `_polyfillSafeAreaInsets()` measures real `env(safe-area-inset-*)` and substitutes island/home-indicator defaults only on tall notch-class iOS devices in portrait when env returns 0 — the WebKit bug).
- **All overlays:** the initial fix reached only 3 in-flow surfaces; a full audit of **every fixed-position surface** found the rest colliding. New gated `components/safe-area.css` pads modal overlays + clamps `.modal-content` to `100dvh − insets`, offsets top-anchored toast/banner/notif/find-panel, lifts bottom bars, and (from the audit) covers the **file-browser panel** bottom and the **terminal/reconnect overlay**. Tokens `--sa-top`/`--sa-bottom` added; polyfill extended to the bottom axis and **self-gated to standalone** so a non-PWA iOS tab can't get fake insets.
- **Mode-switcher FAB fix:** the audit surfaced a pre-existing bug — `.mode-switcher` used `z-index: var(--z-modal)` (equal to the modal layer) so the floating control painted **over** open dialogs on mobile (any browser, not just PWA). Dropped to `--z-sticky` (above terminal, below the modal backdrop).
- **Arrow-key tooltips** — `←↑↓→` + dismiss gained `title` (had `aria` only).

**Self-test:** `scripts/pwa-safearea-validate.js` — Playwright harness driving a real dev server at **iPhone 16 (393×852)** and **desktop PWA (1280×800)**, forcing standalone + the inset variables, opening every fixed surface (both session modals, plan, shortcuts, folder-browser, settings, terminal overlay, toast, banner, extra-keys bar) and asserting effective content edges (rect ± padding) clear the safe zones. **Before: 5 collisions on iPhone 16. After: 22/22 surfaces clear on both viewports.** Modals were also screenshot-inspected for icon/text/footer placement.

_Not screenshot-verified (flagged honestly):_ the file-browser panel (its real toggle needs an active session — covered by CSS + geometry only) and the desktop cursor-positioned context menus (not edge-anchored; the mobile term-context-menu bottom-sheet is padded). Headless Chromium can't reproduce real iOS `env()`, so the harness forces the variables the polyfill sets on-device — it validates CSS consumption, not WebKit's own detection.

## 2. General file upload — attach button + paste (not just drag-drop)

One shared pipeline now backs drag-drop + attach button + paste. `generic-drop-handler.js` exposes `dispatchFiles()` + a no-`accept` `triggerFilePicker()`; `app.js` `_attachFiles()` partitions image (existing preview → `image_upload`, **unchanged**) vs non-image (upload to `.claude-attachments/` + `@<path>`). **No image regression** — image paths untouched, non-image strictly additive. Socket captured at attach-init (session-switch race); multi-image selection surfaces a notice (both from review). Context-menu "Paste Image" stays image-only (async Clipboard API can't retrieve arbitrary files); OS Ctrl+V is the non-image paste route.

### Windows-first hardening
`sanitizeFileName` strips NTFS-forbidden `< > : " | ? *` (`:` kills ADS), trims trailing dot/space, prefixes reserved device names (`CON`/`PRN`/`AUX`/`NUL`/`COM1-9`/`LPT1-9`) with `_`.

## Test plan
- [x] `npm test` — full suite green (**1206 passing**, 3 pending).
- [x] PWA harness: 22/22 surfaces clear on iPhone 16 + desktop PWA; modals screenshot-inspected.
- [x] New unit tests: `file-utils-sanitize-windows`, `collectNonImageFiles`, `dispatchFiles` + `triggerFilePicker`, `extra-keys-tooltips`.
- [x] Adversarial review (codex-reviewer, high) on both diffs; HIGH/MEDIUM findings fixed (socket race, multi-image, polyfill standalone-gating + non-notch fallback guard).
- [ ] Manual device pass: iOS PWA — open settings/toast/keyboard/file-browser, confirm island + home-indicator clearance; attach a PDF → `@<path>`; attach a PNG → preview unchanged.

## Notes
- Non-PWA / desktop / browser-tab layouts unchanged (everything gated behind `html.pwa-standalone`; tokens resolve to 0 without the standalone polyfill).
- Deferred: cross-CLI `@path` injection (Gemini/Codex get Claude-native syntax verbatim); session-driven harness run to screenshot-verify the file-browser panel + desktop context menus.
- Supersedes #109.