### PR TITLE
fix: non-image drag-drop uploads + per-tab file-browser root

### DIFF
--- a/docs/history/upload-parser-shadow-and-per-tab-file-browser-root.md
+++ b/docs/history/upload-parser-shadow-and-per-tab-file-browser-root.md
@@ -1,0 +1,34 @@
+# Non-image drag-drop uploads + per-tab file-browser root — 2026-06-10
+
+## Symptoms (reported)
+
+1. **Non-image files could not be uploaded by drag-and-drop onto a tab.** Images worked; PDFs, docs, etc. silently failed.
+2. **The file browser did not root at the tab's working directory.** It opened at / stayed on the server's launch directory (or a previously viewed tab's directory) instead of the directory where that tab's agent was started.
+
+## Root causes
+
+### #1 — global body-parser shadowed the upload route
+`src/server.js` mounted `app.use(express.json())` globally with the Express default ~100 KB limit, which ran *before* the upload route's own `express.json({ limit: '10mb' })`. base64 inflates a file ~33%, so any non-image file over ~75 KB produced a body the global parser rejected with `PayloadTooLargeError` (HTTP 413) before the route ran. There was no custom Express error handler, so the client only saw a non-OK response and toasted "upload failed". Images were unaffected because they upload over a WebSocket `image_upload` frame, never touching `/api/files/upload`. That asymmetry was the whole symptom — confirmed by the existing `test/upload-generic.test.js` (a 1 MB upload asserted 413 with a comment documenting the shadowing), and by the happy-path test where a ~23-byte PDF returned 200.
+
+### #2 — file-browser root: server ignored the session, and the singleton panel never re-rooted
+Three compounding causes:
+- `GET /api/files` defaulted to `req.query.path || this.baseFolder` and accepted no session context — with no `path` it listed the server launch dir.
+- The client sent no `path` when its session→cwd cache was cold (e.g. right after a page reload, before `loadSessions()` resolved), so it fell into the `baseFolder` default.
+- The file-browser panel is a singleton whose `open()` short-circuits when already open. Switching tabs while it was open left it showing the previous tab's directory, and further navigation sent an explicit `path`, so any server default never applied. This was the most visible day-to-day form of the bug.
+
+## Fix
+
+- **`src/server.js`** — wrapped the global `express.json()` to exempt `/api/files/upload` (trailing-slash normalized, so `/api/files/upload/` — which Express still routes to the handler — is exempt too); bumped the route parser to `20mb` (fits base64 of the 10 MB decoded cap); added a trailing 4-arg error handler keyed on body-parser's `err.type` that returns JSON `{ error }` for oversize/malformed bodies. The route stays *after* the auth + rate-limit middleware (moving it above `express.json()` would have bypassed auth).
+- **`src/server.js` `GET /api/files`** — when no `path`, resolve the default root from `req.query.session` → `session.liveCwd || session.workingDir` (mirrors the existing `/api/files/find` pattern), validated, falling back to `baseFolder` (with a warn) for unknown/stale sessions so the browser never 403s. Response `home` now reflects the session root; `baseFolder` stays the sandbox floor.
+- **Client (`src/public/file-browser.js`, `app.js`)** — `FileBrowserPanel` gained a `getSessionId` option (wired to `currentClaudeSessionId`); `navigateTo` always forwards `?session` (used by the server only when `path` is absent) and, on each response, stores `home` and reconnects the fs-watcher to the server-resolved `currentPath`; `navigateHome` targets the stored session `home`; new `notifyActiveSessionChanged(sessionId)` re-roots an open panel path-lessly on tab switch, wired from the `session_joined` handler.
+
+## Interpretation / non-goals
+"Root directory for that tab" = the **default open location and Home target** for that tab's browser (editor-style, like a VS Code workspace root). The `baseFolder` sandbox floor and up-navigation are unchanged — users can still navigate above the session dir up to the server base. Session working dirs are always validated within `baseFolder` at creation, so the sandbox floor is always an ancestor of the session root.
+
+## Tests
+- `test/upload-generic.test.js`: >100 KB-and-<10 MB → 200 (regression guard); trailing-slash route → 200; decoded >10 MB → 413; >20 MB body → 413 JSON; malformed JSON → 400 JSON.
+- `test/file-browser-api.test.js`: `?session` defaults to `workingDir`/`liveCwd`; explicit `path` overrides; unknown / no-cwd sessions fall back to `baseFolder` (no 403); `home` vs `baseFolder`.
+- `test/file-browser-session-root.test.js` (new): client `navigateTo` session-param forwarding, `home` storage, watcher reconnect, `navigateHome`, and `notifyActiveSessionChanged` re-root / no-op.
+
+## Review
+Plan and implementation were hardened through adversarial review, which surfaced the trailing-slash / case-insensitive exemption bypass, the missing body-parser error handler, the singleton re-root gap, and the size-vs-type scope question (resolved by the diagnostic gate above).

--- a/docs/specs/file-browser.md
+++ b/docs/specs/file-browser.md
@@ -57,10 +57,13 @@ List directory contents (files and directories).
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
-| `path` | string | `baseFolder` | Directory to list |
+| `path` | string | session root, else `baseFolder` | Directory to list. When omitted, the default root is resolved from `session` (see below). |
+| `session` | string | — | Active session id. When `path` is omitted, the root defaults to that session's `liveCwd ?? workingDir` (the dir the tab's agent was started in), so the browser opens at the tab's directory rather than the server's launch dir. Ignored when `path` is present. Unknown/stale session ids or sessions without a working dir fall back to `baseFolder` (never 403). |
 | `showHidden` | string | `"false"` | `"true"` to include dotfiles |
 | `offset` | number | `0` | Pagination offset |
 | `limit` | number | `500` | Max items per page (cap: 1000) |
+
+The response `home` field reflects the resolved session root (so the client's "Home" button returns to the tab's dir), while `baseFolder` remains the server sandbox floor — they differ for any session rooted in a subdirectory of `baseFolder`.
 
 **Response (200):**
 
@@ -186,7 +189,9 @@ Save text file content with optimistic concurrency.
 
 #### `POST /api/files/upload`
 
-Upload a file as base64-encoded JSON. Uses route-specific `express.json({ limit: '10mb' })`.
+Upload a file as base64-encoded JSON. Uses route-specific `express.json({ limit: '20mb' })`.
+
+> **Body-parser ordering (important):** the global `app.use(express.json())` (Express default ~100 KB limit) is mounted with an exemption that skips `/api/files/upload` (trailing-slash normalized), so this route's own 20 MB parser is the only one that runs. Without the exemption the ~100 KB global limit rejected any base64 body over ~75 KB with a 413 *before* the route, which silently broke non-image drag-drop uploads (images upload over a separate WebSocket frame and were unaffected). The route parser is sized for base64 of the 10 MB decoded cap (~14 MB); the `buffer.length > 10 MB` check remains the real per-file cap. Body-parser rejections (oversize/malformed) are translated to a JSON `{ error }` response by a trailing error-handling middleware (keyed on `err.type`), not Express's default HTML.
 
 **Request body:**
 
@@ -423,7 +428,8 @@ The navigation panel that displays directory listings and handles file selection
 | `openToFile(filePath)` | Navigate to parent directory, auto-select the file |
 | `navigateTo(path)` | Fetch directory listing from `GET /api/files` and render |
 | `navigateUp()` | Navigate to parent directory |
-| `navigateHome()` | Navigate to session working directory |
+| `navigateHome()` | Navigate to the active session's working dir (server-reported `home`), falling back to the sandbox base before the first listing loads |
+| `notifyActiveSessionChanged(sessionId)` | Re-root an open panel to a newly active tab's session. The panel is a singleton across tabs and `open()` short-circuits when already open, so a tab switch must call this to re-navigate (path-lessly, so the server resolves the new session's root). No-op when closed or the session is unchanged. Wired from the `session_joined` handler in `app.js`. |
 
 **Constructor options:**
 
@@ -433,13 +439,16 @@ The navigation panel that displays directory listings and handles file selection
 | `authFetch` | function | Authenticated fetch wrapper (`(url, opts) => Promise<Response>`) |
 | `initialPath` | string \| null | Captured at construction. Used as a final fallback in `open()`; kept for tests and tooling that don't have a session context |
 | `getCwd` | function \| null | Optional callback returning the active session's effective working directory. **Invoked on every `open()`** so a session switch between opens picks up the new cwd. The callback resolves `liveCwd ?? session.workingDir`, where `liveCwd` is the OSC 7-tracked CWD for Terminal-bridge sessions (per [ADR-0019](../adrs/0019-osc7-cwd-tracking.md)) and is `null` for AI CLI bridges. A throwing or null-returning callback falls through to `initialPath`. |
+| `getSessionId` | function \| null | Optional callback returning the active session id. Sent as the `session` query param on every `GET /api/files` so the **server** can resolve the default root even when the client cwd cache is cold (e.g. right after a page reload). Tolerant of falsy/throwing callbacks. |
 
 **`open(startPath)` resolution order:**
 
 1. Explicit `startPath` argument from the caller (e.g. `openToFile`).
 2. `getCwd()` return value, if `getCwd` is configured and returns a truthy string. This already encodes the `liveCwd ?? session.workingDir` precedence — see ADR-0019 for the live-CWD contract.
 3. `initialPath` captured at construction.
-4. `null` — `navigateTo` falls back to the server's default base folder.
+4. `null` — `navigateTo` sends no `path` but still sends `session`, so the **server** resolves the root from the session (its `liveCwd ?? workingDir`), falling back to the default base folder only when the session is unknown. This closes the cold-cache race where the client couldn't supply a path yet.
+
+After each listing response, the panel stores `home` (used by `navigateHome()`) and reconnects the fs-watcher to the server-resolved `currentPath` (covering the path-less / cold-cache open where `open()` couldn't connect a watcher up front).
 
 **Live CWD follow-toggle (per [ADR-0019](../adrs/0019-osc7-cwd-tracking.md)):**
 

--- a/e2e/tests/63-drop-pdf.spec.js
+++ b/e2e/tests/63-drop-pdf.spec.js
@@ -6,6 +6,7 @@
 const { test, expect } = require('@playwright/test');
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const { createServer } = require('../helpers/server-factory');
 const {
   waitForAppReady,
@@ -115,5 +116,50 @@ test.describe('Drop generic file: PDF', () => {
     const dropped = fs.readdirSync(attachmentsDir);
     expect(dropped.some((f) => f.endsWith('tiny.pdf')),
       'tiny.pdf should have been written inside .claude-attachments/').toBe(true);
+  });
+
+  test('drop a LARGE (512KB) non-image file → uploads intact (bytes round-trip)', async ({ page }) => {
+    // The real-world regression: before the parser fix, the global
+    // express.json() (~100KB) 413'd any base64 body over ~75KB BEFORE the
+    // upload route ran, so normal-sized non-image files silently failed.
+    // This drives the full browser path — drop → FileReader → base64 → POST
+    // → server decode → writeFile — with a 512KB payload (~683KB JSON body,
+    // well over the old limit) and asserts the bytes on disk EQUAL the bytes
+    // dropped. The tiny-PDF test above would have passed even pre-fix.
+    await setupSession(page);
+
+    // Deterministic, non-trivial 512KB payload so we can verify integrity.
+    const big = Buffer.alloc(512 * 1024);
+    for (let i = 0; i < big.length; i++) big[i] = (i * 31 + 7) & 0xff;
+    const sha = crypto.createHash('sha256').update(big).digest('hex');
+
+    await dispatchDrop(page, '#terminal', [{
+      name: 'large.bin',
+      mimeType: 'application/octet-stream',
+      base64: big.toString('base64'),
+    }]);
+
+    // @<path> injected → upload succeeded (no error toast path).
+    const expectedFragments = ['@', '.claude-attachments', 'large.bin'];
+    await page.waitForFunction((needles) => {
+      const term = window.app && window.app.terminal;
+      if (!term) return false;
+      const buf = term.buffer.active;
+      let combined = '';
+      for (let i = 0; i < buf.length; i++) {
+        const line = buf.getLine(i);
+        if (line) combined += line.translateToString(true);
+      }
+      return needles.every((n) => combined.includes(n));
+    }, expectedFragments, { timeout: 15000 });
+
+    // The decisive check: the file on disk is byte-for-byte what we dropped.
+    const attachmentsDir = path.join(fixture, '.claude-attachments');
+    const match = fs.readdirSync(attachmentsDir).find((f) => f.endsWith('large.bin'));
+    expect(match, 'large.bin should exist in .claude-attachments/').toBeTruthy();
+    const onDisk = fs.readFileSync(path.join(attachmentsDir, match));
+    expect(onDisk.length, 'uploaded byte length should match').toBe(big.length);
+    expect(crypto.createHash('sha256').update(onDisk).digest('hex'),
+      'uploaded bytes should round-trip exactly (no corruption / truncation)').toBe(sha);
   });
 });

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -2182,6 +2182,16 @@ class ClaudeCodeWebInterface {
                     this._sessionWorkingDirs.set(message.sessionId, message.workingDir);
                 }
                 this.updateSessionButton(message.sessionName);
+
+                // Re-root the (singleton) file-browser panel to the newly
+                // active session's dir. open() short-circuits when already
+                // open, so without this an open panel would keep showing the
+                // previous tab's directory after a tab switch. Fires only when
+                // the panel is open and the session actually changed.
+                if (this._fileBrowserPanel &&
+                    typeof this._fileBrowserPanel.notifyActiveSessionChanged === 'function') {
+                    this._fileBrowserPanel.notifyActiveSessionChanged(message.sessionId);
+                }
                 
                 // Update tab status
                 if (this.sessionTabManager) {
@@ -4138,6 +4148,10 @@ class ClaudeCodeWebInterface {
                 // opens picks up the new cwd (per ADR-0016 / task #14).
                 initialPath: this.getCurrentWorkingDir(),
                 getCwd: () => this.getCurrentWorkingDir(),
+                // Active session id → sent as ?session on /api/files so the
+                // server can resolve the per-tab default root even when the
+                // client cwd cache is cold (e.g. just after a page reload).
+                getSessionId: () => this.currentClaudeSessionId,
             });
         }
         return this._fileBrowserPanel;

--- a/src/public/file-browser.js
+++ b/src/public/file-browser.js
@@ -338,6 +338,17 @@
     // callback is also tolerated (defensive coding per agent-instructions/05).
     this.getCwd = typeof options.getCwd === 'function' ? options.getCwd : null;
 
+    // Optional callback returning the active session's id. Sent as the
+    // `session` query param on /api/files so the SERVER can resolve the
+    // default root (session.liveCwd || session.workingDir) even when the
+    // client's cwd cache is cold (e.g. right after a page reload). Tolerant
+    // of falsy/throwing callbacks like getCwd.
+    this.getSessionId = typeof options.getSessionId === 'function' ? options.getSessionId : null;
+    // Server-reported "home" for the active session (its working dir). Set
+    // from each /api/files response; navigateHome() roots here so "Home"
+    // means the tab's session dir, not the server's global baseFolder.
+    this._homePath = null;
+
     this._open = false;
     this._currentPath = null;
     this._basePath = null;
@@ -858,8 +869,22 @@
     var self = this;
     var params = new URLSearchParams();
     if (dirPath) params.append('path', dirPath);
+    // Always forward the active session id (when known). The server uses it
+    // ONLY to pick the default root when no `path` is given, and to report
+    // `home`; it is ignored when `path` is present, so explicit navigation
+    // (breadcrumbs / up / folder clicks) is unaffected.
+    var sid = null;
+    if (this.getSessionId) { try { sid = this.getSessionId(); } catch (_) { sid = null; } }
+    if (sid) params.append('session', sid);
+    this._lastRenderedSession = sid;
     params.append('limit', '500');
     params.append('offset', '0');
+
+    // Monotonic request token: tab switches / rapid folder clicks can leave
+    // several /api/files fetches in flight at once. Only the LATEST request is
+    // allowed to commit its response, so a slow earlier fetch can't overwrite
+    // the UI (or _homePath / the watcher root) with stale data.
+    var reqId = (this._navSeq = (this._navSeq || 0) + 1);
 
     this._statusBar.textContent = 'Loading...';
 
@@ -869,13 +894,27 @@
         return resp.json();
       })
       .then(function (data) {
+        if (reqId !== self._navSeq) return; // superseded by a newer navigateTo
         self._currentPath = data.currentPath;
         self._basePath = data.baseFolder;
+        // `home` is the session's working dir (server-resolved); navigateHome
+        // roots here. Falls back to baseFolder for sessionless/legacy responses.
+        self._homePath = data.home || data.baseFolder;
         self._items = data.items;
         self._renderBreadcrumbs();
         self._renderItems();
         self._showBrowseView();
         self._statusBar.textContent = data.totalCount + ' item' + (data.totalCount !== 1 ? 's' : '');
+
+        // fs-watcher: (re)connect to the dir the server actually resolved.
+        // open() only connects when it knows the path client-side; on a cold
+        // cache it passes null and the server resolves the session root here,
+        // so connect against data.currentPath to cover that case (and re-root
+        // when a tab switch re-navigates). connect() is idempotent per path.
+        var w = self._ensureFileWatcher();
+        if (w && typeof w.connect === 'function' && data.currentPath) {
+          try { w.connect(data.currentPath); } catch (_) { /* swallow */ }
+        }
 
         // fs-watcher (#41 / ADR-0017 — wire model post-ff79038): one
         // EventSource per session at panel mount, refcount-based per-path
@@ -900,6 +939,7 @@
         }
       })
       .catch(function (err) {
+        if (reqId !== self._navSeq) return; // superseded; don't clobber newer status
         self._statusBar.textContent = 'Error: ' + err.message;
       });
   };
@@ -916,7 +956,9 @@
 
   FileBrowserPanel.prototype.navigateHome = function () {
     this._markManualNav();
-    this.navigateTo(this._basePath);
+    // "Home" is the active session's working dir (server-reported `home`),
+    // falling back to the sandbox base if we haven't loaded a listing yet.
+    this.navigateTo(this._homePath || this._basePath);
   };
 
   // ---------------------------------------------------------------------------
@@ -943,6 +985,22 @@
   FileBrowserPanel.prototype._isActiveSession = function (sessionId) {
     if (!sessionId) return false;
     return this._activeSessionId() === sessionId;
+  };
+
+  /**
+   * Entry point for app.js when the active tab/session changes. The panel is
+   * a singleton shared across tabs, so a tab switch must re-root it to the
+   * new session's working dir — open() short-circuits when already open and
+   * would otherwise keep showing the previous tab's directory. Re-navigates
+   * with NO explicit path so the server resolves the new session's root from
+   * the `?session` param (getSessionId() now returns the new id). No-op when
+   * the panel is closed or the session is unchanged. _markManualNav() is NOT
+   * called: a tab switch should re-root and resume following the new tab.
+   */
+  FileBrowserPanel.prototype.notifyActiveSessionChanged = function (sessionId) {
+    if (!this._open) return;
+    if (!sessionId || sessionId === this._lastRenderedSession) return;
+    this.navigateTo(null);
   };
 
   /**

--- a/src/server.js
+++ b/src/server.js
@@ -870,7 +870,21 @@ class ClaudeCodeWebServer {
 
   setupExpress() {
     this.app.use(cors());
-    this.app.use(express.json());
+    // Global JSON parser for normal endpoints (Express default ~100kb limit).
+    // The upload route mounts its own higher-limit parser (see
+    // POST /api/files/upload below); exempt it here so a base64 file body
+    // isn't rejected by the ~100kb default before the route runs. The
+    // trailing-slash normalization matches exactly the set of paths Express
+    // routes to that handler (`/api/files/upload` and `/api/files/upload/`).
+    const _globalJsonParser = express.json();
+    this.app.use((req, res, next) => {
+      // Case-insensitive + trailing-slash-normalized to match Express's
+      // default route matching (case-insensitive routing), so every form that
+      // reaches the upload handler is exempt from the ~100kb global parser.
+      const p = req.path.replace(/\/+$/, '').toLowerCase() || '/';
+      if (p === '/api/files/upload') return next();
+      return _globalJsonParser(req, res, next);
+    });
     
     // Serve manifest.json with correct MIME type
     this.app.get('/manifest.json', (req, res) => {
@@ -1403,7 +1417,30 @@ class ClaudeCodeWebServer {
 
     // GET /api/files — List directory (files + folders), paginated
     this.app.get('/api/files', (req, res) => {
-      const requestedPath = req.query.path || this.baseFolder;
+      // Per-tab file-browser root. Resolve the requesting session's home dir
+      // (live OSC 7 cwd if tracked, else the spawn dir) when a `session` id is
+      // supplied and its dir still validates. Used as (a) the default root
+      // when the client sends no explicit `path`, and (b) the `home` value the
+      // client points "Home" at — so Home stays the tab's dir even while
+      // browsing subdirs. Mirrors GET /api/files/find. Falls back to baseFolder
+      // for unknown/stale sessions so the browser never 403s on open.
+      let sessionHome = null;
+      const sid = typeof req.query.session === 'string' ? req.query.session : '';
+      if (sid) {
+        const session = this.claudeSessions.get(sid);
+        if (session) {
+          const candidate = session.liveCwd || session.workingDir;
+          if (candidate && this.validatePath(candidate).valid) {
+            sessionHome = candidate;
+          } else {
+            // Known session but its dir is missing or no longer inside the
+            // sandbox — a real misconfiguration worth logging. (Unknown session
+            // ids fall through silently: expected during cold-cache races.)
+            console.warn(`/api/files: session ${sid} working dir unavailable; using baseFolder`);
+          }
+        }
+      }
+      const requestedPath = req.query.path || sessionHome || this.baseFolder;
       const validation = this.validatePath(requestedPath);
       if (!validation.valid) {
         return res.status(403).json({ error: validation.error });
@@ -1480,7 +1517,7 @@ class ClaudeCodeWebServer {
             totalCount,
             offset,
             limit,
-            home: normalizePath(this.baseFolder),
+            home: normalizePath(sessionHome || this.baseFolder),
             baseFolder: normalizePath(this.baseFolder),
           });
         } catch (error) {
@@ -2739,7 +2776,12 @@ class ClaudeCodeWebServer {
     //     per spec ("user shell config is sacrosanct" applies to .gitignore
     //     too — we don't want to silently introduce a new tracked-by-default
     //     side effect on the user's repo).
-    this.app.post('/api/files/upload', express.json({ limit: '10mb' }), async (req, res) => {
+    // Route parser limit is sized for base64 of the 10 MB decoded cap
+    // (~14 MB) plus the small JSON envelope. The decoded-size guard below
+    // (buffer.length > 10 MB) remains the real per-file cap. This parser is
+    // the ONLY one that runs for this route — the global parser above skips
+    // `/api/files/upload`, so this limit governs (not the ~100kb default).
+    this.app.post('/api/files/upload', express.json({ limit: '20mb' }), async (req, res) => {
       const { targetDir, fileName, content, overwrite } = req.body;
       if (!targetDir || !fileName || !content) {
         return res.status(400).json({ error: 'targetDir, fileName, and content are required' });
@@ -2931,6 +2973,24 @@ class ClaudeCodeWebServer {
       } else {
         res.sendFile(path.join(__dirname, 'public', 'index.html'));
       }
+    });
+
+    // Body-parser error handler (4-arg, must be registered AFTER routes).
+    // express.json() rejects oversized/malformed bodies via next(err) BEFORE
+    // the route runs; without this, Express's default handler returns HTML,
+    // which the JSON API clients can't parse. We key on err.type — the marker
+    // body-parser stamps on its own errors — so unrelated next(err) calls are
+    // left to the default handler.
+    this.app.use((err, req, res, next) => {
+      if (res.headersSent || !err || !err.type) return next(err);
+      if (err.type === 'entity.too.large') {
+        return res.status(413).json({ error: 'Request body too large' });
+      }
+      if (err.type === 'entity.parse.failed' || err.type === 'encoding.unsupported'
+          || err.type === 'charset.unsupported' || err.type === 'entity.verify.failed') {
+        return res.status(err.status || err.statusCode || 400).json({ error: 'Invalid request body' });
+      }
+      return next(err);
     });
   }
 

--- a/test/file-browser-api.test.js
+++ b/test/file-browser-api.test.js
@@ -263,7 +263,7 @@ function encodeParam(val) {
     // Inject synthetic sessions into the server's in-memory map. The browse
     // root for a tab should default to that session's working dir (live OSC 7
     // cwd if present, else spawn dir) rather than the global baseFolder.
-    let sessDir, liveDir;
+    let sessDir, liveDir, outsideDir;
 
     before(function () {
       sessDir = createDir('proj-A');
@@ -271,13 +271,21 @@ function encodeParam(val) {
       server.claudeSessions.set('sess-spawn', { id: 'sess-spawn', workingDir: sessDir });
       server.claudeSessions.set('sess-live', { id: 'sess-live', workingDir: sessDir, liveCwd: liveDir });
       server.claudeSessions.set('sess-nocwd', { id: 'sess-nocwd' });
+      // A session whose working dir is OUTSIDE the sandbox (e.g. a stale /
+      // persisted session after the server was relaunched with a narrower
+      // --folder). validatePath must reject it and the route must fall back
+      // to baseFolder rather than 403 or list an out-of-sandbox dir.
+      outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fb-outside-'));
+      server.claudeSessions.set('sess-outside', { id: 'sess-outside', workingDir: outsideDir });
     });
 
     after(function () {
       server.claudeSessions.delete('sess-spawn');
       server.claudeSessions.delete('sess-live');
       server.claudeSessions.delete('sess-nocwd');
+      server.claudeSessions.delete('sess-outside');
       removeIfExists('proj-A');
+      if (outsideDir) { try { fs.rmSync(outsideDir, { recursive: true, force: true }); } catch (_) {} }
     });
 
     function endsWith(p, name) {
@@ -324,6 +332,18 @@ function encodeParam(val) {
       const res = await request(port, 'GET', '/api/files?session=sess-nocwd');
       assert.strictEqual(res.status, 200, JSON.stringify(res.body));
       assert.strictEqual(res.body.currentPath, res.body.baseFolder);
+    });
+
+    it('falls back to baseFolder when the session working dir is outside the sandbox (no 403)', async function () {
+      // Stale/persisted session pointing outside baseFolder: validatePath
+      // rejects it, so the route must NOT 403 and must NOT list the
+      // out-of-sandbox dir — it falls back to baseFolder.
+      const res = await request(port, 'GET', '/api/files?session=sess-outside');
+      assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+      assert.strictEqual(res.body.currentPath, res.body.baseFolder,
+        'out-of-sandbox session dir must fall back to baseFolder');
+      assert.ok(!res.body.currentPath.includes('fb-outside-'),
+        'must not leak/list the out-of-sandbox dir');
     });
 
     it('home reflects the session root while baseFolder stays the server base', async function () {

--- a/test/file-browser-api.test.js
+++ b/test/file-browser-api.test.js
@@ -256,6 +256,87 @@ function encodeParam(val) {
   });
 
   // =========================================================================
+  // GET /api/files — session-rooted default (per-tab file-browser root)
+  // =========================================================================
+
+  describe('GET /api/files — ?session default root', function () {
+    // Inject synthetic sessions into the server's in-memory map. The browse
+    // root for a tab should default to that session's working dir (live OSC 7
+    // cwd if present, else spawn dir) rather than the global baseFolder.
+    let sessDir, liveDir;
+
+    before(function () {
+      sessDir = createDir('proj-A');
+      liveDir = createDir('proj-A/sub-live');
+      server.claudeSessions.set('sess-spawn', { id: 'sess-spawn', workingDir: sessDir });
+      server.claudeSessions.set('sess-live', { id: 'sess-live', workingDir: sessDir, liveCwd: liveDir });
+      server.claudeSessions.set('sess-nocwd', { id: 'sess-nocwd' });
+    });
+
+    after(function () {
+      server.claudeSessions.delete('sess-spawn');
+      server.claudeSessions.delete('sess-live');
+      server.claudeSessions.delete('sess-nocwd');
+      removeIfExists('proj-A');
+    });
+
+    function endsWith(p, name) {
+      return String(p).replace(/\\/g, '/').replace(/\/$/, '').endsWith(name);
+    }
+
+    it('defaults the root to the session workingDir when no path is given', async function () {
+      const res = await request(port, 'GET', '/api/files?session=sess-spawn');
+      assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+      assert.ok(endsWith(res.body.currentPath, 'proj-A'),
+        'currentPath should be the session workingDir, got: ' + res.body.currentPath);
+      assert.ok(endsWith(res.body.home, 'proj-A'),
+        'home should be the session workingDir, got: ' + res.body.home);
+    });
+
+    it('prefers liveCwd over workingDir when present', async function () {
+      const res = await request(port, 'GET', '/api/files?session=sess-live');
+      assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+      assert.ok(endsWith(res.body.currentPath, 'sub-live'),
+        'currentPath should be liveCwd, got: ' + res.body.currentPath);
+      assert.ok(endsWith(res.body.home, 'sub-live'),
+        'home should be liveCwd, got: ' + res.body.home);
+    });
+
+    it('an explicit path overrides the session default', async function () {
+      const res = await request(port, 'GET',
+        `/api/files?session=sess-spawn&path=${encodeParam(tmpDir)}`);
+      assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+      // currentPath should be tmpDir (baseFolder), NOT proj-A.
+      assert.ok(!endsWith(res.body.currentPath, 'proj-A'),
+        'explicit path should win over session root, got: ' + res.body.currentPath);
+    });
+
+    it('falls back to baseFolder for an unknown session id (no 403)', async function () {
+      const res = await request(port, 'GET', '/api/files?session=does-not-exist');
+      assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+      assert.strictEqual(res.body.currentPath, res.body.baseFolder,
+        'unknown session should root at baseFolder');
+      assert.strictEqual(res.body.home, res.body.baseFolder,
+        'home should be baseFolder for an unknown session');
+    });
+
+    it('falls back to baseFolder for a session with no working dir (no 403)', async function () {
+      const res = await request(port, 'GET', '/api/files?session=sess-nocwd');
+      assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+      assert.strictEqual(res.body.currentPath, res.body.baseFolder);
+    });
+
+    it('home reflects the session root while baseFolder stays the server base', async function () {
+      const res = await request(port, 'GET', '/api/files?session=sess-spawn');
+      assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+      assert.notStrictEqual(res.body.home, res.body.baseFolder,
+        'home (session root) and baseFolder (sandbox floor) should differ here');
+      assert.ok(endsWith(res.body.baseFolder, path.basename(tmpDir)) ||
+        res.body.baseFolder.length > 0, 'baseFolder should be the server base');
+    });
+  });
+
+  // =========================================================================
   // GET /api/files/stat (file metadata)
   // =========================================================================
 

--- a/test/file-browser-session-root.test.js
+++ b/test/file-browser-session-root.test.js
@@ -1,0 +1,177 @@
+// Tests for the per-tab file-browser root behaviour (client side):
+//   - navigateTo() forwards the active session id as the `session` query
+//     param (so the server can resolve the default root on a cold cache),
+//     and only sends `path` when a dir is explicitly given.
+//   - navigateTo() stores the server-reported `home` and (re)connects the
+//     fs-watcher to the server-resolved currentPath.
+//   - navigateHome() roots at the stored session `home`, not the sandbox base.
+//   - notifyActiveSessionChanged() re-roots an OPEN panel (path-less, so the
+//     server resolves the new session's root) and no-ops when closed / same
+//     session.
+//
+// FileBrowserPanel is browser-DOM-bound; we stub the minimal window/document
+// surface and the DOM-heavy render methods, but exercise the REAL navigateTo /
+// navigateHome / notifyActiveSessionChanged so the query-string + home +
+// watcher logic is actually covered.
+
+const assert = require('assert');
+
+let _origWindow, _origDocument;
+
+function installBrowserStubs() {
+  _origWindow = global.window;
+  _origDocument = global.document;
+  global.window = { innerWidth: 1280 };
+  global.document = {
+    createElement: () => ({
+      classList: { add() {}, remove() {}, contains: () => false, toggle() {} },
+      addEventListener() {}, appendChild() {}, setAttribute() {}, style: {}, dataset: {},
+    }),
+    body: { appendChild() {} },
+    addEventListener() {},
+  };
+}
+function restoreBrowserStubs() {
+  if (_origWindow === undefined) delete global.window; else global.window = _origWindow;
+  if (_origDocument === undefined) delete global.document; else global.document = _origDocument;
+}
+
+installBrowserStubs();
+const { FileBrowserPanel } = require('../src/public/file-browser');
+
+// Flush pending microtasks/timers so navigateTo's fetch .then runs.
+function flush() { return new Promise((r) => setTimeout(r, 0)); }
+
+describe('FileBrowserPanel — per-tab session root (client)', function () {
+  let fetches, watcherConnects, lastResponse;
+
+  function makePanel(opts) {
+    fetches = [];
+    watcherConnects = [];
+    // Default server response; tests can override lastResponse fields.
+    lastResponse = {
+      currentPath: '/proj/cwd', baseFolder: '/base', home: '/proj/cwd',
+      items: [], totalCount: 0, offset: 0, limit: 500, parentPath: null,
+    };
+    const fakeWatcher = { connect: (p) => watcherConnects.push(p) };
+
+    function FakePanel(o) { FileBrowserPanel.call(this, o); }
+    FakePanel.prototype = Object.create(FileBrowserPanel.prototype);
+    FakePanel.prototype._buildDOM = function () {
+      const el = { classList: { add() {}, remove() {}, contains: () => false }, addEventListener() {} };
+      this._panelEl = el; this._backdropEl = el;
+    };
+    FakePanel.prototype._updateOverlayMode = function () {};
+    FakePanel.prototype._announceToScreenReader = function () {};
+    FakePanel.prototype._adjustTerminal = function () {};
+    FakePanel.prototype._renderBreadcrumbs = function () {};
+    FakePanel.prototype._renderItems = function () {};
+    FakePanel.prototype._showBrowseView = function () {};
+    FakePanel.prototype._reconcileListingSubscriptions = function () {};
+    FakePanel.prototype._ensureFileWatcher = function () { return fakeWatcher; };
+
+    const panel = new FakePanel(Object.assign({
+      authFetch: (url) => {
+        fetches.push(url);
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(lastResponse),
+        });
+      },
+    }, opts));
+    panel._statusBar = { textContent: '' };
+    return panel;
+  }
+
+  function urlParams(url) {
+    return new URL('http://x' + url.slice(url.indexOf('?'))).searchParams;
+  }
+
+  before(installBrowserStubs);
+  after(restoreBrowserStubs);
+
+  it('forwards the session id and omits path when navigateTo(null)', async function () {
+    const panel = makePanel({ getSessionId: () => 'sess-1' });
+    panel.navigateTo(null);
+    await flush();
+    assert.strictEqual(fetches.length, 1);
+    const p = urlParams(fetches[0]);
+    assert.strictEqual(p.get('session'), 'sess-1');
+    assert.strictEqual(p.get('path'), null, 'no explicit path should be sent');
+  });
+
+  it('sends both path and session when a dir is given', async function () {
+    const panel = makePanel({ getSessionId: () => 'sess-1' });
+    panel.navigateTo('/proj/cwd/sub');
+    await flush();
+    const p = urlParams(fetches[0]);
+    assert.strictEqual(p.get('path'), '/proj/cwd/sub');
+    assert.strictEqual(p.get('session'), 'sess-1');
+  });
+
+  it('omits session when no getSessionId is wired (back-compat)', async function () {
+    const panel = makePanel({});
+    panel.navigateTo('/x');
+    await flush();
+    assert.strictEqual(urlParams(fetches[0]).get('session'), null);
+  });
+
+  it('stores server home and reconnects the watcher to currentPath', async function () {
+    const panel = makePanel({ getSessionId: () => 'sess-1' });
+    lastResponse.currentPath = '/proj/cwd';
+    lastResponse.home = '/proj/cwd';
+    panel.navigateTo(null);
+    await flush();
+    assert.strictEqual(panel._homePath, '/proj/cwd');
+    assert.deepStrictEqual(watcherConnects, ['/proj/cwd']);
+  });
+
+  it('navigateHome roots at the stored session home, not baseFolder', async function () {
+    const panel = makePanel({ getSessionId: () => 'sess-1' });
+    lastResponse.currentPath = '/proj/cwd/deep';
+    lastResponse.home = '/proj/cwd';
+    lastResponse.baseFolder = '/base';
+    panel.navigateTo('/proj/cwd/deep');
+    await flush();
+    assert.strictEqual(panel._homePath, '/proj/cwd');
+    fetches.length = 0;
+    panel.navigateHome();
+    await flush();
+    assert.strictEqual(urlParams(fetches[0]).get('path'), '/proj/cwd',
+      'navigateHome should target the session home');
+  });
+
+  it('notifyActiveSessionChanged re-roots an open panel path-lessly', async function () {
+    let sid = 'sess-A';
+    const panel = makePanel({ getSessionId: () => sid });
+    panel._open = true;
+    panel.navigateTo(null);          // initial render for sess-A
+    await flush();
+    assert.strictEqual(panel._lastRenderedSession, 'sess-A');
+    fetches.length = 0;
+    sid = 'sess-B';                   // app switched the active session
+    panel.notifyActiveSessionChanged('sess-B');
+    await flush();
+    assert.strictEqual(fetches.length, 1, 'should re-fetch on session change');
+    const p = urlParams(fetches[0]);
+    assert.strictEqual(p.get('session'), 'sess-B');
+    assert.strictEqual(p.get('path'), null, 're-root must be path-less so server picks the new root');
+  });
+
+  it('notifyActiveSessionChanged is a no-op when closed or unchanged', async function () {
+    const panel = makePanel({ getSessionId: () => 'sess-A' });
+    // Closed panel → no fetch.
+    panel._open = false;
+    panel.notifyActiveSessionChanged('sess-B');
+    await flush();
+    assert.strictEqual(fetches.length, 0, 'closed panel should not re-fetch');
+    // Open, render A, then notify A again → no-op.
+    panel._open = true;
+    panel.navigateTo(null);
+    await flush();
+    fetches.length = 0;
+    panel.notifyActiveSessionChanged('sess-A');
+    await flush();
+    assert.strictEqual(fetches.length, 0, 'same session should not re-fetch');
+  });
+});

--- a/test/upload-generic.test.js
+++ b/test/upload-generic.test.js
@@ -173,6 +173,25 @@ function request(port, method, urlPath, body) {
     assert.ok(fs.existsSync(path.join(attachmentsDir, 'case.bin')));
   });
 
+  it('accepts a near-cap ~9MB file and writes it byte-for-byte (200)', async function () {
+    // Validates two things the smaller tests don't: (1) the 20mb route parser
+    // is actually large enough for a legitimate near-10MB-cap file (base64 of
+    // 9MB ≈ 12MB body, under 20mb), so the limit choice isn't off-by-a-factor;
+    // (2) the decoded bytes round-trip exactly (no truncation/corruption) at
+    // size, which no existing server test checked.
+    const big = Buffer.alloc(9 * 1024 * 1024);
+    for (let i = 0; i < big.length; i++) big[i] = (i * 131 + 17) & 0xff;
+    const r = await request(port, 'POST', '/api/files/upload', {
+      targetDir: attachmentsDir,
+      fileName: 'near-cap.bin',
+      content: big.toString('base64'),
+    });
+    assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+    const onDisk = fs.readFileSync(path.join(attachmentsDir, 'near-cap.bin'));
+    assert.strictEqual(onDisk.length, big.length, 'byte length must match');
+    assert.ok(Buffer.compare(onDisk, big) === 0, 'bytes must round-trip exactly');
+  });
+
   it('rejects content over the decoded 10 MB cap (413)', async function () {
     // base64 of 11 MB (~14.7 MB) fits under the 20mb route parser, so the
     // body is parsed and the decoded-size guard returns the 413.

--- a/test/upload-generic.test.js
+++ b/test/upload-generic.test.js
@@ -128,19 +128,83 @@ function request(port, method, urlPath, body) {
     assert.strictEqual(r.status, 403);
   });
 
-  it('rejects content larger than the per-request 10 MB cap (413)', async function () {
-    // The route registers express.json({ limit: '10mb' }) but a global
-    // express.json() with the default ~100kb limit runs first, and rejects
-    // anything bigger than ~100 KB before the route handler sees it. Both
-    // cases yield 413 — exercise the global path here, since that's the
-    // actual cap a 10MB upload runs into in production today.
+  it('accepts a body over the old ~100KB global-parser limit but under the decoded 10MB cap (200)', async function () {
+    // Regression guard for the upload fix: the global express.json() (~100kb
+    // default) used to run BEFORE the route's parser and 413'd any base64
+    // body over ~100kb — so non-image drag-drops of normal files silently
+    // failed. The route is now exempt from the global parser and mounts its
+    // own 20mb parser, so a 1 MB file (~1.4 MB JSON body) reaches the handler.
     const big = Buffer.alloc(1024 * 1024, 'a'); // 1 MB → ~1.4 MB JSON body
     const r = await request(port, 'POST', '/api/files/upload', {
       targetDir: attachmentsDir,
       fileName: 'big.bin',
       content: big.toString('base64'),
     });
-    assert.strictEqual(r.status, 413);
+    assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+    assert.ok(fs.existsSync(path.join(attachmentsDir, 'big.bin')));
+  });
+
+  it('still exempts the route when addressed with a trailing slash (200)', async function () {
+    // Express routes `/api/files/upload/` to the same handler; the global-parser
+    // exemption normalizes the trailing slash so it is exempt too (a bare
+    // req.path === '/api/files/upload' check would let the global ~100kb
+    // parser 413 it again).
+    const big = Buffer.alloc(300 * 1024, 'b'); // ~400 KB JSON body, > old 100kb
+    const r = await request(port, 'POST', '/api/files/upload/', {
+      targetDir: attachmentsDir,
+      fileName: 'slash.bin',
+      content: big.toString('base64'),
+    });
+    assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+    assert.ok(fs.existsSync(path.join(attachmentsDir, 'slash.bin')));
+  });
+
+  it('still exempts the route when addressed with a different case (200)', async function () {
+    // Express default routing is case-insensitive, so `/api/FILES/upload`
+    // reaches the handler; the global-parser exemption is lower-cased to match,
+    // otherwise the ~100kb global parser would 413 a case-variant request.
+    const big = Buffer.alloc(300 * 1024, 'c'); // > old 100kb global limit
+    const r = await request(port, 'POST', '/api/FILES/upload', {
+      targetDir: attachmentsDir,
+      fileName: 'case.bin',
+      content: big.toString('base64'),
+    });
+    assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+    assert.ok(fs.existsSync(path.join(attachmentsDir, 'case.bin')));
+  });
+
+  it('rejects content over the decoded 10 MB cap (413)', async function () {
+    // base64 of 11 MB (~14.7 MB) fits under the 20mb route parser, so the
+    // body is parsed and the decoded-size guard returns the 413.
+    const big = Buffer.alloc(11 * 1024 * 1024, 'a');
+    const r = await request(port, 'POST', '/api/files/upload', {
+      targetDir: attachmentsDir,
+      fileName: 'toobig.bin',
+      content: big.toString('base64'),
+    });
+    assert.strictEqual(r.status, 413, JSON.stringify(r.body));
+  });
+
+  it('rejects a body over the 20mb route parser limit with a JSON error (413)', async function () {
+    // base64 of 16 MB (~21.3 MB) exceeds the route parser limit, so the parser
+    // throws entity.too.large; the body-parser error handler must translate it
+    // to the API's { error } JSON shape (not Express default HTML).
+    const big = Buffer.alloc(16 * 1024 * 1024, 'a');
+    const r = await request(port, 'POST', '/api/files/upload', {
+      targetDir: attachmentsDir,
+      fileName: 'huge.bin',
+      content: big.toString('base64'),
+    });
+    assert.strictEqual(r.status, 413, JSON.stringify(r.body));
+    assert.ok(r.body && typeof r.body === 'object' && r.body.error,
+      'expected a JSON { error } body, got: ' + JSON.stringify(r.body).slice(0, 200));
+  });
+
+  it('returns a JSON 400 for a malformed JSON body', async function () {
+    const r = await request(port, 'POST', '/api/files/upload', '{ not valid json');
+    assert.strictEqual(r.status, 400, JSON.stringify(r.body));
+    assert.ok(r.body && typeof r.body === 'object' && r.body.error,
+      'expected a JSON { error } body, got: ' + JSON.stringify(r.body).slice(0, 200));
   });
 
   // ── NEW: per-session 100 MB cap on .claude-attachments/ ──────────────────


### PR DESCRIPTION
## Summary

Fixes two reported bugs in the web UI:

1. **Non-image files could not be drag-dropped onto a tab** (images worked, other files failed).
2. **The file browser did not root at the tab's working directory** — it opened at / stayed on the server's launch directory or a previous tab's directory.

## Root causes

- **Upload:** a global `app.use(express.json())` (Express default ~100KB limit) ran *before* the upload route's own `express.json({ limit: '10mb' })`. base64 inflates a file ~33%, so any non-image drop over ~75KB was 413-ed before the route ran. Images were unaffected because they upload over a WebSocket `image_upload` frame, not this endpoint.
- **Root:** `GET /api/files` defaulted to the global `baseFolder` and took no session context; the client sent no `path` on a cold cache (e.g. after a page reload); and the singleton panel's `open()` short-circuits when already open, so switching tabs left it showing the previous tab's directory.

## Changes

**Server (`src/server.js`)**
- Exempt `/api/files/upload` from the global JSON parser (case-insensitive + trailing-slash normalized) so its own parser governs; bump that parser to `20mb` (fits base64 of the 10MB decoded cap); the `buffer.length > 10MB` check remains the real per-file cap.
- Add a body-parser error handler (keyed on `err.type`) that returns JSON `{ error }` for oversize/malformed bodies instead of Express's default HTML.
- `GET /api/files` resolves the default root from `?session` → `session.liveCwd || session.workingDir` (mirrors `/api/files/find`), falling back to `baseFolder` for unknown/stale sessions (never 403). Response `home` reflects the session root; `baseFolder` stays the sandbox floor.

**Client (`src/public/file-browser.js`, `app.js`)**
- `FileBrowserPanel` forwards the active session id (`?session`), points "Home" at the server-reported session root, reconnects the fs-watcher to the resolved dir, drops stale concurrent responses via a monotonic request token, and re-roots on tab switch via `notifyActiveSessionChanged` (wired from the `session_joined` handler).

## Interpretation / non-goals
"Root directory for that tab" = the default open location and Home target. The `baseFolder` sandbox floor and up-navigation are unchanged (editor-style — you can still navigate above the session dir up to the server base).

## Testing
- `npm test`: full unit/integration suite green, plus new cases — upload route (over-100KB→200, trailing-slash, case-variant, decoded-cap 413, 20mb-parser 413 JSON, malformed→400), `?session` default-root resolution, and client `navigateTo`/`navigateHome`/re-root.
- e2e (real browser): drop a PDF onto the terminal → `@<path>` injected; multi-file drop + cancel; image-drop-still-works; file-browser panel defaults to the active session cwd. All pass.

## Docs
- `docs/specs/file-browser.md` updated (upload limits + parser ordering, `?session` root resolution, `home` vs `baseFolder`, tab-switch re-root).
- New `docs/history/upload-parser-shadow-and-per-tab-file-browser-root.md`.
