### PR TITLE
fix: voice recording crash (binary WS frame) + http→https auto-upgrade

### DIFF
--- a/docs/adrs/0026-voice-binary-frame.md
+++ b/docs/adrs/0026-voice-binary-frame.md
@@ -1,0 +1,104 @@
+# 0026 - Voice upload: binary WebSocket frame
+
+## Status
+
+Accepted (2026-06). Supersedes the base64-in-JSON `voice_upload` transport
+described in `docs/specs/voice-input.md` (the base64 path is kept as a thin
+back-compat shim, not removed).
+
+## Context
+
+Local-mode voice audio was buffered in the browser during recording and sent as
+one **base64-JSON** `voice_upload` WebSocket frame on stop. The server enforces a
+deliberate application-layer guard `MAX_WS_MESSAGE_BYTES = 1 MiB`
+(`src/server.js`, HOT-08) that rejects any frame over 1 MiB **before** `JSON.parse`
+with `ws.close(1009)` — a defense against a client stalling the event loop with
+large/rapid frames.
+
+base64 inflates 16 kHz / 16-bit / mono PCM by 33% (32 KB/s -> ~42.7 KB/s on the
+wire), so a recording crossed 1 MiB at **~24.6 s**. Any clip longer than that
+produced an over-1 MiB frame on stop -> `1009`. Because a server-initiated
+`close(1009)` is a *clean* close (`CloseEvent.wasClean === true`), the client's
+`onclose` skipped the reconnect branch and dead-ended on "Disconnected — refresh
+the page". Net effect: recording for ~30-45 s crashed the page.
+
+A masked inconsistency hid this: the server handler and client both advertise a
+120 s cap, but the 1 MiB wire guard made anything past ~24.6 s unreachable.
+
+A review across security, cross-platform, protocol, browser-audio, and QA
+dimensions evaluated the options:
+
+- **Raise the global 1 MiB guard** — rejected: weakens the event-loop-DoS
+  protection for *all* frame types.
+- **Chunked JSON upload** — viable but adds per-session reassembly state (cap +
+  TTL + cleanup) and keeps the base64 inflation.
+- **Binary WebSocket frame** — chosen: removes the base64 inflation, adds no
+  server reassembly state, and leaves the 1 MiB JSON guard fully intact for text
+  frames. Binary frames are already an established server->client convention
+  (terminal output); this adds the reverse direction.
+
+## Decision
+
+Send local-mode audio as a single **binary** WebSocket frame:
+
+```
+[ "VUP1" (4) ][ version=1 (1) ][ type=0x01 PCM (1) ][ raw Int16 native-endian PCM @16kHz mono ]
+```
+
+- The server dispatcher (`ws.on('message', (message, isBinary))`) branches on
+  `isBinary` **before** the 1 MiB JSON guard. The text/JSON path is unchanged
+  (HOT-08 protection preserved).
+- Binary frames are bounded by `MAX_VOICE_BINARY_FRAME_BYTES = 6 + 3,840,000`:
+  oversize -> `message_too_large` + `close(1009)` (same as the text guard — never
+  an unbounded error-reply loop, which would reopen the DoS hole); a bad/short/
+  unknown header -> `close(1003)`. Framing + the `Buffer[]` fragmented-frame
+  normalize live in pure, unit-tested `src/utils/ws-voice-frame.js`.
+- A versioned/typed header (not a bare magic) lets future inbound-binary features
+  claim their own type byte instead of forcing a wire break.
+- The int16->float32 conversion is deferred to the STT **worker thread**
+  (`sttEngine.transcribePcm16`, `src/utils/pcm.js`) so the event loop never runs
+  the ~1.9 M-sample loop for a 120 s clip.
+- Voice rate-limit state moves onto the session object (`_voiceUploadTimestamps`,
+  mirroring image uploads) so it shares the session lifetime and correctly
+  survives WS reconnects (resetting it on disconnect would let a client evade the
+  limit). It is checked **before** the readiness gate.
+- The legacy base64 `voice_upload` JSON handler is kept as a thin shim over the
+  shared validation/transcribe core (the `'Missing audio data'` guard stays in
+  the shim; binary has no `data.audio`).
+
+Client robustness shipped alongside (the same review surfaced these):
+
+- `onclose` branches on `event.code`: `1009`/`1003` (clean server rejections)
+  show a specific toast and reconnect (bounded) instead of dead-ending; a close
+  mid-transcription clears the mic spinner/timeout; the close code is logged so
+  field data can distinguish `1009` (at stop) from `4000` (pong-timeout).
+- The heartbeat **pong-timeout is suspended while recording** (`HeartbeatWatchdog.pause()`/
+  `resume()`): the capture thread (esp. the ScriptProcessor fallback) can briefly
+  miss a pong, which would otherwise force a spurious `close(4000)` mid-recording.
+- `sendBinary` returns whether the socket was OPEN; a send on a closed socket
+  fails fast (toast) instead of silently dropping and hanging the 90 s spinner.
+- A new recording is refused while a transcription is still pending; a zero-sample
+  recording is dropped client-side.
+
+## Consequences
+
+- Long recordings (up to the 120 s cap) work; the ~24.6 s crash cliff is gone.
+- Two transports exist (binary + the base64 shim). The shim is dead weight once
+  no client emits it; a future ADR may remove it.
+- Inbound binary is now meaningful to the server. The 4-byte magic + version/type
+  header namespaces it; a non-voice inbound-binary feature must add a new type.
+- PCM is shipped in the browser's native endianness (unchanged from the base64
+  path; little-endian on every supported target). A hypothetical big-endian client
+  would need explicit LE framing — not a concern for browsers.
+- **Deferred (documented, not in this change):** pre-existing tab-misrouting
+  (voice exits the main socket; the server routes by `wsInfo.claudeSessionId`,
+  which swaps on tab-switch) and a per-IP WebSocket connection-rate limit (the
+  real backstop for a connect->bad-frame->reconnect loop, since `reconnectAttempts`
+  resets on `onopen`).
+
+## References
+
+- Spec: `docs/specs/voice-input.md`
+- History: `docs/history/voice-binary-frame-crash-2026.md`
+- HOT-08 frame guard: `docs/audits/hot-03-ws-frame-size.md`
+- Tests: `test/voice-frame.test.js`, `test/voice-binary.test.js`

--- a/docs/adrs/0027-http-to-https-auto-upgrade.md
+++ b/docs/adrs/0027-http-to-https-auto-upgrade.md
@@ -1,0 +1,69 @@
+# 0027 - HTTP→HTTPS auto-upgrade on a single port
+
+## Status
+
+Accepted (2026-06).
+
+## Context
+
+Running with `--https`, the server listened only for TLS on `PORT`. A user who
+reached `http://host:PORT` (typed the scheme, followed a bookmark from a prior
+plain-HTTP run, or omitted the scheme so the browser tried HTTP first) hit the
+TLS listener with a plaintext request → an opaque TLS-handshake error / hang,
+not a helpful redirect. We want plaintext HTTP on the port to auto-upgrade to
+HTTPS.
+
+Options considered:
+
+1. **Separate HTTP redirect port** (e.g. also bind 80, or `PORT-1`). Rejected:
+   port 80 needs root and is often taken (IIS/`http.sys` on the Windows-first
+   target); an arbitrary companion port adds CLI surface and a second thing for
+   the user to know. It also doesn't help the user who typed `http://host:PORT`.
+2. **Same-port byte sniffing** (chosen): one listening socket serves both. The
+   user types either scheme on the one port and it works — no extra config, and
+   it directly fixes the `http://host:PORT` case.
+
+## Decision
+
+In HTTPS mode the listening socket is a `net` server that **peeks the first
+byte** of each connection: a TLS ClientHello begins with `0x16` (handshake
+record), so those connections are handed (`emit('connection')`) to the real
+`https` app server; any other first byte is plaintext HTTP and is handed to a
+small redirect server that answers `307` with `Location: https://<host>:<port><url>`.
+
+Key properties:
+
+- **307** (temporary, method-preserving) rather than `301`/`308`: a POST stays a
+  POST, and it is not cached as permanent — so flipping the port back to plain
+  HTTP later isn't poisoned by a stale permanent redirect.
+- **Open-redirect guard:** the redirect host derives from the client `Host`
+  header but is validated to a bare `hostname[:port]` / `[ipv6][:port]` (userinfo
+  `@`, path, control chars rejected), falling back to `localhost`. The port comes
+  from `req.socket.localPort` (correct even on an ephemeral `port: 0`).
+- The **WebSocket server attaches to the inner TLS server**, so a `wss://`
+  upgrade still arrives over an encrypted `TLSSocket` (`req.socket.encrypted`
+  stays true for the secure-context / voice checks). A plaintext `ws://` upgrade
+  to the port gets the same `307` written raw instead of an abrupt reset.
+- **Pre-handoff guards:** a connection that errors or sends no data within 10 s
+  (port scanner / slowloris) is destroyed before routing; the timer + error
+  listener are cleared on handoff so the target server owns the socket lifecycle.
+- **Shutdown:** `close()` destroys the tracked proxied sockets and closes both
+  inner servers (they receive connections via `emit('connection')`, which
+  bypasses their internal connection tracking, so they wouldn't otherwise drain).
+
+The non-HTTPS path is unchanged (a plain `http` server).
+
+## Consequences
+
+- One port, both schemes — simplest UX, no new flags or privileged ports.
+- A tiny per-connection cost (one `readable` + 1-byte read + an `unshift`) and an
+  extra in-process hop for every connection in HTTPS mode.
+- Inbound connections are injected into the inner servers, bypassing their
+  connection tracking — handled explicitly in `close()`.
+- No HSTS is sent (would conflict with self-signed certs and with switching the
+  port between http/https modes); the redirect alone is the upgrade mechanism.
+
+## References
+
+- Spec: `docs/specs/server.md` (HTTPS and HTTP→HTTPS auto-upgrade)
+- Tests: `test/https-upgrade.test.js`

--- a/docs/history/voice-binary-frame-crash-2026.md
+++ b/docs/history/voice-binary-frame-crash-2026.md
@@ -1,0 +1,81 @@
+# Voice recording crashes the page after ~25-45 s (2026-06)
+
+## Symptom
+
+Recording with the mic crashed the page after ~30-45 s of speech: it showed the
+"Disconnected — refresh the page" banner and the session had to be re-established.
+Short recordings were fine.
+
+## Root cause
+
+Local-mode audio was buffered in the browser during recording and sent as **one
+base64-JSON `voice_upload` WebSocket frame on stop** (not streamed). The server
+rejects any frame over `MAX_WS_MESSAGE_BYTES = 1 MiB` (`src/server.js`, the HOT-08
+guard) with `ws.close(1009)` **before** `JSON.parse`.
+
+base64 inflates 16 kHz / 16-bit / mono PCM by 33%:
+
+```
+32,000 raw bytes/s × 4/3 (base64) ≈ 42,667 bytes/s on the wire
+1,048,576 / 42,667 ≈ 24.6 s
+```
+
+So any clip longer than ~24.6 s produced an over-1 MiB frame on stop -> `1009`.
+The "30-45 s" the user reported was just the loose clip length; the crash fired
+the instant they stopped.
+
+Two things made it worse and hid it:
+
+1. A server-initiated `close(1009)` is a **clean** close, so the browser sets
+   `CloseEvent.wasClean === true`. The client `onclose` only branched on
+   `!event.wasClean`, so it **skipped reconnect** and dead-ended on
+   "refresh the page" — an immediate dead-end on the first `1009`.
+2. The server voice handler and client both advertised a **120 s** cap, but the
+   1 MiB wire guard made anything past ~24.6 s unreachable. The existing oversized
+   test used a 120 s clip "to be obviously over" and never noticed a normal ~25 s
+   recording also crossed the line.
+
+A secondary, *unconfirmed-but-plausible* path was identified and guarded: the
+client heartbeat pong-timeout (25 s ping + 10 s window) fires on the **client**
+main thread, and capture is not fully off-thread (the ScriptProcessor fallback is
+main-thread). A long recording under main-thread pressure could miss a pong ->
+`close(4000)` mid-recording. The close code is now logged to distinguish it.
+
+## Fix
+
+Switched the local-mode transport to a single **binary** WebSocket frame
+(`"VUP1"` + version + type + raw Int16 PCM), routed past the 1 MiB JSON guard to a
+dedicated `MAX_VOICE_BINARY_FRAME_BYTES` bound (oversize -> 1009, bad header ->
+1003). The base64 `voice_upload` handler is kept as a thin shim over a shared
+`_processVoicePcm` core. See ADR-0026 for the full decision and the robustness
+changes (onclose code handling, heartbeat pause during recording, worker-side
+int16->float32 conversion, session-scoped rate limit, send-on-closed-socket
+fail-fast). 
+
+## How it was found
+
+A review across security, cross-platform, protocol, browser-audio, and QA
+dimensions over the *plan*:
+
+- The browser-audio review caught that the heartbeat theory was wrongly declared
+  "refuted" and that capture is partly main-thread.
+- The protocol review established the `wasClean === true` dead-end (the original
+  analysis assumed it fell into the reconnect path).
+- The QA review caught that STT is force-disabled under test
+  (`server.js` `underTest`), so success-path tests would false-green without a
+  ready-stub injection seam (`server.sttEngine` is reassigned in tests).
+- The cross-platform review flagged the ws `Buffer[]` fragmented-frame path as
+  the one genuine platform risk, now covered by a unit test.
+
+## Tests
+
+- `test/voice-frame.test.js` — pure units: client `buildVoiceFrame`,
+  `classifyVoiceClose`; server `normalizeBinaryMessage`/`classifyVoiceFrame`
+  (incl. the `Buffer[]` fragmented case); `pcm16ToFloat32`.
+- `test/voice-binary.test.js` — integration: a ~30 s binary frame transcribes and
+  the socket stays open (the case that crashed); oversize -> 1009; bad/short
+  header -> 1003; zero-PCM -> "too short" (open); odd-length -> "invalid" (open);
+  binary-path rate limit.
+- Regression kept green: `test/voice-integration.test.js` (base64 shim paths),
+  `test/longevity/event-loop/hot-03-ws-frame-size.test.js` (text 1 MiB guard),
+  `test/heartbeat-watchdog.test.js`.

--- a/docs/specs/server.md
+++ b/docs/specs/server.md
@@ -14,7 +14,7 @@ new ClaudeCodeWebServer(options)
 | `auth` | string | `undefined` | Bearer token for authentication; when set, all HTTP and WebSocket requests must provide it |
 | `noAuth` | boolean | `false` | Disable authentication entirely (`--disable-auth`) |
 | `dev` | boolean | `false` | Enable verbose console logging |
-| `https` | boolean | `false` | Start an HTTPS server instead of HTTP |
+| `https` | boolean | `false` | Start an HTTPS server instead of HTTP. Plaintext `http://` requests to the same port auto-upgrade (307) to `https://` (see below) |
 | `cert` | string | -- | Path to PEM certificate file (required when `https` is true) |
 | `key` | string | -- | Path to PEM private key file (required when `https` is true) |
 | `folderMode` | boolean | `true` | Enable folder-selection UI (defaults to true; always enabled in current CLI) |
@@ -190,6 +190,37 @@ Returns persistence metadata from `SessionStore.getSessionMetadata()`.
 
 #### `GET /`
 Serves `src/public/index.html`.
+
+---
+
+## HTTPS and HTTP→HTTPS auto-upgrade
+
+When `https` is enabled, the single listening port serves both TLS and a
+plaintext-HTTP redirect, so `http://host:PORT` and `https://host:PORT` both work
+(a user who reaches the port over plain HTTP is upgraded instead of getting an
+opaque TLS-handshake error).
+
+- The listening socket is a `net` server that **sniffs the first byte**: a TLS
+  ClientHello starts with `0x16`, so those connections are handed to the real
+  `https` app server; anything else is plaintext HTTP and is handed to a small
+  redirect server.
+- The redirect server answers **`307`** (method-preserving; not cached as
+  permanent, so switching the port back to plain-HTTP mode later isn't poisoned
+  by a stale `301`) with `Location: https://<host>:<port><url>`. A plaintext
+  `ws://` upgrade gets the same `307` written raw instead of an abrupt reset.
+- The redirect host comes from the client `Host` header but is **validated to a
+  bare `hostname[:port]` / `[ipv6][:port]`** (userinfo `@`, paths, and control
+  chars rejected) and falls back to `localhost` — preventing an open redirect to
+  an external origin via a forged `Host`.
+- The WebSocket server attaches to the inner TLS server, so a `wss://` upgrade
+  still arrives over an encrypted `TLSSocket` (`req.socket.encrypted` stays true
+  for the secure-context / voice checks).
+- Self-signed certs (no `cert`/`key` given) are generated/cached at
+  `~/.ai-or-die/certs/`; for a trusted, installable origin use `--tunnel`.
+
+`close()` destroys the proxied sockets and closes both inner servers (they
+receive connections via `emit('connection')`, which bypasses their own
+connection tracking).
 
 ---
 

--- a/docs/specs/voice-input.md
+++ b/docs/specs/voice-input.md
@@ -97,22 +97,50 @@ Downloads, caches, and validates the Parakeet V3 INT8 ONNX model:
 
 | Message | Direction | Payload | Description |
 |---------|-----------|---------|-------------|
-| `voice_upload` | Client -> Server | base64-encoded Int16 PCM (16kHz mono) | Audio data for transcription |
+| binary voice frame | Client -> Server | `VUP1` header + raw Int16 PCM | Primary local-mode audio path (see below) |
+| `voice_upload` | Client -> Server | `{ audio: base64 Int16 PCM }` | Legacy base64 shim, kept for back-compat |
 | `voice_transcription` | Server -> Client | `{ text }` | Transcription result |
-| `voice_transcription_error` | Server -> Client | `{ error }` | Transcription failure |
+| `voice_transcription_error` | Server -> Client | `{ message }` | Transcription failure |
 | `voice_model_progress` | Server -> Client | `{ progress, total, eta }` | Model download progress |
 | `voice_download_model` | Client -> Server | `{}` | Request to start model download |
 | `voice_status` | Server -> Client | `{ localStatus, cloudAvailable }` | STT engine availability |
 
 ### Binary Frame Protocol
 
-Local mode audio uses binary WebSocket frames with a `0x01` prefix byte followed by raw Int16 PCM data.
+Local-mode audio is sent as a single **binary** WebSocket frame (not base64-in-JSON —
+base64's 33% inflation pushed long clips past the 1 MiB JSON frame guard and crashed
+the page; see ADR-0026). Framing (`src/utils/ws-voice-frame.js`):
+
+```
+[ "VUP1" (4 bytes) ][ version=1 (1) ][ type=0x01 PCM (1) ][ raw Int16 PCM, 16 kHz mono ]
+```
+
+- PCM byte order is the browser `Int16Array`'s **native** endianness (little-endian on
+  every supported target).
+- The 6-byte header is even, so the PCM stays 2-byte aligned. The version/type bytes let
+  future inbound-binary features claim their own tag instead of forcing a wire break.
+- The server dispatcher routes inbound binary frames **before** the 1 MiB JSON guard and
+  normalizes ws `Buffer[]` (fragmented) frames before validating.
+- The int16->float32 conversion runs in the STT **worker thread**
+  (`sttEngine.transcribePcm16`), never on the event loop.
+- The legacy `voice_upload` JSON message still works (thin shim that decodes base64 and
+  shares the same validation/transcribe core); no current client emits it.
 
 ### Validation
 
-- **Buffer size limit**: Maximum 3,840,000 bytes (120s at 16kHz, 2 bytes per sample).
-- **Rate limiting**: 10 voice uploads per minute per session.
-- **Timeout**: 60 seconds per transcription request.
+- **Binary frame size**: oversize (> `6 + 3,840,000` bytes) -> `message_too_large` error +
+  WS close **1009**. Bad/short/unknown header -> WS close **1003** (`unsupported binary`).
+- **PCM size**: maximum 3,840,000 bytes (120 s at 16 kHz, 2 bytes/sample); too short (< 2)
+  or odd length -> `voice_transcription_error` (socket stays open).
+- **Rate limiting**: 10 voice uploads per minute per session (state on the session object,
+  GC'd with the session; checked before the readiness gate so it applies even when STT is
+  unavailable).
+- **Timeout**: 60 seconds per transcription request (server); 90 seconds client-side.
+- **Client robustness**: a close mid-transcription clears the mic spinner/timeout; a
+  server-initiated `1009`/`1003` (clean close) shows a specific toast and reconnects
+  instead of dead-ending; the heartbeat pong-timeout is suspended while recording (the
+  busy capture thread can briefly miss a pong); a send on a non-OPEN socket fails fast
+  instead of hanging the spinner.
 
 ---
 
@@ -229,12 +257,16 @@ The 670MB Parakeet V3 model is cached across CI runs via `actions/cache`.
 | File | Role |
 |------|------|
 | `src/utils/model-manager.js` | Download, cache, validate Parakeet V3 model |
-| `src/stt-worker.js` | Worker thread: load model, run inference |
-| `src/stt-engine.js` | Model + worker coordinator, concurrency queue |
+| `src/utils/pcm.js` | Pure int16->float32 conversion (worker + unit tests) |
+| `src/utils/ws-voice-frame.js` | Inbound binary frame normalize/classify (pure, unit-tested) |
+| `src/stt-worker.js` | Worker thread: load model, convert PCM, run inference |
+| `src/stt-engine.js` | Model + worker coordinator, concurrency queue, `transcribePcm16` |
 | `src/public/voice-handler.js` | Browser recording (cloud + local modes) |
 | `src/public/voice-processor.js` | AudioWorklet processor |
+| `src/public/voice-frame.js` | Client frame builder + close-code classifier (pure) |
+| `src/public/heartbeat-watchdog.js` | WS ping/pong liveness; `pause()`/`resume()` during recording |
 | `src/public/components/voice-input.css` | All voice UI states and animations |
-| `src/server.js` | WebSocket handlers, binary frames, STT init |
+| `src/server.js` | WebSocket handlers, binary frame dispatcher, STT init |
 | `src/utils/self-signed-cert.js` | Auto-generate and cache self-signed HTTPS certs |
-| `src/public/app.js` | Voice UI, mode selection, keyboard shortcuts |
+| `src/public/app.js` | Voice UI, `buildVoiceFrame`/`sendBinary`, onclose handling, keyboard shortcuts |
 | `bin/ai-or-die.js` | CLI flags (--stt, --stt-endpoint, etc.) |

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -1386,8 +1386,19 @@ class ClaudeCodeWebInterface {
 
         this.voiceController = new window.VoiceHandler.VoiceInputController({
             mode: this.voiceMode,
+            // Refuse a new recording while a previous transcription is still
+            // pending (single timeout slot + no correlation id — overlapping
+            // uploads would clobber each other's spinner/timeout).
+            canStart: function () {
+                return !self._voiceTranscriptionTimeout;
+            },
             onRecordingStart: function () {
                 self._playMicChime('on');
+                // Suspend the heartbeat pong-timeout while capturing: the main
+                // thread can be busy enough (esp. the ScriptProcessor fallback)
+                // to miss a pong, which would otherwise force a spurious reconnect.
+                self._voiceRecordingActive = true;
+                if (self._heartbeat) self._heartbeat.pause();
                 btn.classList.add('recording');
                 btn.classList.remove('processing');
                 btn.setAttribute('aria-pressed', 'true');
@@ -1415,6 +1426,8 @@ class ClaudeCodeWebInterface {
             },
             onRecordingStop: function (result) {
                 self._playMicChime('off');
+                self._voiceRecordingActive = false;
+                if (self._heartbeat) self._heartbeat.resume();
                 btn.classList.remove('recording');
                 btn.setAttribute('aria-pressed', 'false');
                 btn.title = 'Voice Input (Ctrl+Shift+M)';
@@ -1425,21 +1438,33 @@ class ClaudeCodeWebInterface {
                 }
 
                 if (self.voiceMode === 'local' && result && result.samples) {
-                    btn.classList.add('processing');
-                    // Convert Int16 PCM to base64 efficiently (chunked to avoid call stack overflow)
-                    var pcmBytes = new Uint8Array(result.samples.buffer);
-                    var CHUNK_SIZE = 8192;
-                    var parts = [];
-                    for (var i = 0; i < pcmBytes.length; i += CHUNK_SIZE) {
-                        var chunk = pcmBytes.subarray(i, Math.min(i + CHUNK_SIZE, pcmBytes.length));
-                        parts.push(String.fromCharCode.apply(null, chunk));
+                    // Guard against a zero-sample recording (would send a
+                    // header-only frame the server rejects as "too short").
+                    if (!result.samples.byteLength || result.samples.byteLength < 2) {
+                        btn.classList.remove('processing');
+                        if (window.feedback) window.feedback.error('No audio captured');
+                        return;
                     }
-                    var base64Audio = btoa(parts.join(''));
-                    self.send({
-                        type: 'voice_upload',
-                        audio: base64Audio,
-                        durationMs: result.durationMs
-                    });
+
+                    btn.classList.add('processing');
+
+                    // Send raw Int16 PCM as a tagged binary WS frame (no base64 —
+                    // base64's 33% inflation is what pushed long clips past the
+                    // 1 MiB frame guard and crashed the page).
+                    var frame = window.VoiceFrame.buildVoiceFrame(result.samples);
+                    var sent = self.sendBinary(frame);
+
+                    if (!sent) {
+                        // Socket not OPEN (e.g. mid-reconnect): fail fast instead of
+                        // silently dropping the frame and hanging the spinner 90 s.
+                        btn.classList.remove('processing');
+                        var notSentMsg = 'Connection not ready — recording not sent';
+                        if (window.feedback) window.feedback.error(notSentMsg);
+                        if (self.terminal) {
+                            self.terminal.write('\r\n\x1b[31m[Voice error] ' + notSentMsg + '\x1b[0m\r\n');
+                        }
+                        return;
+                    }
 
                     // Client-side timeout for transcription processing (90 seconds)
                     self._voiceTranscriptionTimeout = setTimeout(function () {
@@ -1467,6 +1492,8 @@ class ClaudeCodeWebInterface {
                 self._deliverVoiceTranscription(text);
             },
             onError: function (err) {
+                self._voiceRecordingActive = false;
+                if (self._heartbeat) self._heartbeat.resume();
                 btn.classList.remove('recording', 'processing');
                 btn.setAttribute('aria-pressed', 'false');
                 btn.title = 'Voice Input (Ctrl+Shift+M)';
@@ -1497,6 +1524,8 @@ class ClaudeCodeWebInterface {
                 }
             },
             onCancel: function () {
+                self._voiceRecordingActive = false;
+                if (self._heartbeat) self._heartbeat.resume();
                 btn.classList.remove('recording', 'processing');
                 btn.setAttribute('aria-pressed', 'false');
                 btn.title = 'Voice Input (Ctrl+Shift+M)';
@@ -2043,6 +2072,32 @@ class ClaudeCodeWebInterface {
                 if (this._heartbeat) { this._heartbeat.stop(); this._heartbeat = null; }
                 if (this._heartbeatTimer) { clearInterval(this._heartbeatTimer); this._heartbeatTimer = null; }
                 if (this._pongTimer) { clearTimeout(this._pongTimer); this._pongTimer = null; }
+
+                // A close mid-transcription must not leave the mic spinner + its
+                // 90 s timeout hanging.
+                if (this._voiceTranscriptionTimeout) {
+                    clearTimeout(this._voiceTranscriptionTimeout);
+                    this._voiceTranscriptionTimeout = null;
+                }
+                this._voiceRecordingActive = false;
+                const voiceBtn = document.getElementById('voiceInputBtn');
+                if (voiceBtn) voiceBtn.classList.remove('processing');
+
+                // Log the close code so field reports can tell a server frame
+                // rejection (1009/1003, at stop) from a heartbeat pong-timeout
+                // (4000, mid-recording).
+                console.warn('[ws] closed', event.code, event.reason || '');
+
+                // 1009/1003 are server-initiated CLEAN closes (wasClean=true): the
+                // server rejected our frame. Surface a specific message and still
+                // reconnect below, instead of dead-ending on "refresh the page".
+                const voiceClose = (window.VoiceFrame && window.VoiceFrame.classifyVoiceClose)
+                    ? window.VoiceFrame.classifyVoiceClose(event.code)
+                    : { rejected: false, message: null };
+                if (voiceClose.rejected && window.feedback) {
+                    window.feedback.error(voiceClose.message);
+                }
+
                 // During server restart, don't count failures against reconnect budget
                 // but still use backoff to avoid thundering herd
                 if (this._serverRestarting) {
@@ -2056,7 +2111,7 @@ class ClaudeCodeWebInterface {
                         if (restartGen !== this._socketGeneration) return;
                         this.reconnect();
                     }, restartBackoff);
-                } else if (!event.wasClean && this.reconnectAttempts < this.maxReconnectAttempts) {
+                } else if ((!event.wasClean || voiceClose.rejected) && this.reconnectAttempts < this.maxReconnectAttempts) {
                     this.updateStatus('Reconnecting (' + (this.reconnectAttempts + 1) + '/' + this.maxReconnectAttempts + ')...');
                     // First attempt is fast (250ms covers a server-process restart window);
                     // subsequent attempts use exponential backoff with jitter.
@@ -2172,6 +2227,17 @@ class ClaudeCodeWebInterface {
         if (this.socket && this.socket.readyState === WebSocket.OPEN) {
             this.socket.send(JSON.stringify(data));
         }
+    }
+
+    // Send a binary WS frame (e.g. a voice PCM frame). Returns true if it was
+    // handed to an OPEN socket, false otherwise so the caller can react to a
+    // closed/closing socket instead of silently dropping the frame.
+    sendBinary(view) {
+        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+            this.socket.send(view);
+            return true;
+        }
+        return false;
     }
 
     _handleStickyNoteUpdate(message) {
@@ -4368,6 +4434,9 @@ class ClaudeCodeWebInterface {
             log: (m) => console.warn('[heartbeat]', m),
         });
         this._heartbeat.start();
+        // If a recording is in progress (e.g. this heartbeat was re-created after
+        // a reconnect mid-recording), keep pong-timeout enforcement suspended.
+        if (this._voiceRecordingActive) this._heartbeat.pause();
         // Keep _heartbeatTimer/_pongTimer references in sync for legacy code
         // (disconnect() still nulls them defensively); the watchdog owns the
         // real timer lifecycle via stop().

--- a/src/public/heartbeat-watchdog.js
+++ b/src/public/heartbeat-watchdog.js
@@ -59,6 +59,10 @@
             this._clearTimeout = t.clearTimeout || ((id) => clearTimeout(id));
             this._heartbeatTimer = null;
             this._pongTimer = null;
+            // When paused (e.g. during mic recording), pings still go out but a
+            // missed pong does NOT force a reconnect — the client main thread can
+            // be busy capturing audio and briefly stop servicing the pong.
+            this._paused = false;
         }
 
         _isStale() {
@@ -75,6 +79,9 @@
             } catch (_) {
                 return;
             }
+            // Paused: keep liveness pings flowing but do NOT arm the pong-timeout
+            // (a missed pong while recording must not force-close the socket).
+            if (this._paused) return;
             if (this._pongTimer) this._clearTimeout(this._pongTimer);
             this._pongTimer = this._setTimeout(() => {
                 if (this._isStale()) return;
@@ -117,6 +124,24 @@
                 this._clearTimeout(this._pongTimer);
                 this._pongTimer = null;
             }
+        }
+
+        /**
+         * Suspend pong-timeout enforcement (pings continue). Use while the client
+         * main thread may be busy enough to miss a pong — e.g. mic recording —
+         * so a transient stall doesn't trigger a spurious reconnect.
+         */
+        pause() {
+            this._paused = true;
+            if (this._pongTimer) {
+                this._clearTimeout(this._pongTimer);
+                this._pongTimer = null;
+            }
+        }
+
+        /** Resume normal pong-timeout enforcement (next ping re-arms it). */
+        resume() {
+            this._paused = false;
         }
     }
 

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -801,6 +801,7 @@
     <script src="vscode-tunnel.js"></script>
     <script src="app-tunnel.js"></script>
     <script src="voice-handler.js"></script>
+    <script src="voice-frame.js"></script>
     <script src="command-palette.js"></script>
     <script src="extra-keys.js"></script>
     <script src="input-overlay.js"></script>

--- a/src/public/voice-frame.js
+++ b/src/public/voice-frame.js
@@ -1,0 +1,73 @@
+/**
+ * VoiceFrame
+ *
+ * Pure helpers for the client->server binary voice path, factored out of app.js
+ * so they can be unit-tested in Node. Mirrors the UMD shape of
+ * heartbeat-watchdog.js (CommonJS in tests, `window.VoiceFrame` in the browser).
+ */
+(function (global, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        global.VoiceFrame = factory();
+    }
+}(typeof self !== 'undefined' ? self : this, function () {
+
+    // Wire header: [ "VUP1" (4) ][ version (1) ][ type (1) ] then raw 16-bit PCM.
+    var MAGIC_V = 0x56; // 'V'
+    var MAGIC_U = 0x55; // 'U'
+    var MAGIC_P = 0x50; // 'P'
+    var MAGIC_1 = 0x31; // '1'
+    var PROTO_VERSION = 0x01;
+    var FRAME_TYPE_PCM = 0x01;
+    var HEADER_BYTES = 6;
+
+    /**
+     * Build a binary voice frame: the 6-byte header followed by the PCM bytes of
+     * `samples`. Uses byteOffset/byteLength so a subarray-backed Int16Array is
+     * copied correctly (not the whole underlying buffer).
+     *
+     * @param {Int16Array} samples
+     * @returns {Uint8Array}
+     */
+    function buildVoiceFrame(samples) {
+        var pcm = new Uint8Array(samples.buffer, samples.byteOffset, samples.byteLength);
+        var frame = new Uint8Array(HEADER_BYTES + pcm.length);
+        frame[0] = MAGIC_V;
+        frame[1] = MAGIC_U;
+        frame[2] = MAGIC_P;
+        frame[3] = MAGIC_1;
+        frame[4] = PROTO_VERSION;
+        frame[5] = FRAME_TYPE_PCM;
+        frame.set(pcm, HEADER_BYTES);
+        return frame;
+    }
+
+    /**
+     * Classify a WebSocket close code for the voice path.
+     *
+     * 1009 (server rejected an oversized frame) and 1003 (unsupported/garbage
+     * binary) are server-initiated CLEAN closes, so `event.wasClean` is true and
+     * the default onclose path would SKIP reconnect and dead-end on
+     * "refresh the page". Treat them as recoverable: show a specific message and
+     * still reconnect (bounded by the normal attempt budget).
+     *
+     * @param {number} code
+     * @returns {{rejected: boolean, message: (string|null)}}
+     */
+    function classifyVoiceClose(code) {
+        if (code === 1009 || code === 1003) {
+            return {
+                rejected: true,
+                message: 'A voice message was rejected by the server. Reconnecting…'
+            };
+        }
+        return { rejected: false, message: null };
+    }
+
+    return {
+        HEADER_BYTES: HEADER_BYTES,
+        buildVoiceFrame: buildVoiceFrame,
+        classifyVoiceClose: classifyVoiceClose
+    };
+}));

--- a/src/public/voice-handler.js
+++ b/src/public/voice-handler.js
@@ -625,6 +625,9 @@ function VoiceInputController(options) {
   this._onTranscription = options.onTranscription || null;
   this._onError = options.onError || null;
   this._onCancel = options.onCancel || null;
+  // Optional predicate: if it returns false, a start request is ignored (e.g.
+  // a previous transcription is still pending). Gates both button + keyboard.
+  this._canStart = options.canStart || null;
 
   this._recorder = null;
   this._starting = false;
@@ -670,6 +673,7 @@ VoiceInputController.prototype.startRecording = function () {
   var self = this;
   if (self._starting) return;
   if (self._recorder && self._recorder.isRecording) return;
+  if (self._canStart && !self._canStart()) return;
 
   self._starting = true;
   self._recorder = self._createRecorder();

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const http = require('http');
 const https = require('https');
+const net = require('net');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
@@ -3156,6 +3157,7 @@ class ClaudeCodeWebServer {
     this._ensureStickyNoteEngine();
 
     let server;
+    let wsHost; // the server the WebSocket server attaches to (TLS server in HTTPS mode)
 
     if (this.useHttps) {
       let cert, key;
@@ -3182,13 +3184,90 @@ class ClaudeCodeWebServer {
         console.log('        Browsers will show a security warning on first visit.');
         console.log('        For a trusted, installable origin use \x1b[1m--tunnel\x1b[0m.');
       }
-      server = https.createServer({ cert, key }, this.app);
+
+      // The real TLS app server. The WebSocket server attaches HERE so a wss://
+      // upgrade arrives over an encrypted TLSSocket (req.socket.encrypted stays
+      // true for the secure-context / voice checks).
+      const tlsServer = https.createServer({ cert, key }, this.app);
+
+      // Build the https redirect target from the SAME host:port the client
+      // reached. The Host header is client-controlled, so accept ONLY a bare
+      // hostname[:port] (or [ipv6][:port]) — reject userinfo (`@`), paths, and
+      // control chars to prevent an open redirect to an external origin
+      // (e.g. Host: user:pass@evil.com). Fall back to localhost otherwise.
+      const redirectLocation = (req) => {
+        const raw = String(req.headers.host || '');
+        const validHost = /^[A-Za-z0-9.-]+(?::\d+)?$/.test(raw)
+          || /^\[[0-9a-fA-F:]+\](?::\d+)?$/.test(raw);
+        const hostname = validHost ? raw.replace(/:\d+$/, '') : 'localhost';
+        const port = req.socket.localPort || this.port;
+        // req.url is parser-validated (no CR/LF in a valid request target).
+        return `https://${hostname}:${port}${req.url}`.replace(/[\r\n]/g, '');
+      };
+
+      // Plaintext HTTP on the SAME port -> redirect to https. A user who reaches
+      // http://host:PORT is auto-upgraded instead of getting an opaque
+      // TLS-handshake error. 307 keeps the method and is not cached as permanent
+      // (switching the port back to http mode later isn't poisoned by a stale 301).
+      const httpRedirectServer = http.createServer((req, res) => {
+        const location = redirectLocation(req);
+        res.writeHead(307, { Location: location, 'Content-Type': 'text/plain' });
+        res.end(`Redirecting to ${location}\n`);
+      });
+      // A plaintext ws:// upgrade to the TLS port: answer with the same redirect
+      // (written raw — an upgrade has no res object) instead of an abrupt RST.
+      httpRedirectServer.on('upgrade', (req, socket) => {
+        const location = redirectLocation(req);
+        try {
+          socket.end(
+            'HTTP/1.1 307 Temporary Redirect\r\n' +
+            `Location: ${location}\r\n` +
+            'Connection: close\r\n\r\n'
+          );
+        } catch (_) { try { socket.destroy(); } catch (__) { /* ignore */ } }
+      });
+
+      // Front both with a 1-byte sniffer: a TLS ClientHello starts with 0x16
+      // (handshake record); anything else is plaintext HTTP. One listening port
+      // therefore serves both — http:// and https:// to PORT both work.
+      this._proxySockets = new Set();
+      server = net.createServer((socket) => {
+        this._proxySockets.add(socket);
+        socket.once('close', () => this._proxySockets.delete(socket));
+        // Pre-handoff guards: drop a connection that errors or sends no data
+        // (port scanner / slowloris) before we know which server owns it. Both
+        // are cleared the moment we route, so the target server's own lifecycle
+        // and timeouts take over cleanly.
+        const sniffTimer = setTimeout(() => { try { socket.destroy(); } catch (_) { /* ignore */ } }, 10000);
+        const onSniffError = () => {
+          clearTimeout(sniffTimer);
+          try { socket.destroy(); } catch (_) { /* ignore */ }
+        };
+        socket.on('error', onSniffError);
+        socket.once('readable', () => {
+          clearTimeout(sniffTimer);
+          socket.removeListener('error', onSniffError);
+          const chunk = socket.read(1);
+          if (!chunk) { socket.destroy(); return; }
+          socket.unshift(chunk);
+          const target = chunk[0] === 0x16 ? tlsServer : httpRedirectServer;
+          target.emit('connection', socket);
+        });
+      });
+
+      this._tlsServer = tlsServer;
+      this._httpRedirectServer = httpRedirectServer;
+      wsHost = tlsServer;
+      console.log('        http:// requests on this port auto-upgrade to https.');
     } else {
       server = http.createServer(this.app);
+      this._tlsServer = null;
+      this._httpRedirectServer = null;
+      wsHost = server;
     }
 
     this.wss = new WebSocket.Server({
-      server,
+      server: wsHost,
       maxPayload: 8 * 1024 * 1024,
       // Compression disabled — binary frames already send with compress:false,
       // and JSON control messages are small/infrequent. Saves ~300KB per connection
@@ -5262,6 +5341,23 @@ class ClaudeCodeWebServer {
     }
     if (this.server) {
       this.server.close();
+    }
+    // In HTTPS mode `this.server` is the TLS-sniffing proxy that owns the
+    // listening port; the TLS app server and the http->https redirect server sit
+    // behind it. Sockets are handed to them via emit('connection'), bypassing
+    // their internal connection tracking, so destroy the proxied sockets here
+    // (and close the inner servers) to avoid keep-alive connections lingering.
+    if (this._proxySockets) {
+      for (const s of this._proxySockets) {
+        try { s.destroy(); } catch (_) { /* ignore */ }
+      }
+      this._proxySockets.clear();
+    }
+    if (this._tlsServer) {
+      try { this._tlsServer.close(); } catch (_) { /* ignore */ }
+    }
+    if (this._httpRedirectServer) {
+      try { this._httpRedirectServer.close(); } catch (_) { /* ignore */ }
     }
 
     // Flush pending output and stop all sessions with a 5-second timeout

--- a/src/server.js
+++ b/src/server.js
@@ -46,6 +46,18 @@ const RestartManager = require('./restart-manager');
 // See docs/audits/hot-03-ws-frame-size.md.
 const MAX_WS_MESSAGE_BYTES = 1 * 1024 * 1024;
 
+// Inbound binary voice frames (client mic -> server STT) bypass the JSON guard
+// above. Framing + validation (incl. the Buffer[] fragmented-frame normalize)
+// lives in utils/ws-voice-frame so it can be unit-tested without a live socket.
+// A frame is bounded by MAX_VOICE_BINARY_FRAME_BYTES (oversize -> 1009 close,
+// like the text guard); a bad/short header -> 1003 close.
+const {
+  MAX_VOICE_PCM_BYTES,
+  MAX_VOICE_BINARY_FRAME_BYTES,
+  normalizeBinaryMessage,
+  classifyVoiceFrame,
+} = require('./utils/ws-voice-frame');
+
 // Pre-built PWA screenshot SVG buffers (served at /screenshot-wide.png and /screenshot-narrow.png)
 const SCREENSHOT_WIDE_BUF = Buffer.from(`
   <svg width="1280" height="720" viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg">
@@ -148,8 +160,6 @@ class ClaudeCodeWebServer {
       modelsDir: options.sttModelDir,
       numThreads: options.sttThreads ? parseInt(options.sttThreads, 10) : undefined,
     });
-    this._voiceUploadCounts = new Map();
-
     // Per-tab local-LLM "sticky note" summariser. ON by default for AI-agent
     // tabs; disable globally with --no-sticky-notes / AIORDIE_DISABLE_STICKY_NOTES=1
     // (sticky-notes only — does NOT affect STT). The engine lazily downloads its
@@ -1318,11 +1328,6 @@ class ClaudeCodeWebServer {
       // (PR #99 regression) — kernel inotify-watch + FD exhaustion after
       // weeks of uptime. See _cleanupFsWatchSession.
       this._cleanupFsWatchSession(sessionId, 'session_deleted');
-
-      // Drop the voice-upload rate-limit history for this session. Map
-      // grew unbounded across session-create/delete churn on long-lived
-      // servers (smaller cousin of the _fsWatchSessions leak).
-      this._voiceUploadCounts.delete(sessionId);
 
       // Stop + tear down the summariser so an in-flight inference is discarded.
       this.stickyNoteSummarizer.cancel(sessionId);
@@ -3237,7 +3242,39 @@ class ClaudeCodeWebServer {
     };
     this.webSocketConnections.set(wsId, wsInfo);
 
-    ws.on('message', (message) => {
+    ws.on('message', (message, isBinary) => {
+      // Inbound BINARY frames are voice audio (client mic). Handle them BEFORE
+      // the JSON guard below: they legitimately exceed 1 MiB (up to 3.84 MB of
+      // 120 s PCM) and must not be killed by the text-frame guard. They are
+      // still bounded (oversize -> 1009; bad/short header -> 1003) so this does
+      // not reopen the event-loop-DoS hole the JSON guard closes.
+      if (isBinary) {
+        // ws delivers a Buffer when un-fragmented and a Buffer[] when the frame
+        // arrived in multiple WS continuation fragments. Normalize first, then
+        // classify on the normalized buffer (never on `message.length`, which is
+        // the fragment COUNT for an array).
+        const buf = normalizeBinaryMessage(message);
+        const verdict = classifyVoiceFrame(buf);
+        if (verdict.action === 'oversize') {
+          try {
+            this.sendToWebSocket(ws, {
+              type: 'error',
+              code: 'message_too_large',
+              message: `Binary voice frame exceeds ${MAX_VOICE_BINARY_FRAME_BYTES} bytes`,
+              received_bytes: buf.length,
+              limit_bytes: MAX_VOICE_BINARY_FRAME_BYTES,
+            });
+          } catch (_) { /* socket may be half-closed */ }
+          try { ws.close(1009, 'message_too_large'); } catch (_) {}
+          return;
+        }
+        if (verdict.action === 'unsupported') {
+          try { ws.close(1003, 'unsupported binary'); } catch (_) {}
+          return;
+        }
+        this.handleVoiceBinary(wsId, verdict.pcm);
+        return;
+      }
       // HOT-08: application-layer size guard, runs BEFORE JSON.parse.
       // Buffer.byteLength handles both string and Buffer message types.
       // On oversize, send a marker error frame and close with WS-standard
@@ -4677,11 +4714,11 @@ class ClaudeCodeWebServer {
         }
 
         // Same per-session cleanup contract as the DELETE handler:
-        // tear down any orphan fs-watch SSE + voice-upload history
-        // BEFORE removing the parent session entry, otherwise the
-        // chokidar watcher leaks (PR #99 regression).
+        // tear down any orphan fs-watch SSE BEFORE removing the parent session
+        // entry, otherwise the chokidar watcher leaks (PR #99 regression). The
+        // voice-upload rate-limit history lives on the session object and is
+        // dropped with it below.
         try { this._cleanupFsWatchSession(top.id, 'session_evicted'); } catch (_) { /* ignore */ }
-        try { this._voiceUploadCounts.delete(top.id); } catch (_) { /* ignore */ }
         try { this.stickyNoteSummarizer.cancel(top.id); } catch (_) { /* ignore */ }
         try { this._stickyJsonl.delete(top.id); } catch (_) { /* ignore */ }
         if (this._foregroundSessionId === top.id) this._foregroundSessionId = null;
@@ -4888,7 +4925,8 @@ class ClaudeCodeWebServer {
         total: this.claudeSessions.size,
         ws_connections: this.webSocketConnections.size,
         fs_watch_sessions: (this._fsWatchSessions && this._fsWatchSessions.size) || 0,
-        voice_upload_counts: (this._voiceUploadCounts && this._voiceUploadCounts.size) || 0,
+        voice_upload_counts: Array.from(this.claudeSessions.values())
+          .filter(s => s._voiceUploadTimestamps && s._voiceUploadTimestamps.length).length,
         activity_broadcast_timestamps: (this.activityBroadcastTimestamps && this.activityBroadcastTimestamps.size) || 0,
       },
       // DISK-02/03: cached disk usage sample (60 s TTL, never blocks the
@@ -5456,7 +5494,37 @@ class ClaudeCodeWebServer {
     }
   }
 
+  // Thin shim for the legacy base64-JSON voice_upload path. The 'Missing audio
+  // data' guard must live HERE (the binary path has no data.audio); after the
+  // binary-frame switch no live client emits this, but it is kept for
+  // back-compat and shares the validation/transcribe core below.
   async handleVoiceUpload(wsId, data) {
+    const wsInfo = this.webSocketConnections.get(wsId);
+    if (!wsInfo) return;
+
+    if (!data.audio || typeof data.audio !== 'string') {
+      this.sendToWebSocket(wsInfo.ws, {
+        type: 'voice_transcription_error',
+        message: 'Missing audio data'
+      });
+      return;
+    }
+
+    await this._processVoicePcm(wsId, Buffer.from(data.audio, 'base64'));
+  }
+
+  // Binary voice frame path. The ws dispatcher has already validated the 6-byte
+  // header and sliced it off, so `pcmBuffer` is raw 16-bit PCM.
+  async handleVoiceBinary(wsId, pcmBuffer) {
+    await this._processVoicePcm(wsId, pcmBuffer);
+  }
+
+  // Shared voice core for both the base64 shim and the binary path. Check order
+  // is cheapest/most-restrictive first; the rate limit stays BEFORE the isReady
+  // gate (so it is enforced even when STT is unavailable), and the int16->float32
+  // conversion is deferred to the STT worker (transcribePcm16) rather than run on
+  // the event loop here.
+  async _processVoicePcm(wsId, pcmBuffer) {
     const wsInfo = this.webSocketConnections.get(wsId);
     if (!wsInfo) return;
 
@@ -5494,23 +5562,21 @@ class ClaudeCodeWebServer {
       return;
     }
 
-    // Rate limit: max 10 voice uploads per minute per session (check early to prevent abuse)
-    const sessionId = wsInfo.claudeSessionId;
-    if (!this._voiceUploadCounts.has(sessionId)) {
-      this._voiceUploadCounts.set(sessionId, []);
-    }
-    const timestamps = this._voiceUploadCounts.get(sessionId);
+    // Rate limit: max 10 voice uploads per minute per session. State lives on the
+    // session object (mirrors image uploads at saveImageToTemp) so it shares the
+    // session's lifetime — GC'd on session delete/evict, and correctly survives a
+    // WS reconnect (the budget must NOT reset when the socket drops).
     const now = Date.now();
-    const recent = timestamps.filter(ts => now - ts < 60000);
-    this._voiceUploadCounts.set(sessionId, recent);
-    if (recent.length >= 10) {
+    if (!session._voiceUploadTimestamps) session._voiceUploadTimestamps = [];
+    session._voiceUploadTimestamps = session._voiceUploadTimestamps.filter(ts => now - ts < 60000);
+    if (session._voiceUploadTimestamps.length >= 10) {
       this.sendToWebSocket(wsInfo.ws, {
         type: 'voice_transcription_error',
         message: 'Rate limit exceeded: maximum 10 voice uploads per minute.'
       });
       return;
     }
-    recent.push(now);
+    session._voiceUploadTimestamps.push(now);
 
     if (!this.sttEngine.isReady()) {
       this.sendToWebSocket(wsInfo.ws, {
@@ -5521,19 +5587,8 @@ class ClaudeCodeWebServer {
     }
 
     try {
-      // Validate audio data
-      if (!data.audio || typeof data.audio !== 'string') {
-        this.sendToWebSocket(wsInfo.ws, {
-          type: 'voice_transcription_error',
-          message: 'Missing audio data'
-        });
-        return;
-      }
-
-      const audioBuffer = Buffer.from(data.audio, 'base64');
-
       // Max 120s of 16kHz 16-bit mono PCM = 3,840,000 bytes
-      if (audioBuffer.length > 3840000) {
+      if (pcmBuffer.length > MAX_VOICE_PCM_BYTES) {
         this.sendToWebSocket(wsInfo.ws, {
           type: 'voice_transcription_error',
           message: 'Audio too long (max 120 seconds)'
@@ -5541,7 +5596,7 @@ class ClaudeCodeWebServer {
         return;
       }
 
-      if (audioBuffer.length < 2) {
+      if (pcmBuffer.length < 2) {
         this.sendToWebSocket(wsInfo.ws, {
           type: 'voice_transcription_error',
           message: 'Audio too short'
@@ -5549,7 +5604,7 @@ class ClaudeCodeWebServer {
         return;
       }
 
-      if (audioBuffer.length % 2 !== 0) {
+      if (pcmBuffer.length % 2 !== 0) {
         this.sendToWebSocket(wsInfo.ws, {
           type: 'voice_transcription_error',
           message: 'Invalid audio data: buffer length must be even (16-bit PCM samples)'
@@ -5557,11 +5612,8 @@ class ClaudeCodeWebServer {
         return;
       }
 
-
-      // Convert Int16 PCM buffer to Float32Array for sherpa-onnx
-      const float32 = this._int16ToFloat32(audioBuffer);
-
-      const text = await this.sttEngine.transcribe(float32);
+      // Raw int16 PCM -> the worker converts to Float32 off the event loop.
+      const text = await this.sttEngine.transcribePcm16(pcmBuffer);
 
       this.sendToWebSocket(wsInfo.ws, {
         type: 'voice_transcription',
@@ -5650,17 +5702,6 @@ class ClaudeCodeWebServer {
         this.sendToWebSocket(wsInfo.ws, data);
       }
     }
-  }
-
-  _int16ToFloat32(int16Buffer) {
-    // Copy to ensure 2-byte alignment (Node.js Buffers may have odd byteOffset)
-    const aligned = new Uint8Array(int16Buffer).buffer;
-    const int16 = new Int16Array(aligned);
-    const float32 = new Float32Array(int16.length);
-    for (let i = 0; i < int16.length; i++) {
-      float32[i] = int16[i] / 32768.0;
-    }
-    return float32;
   }
 
   async saveImageToTemp(session, data) {

--- a/src/stt-engine.js
+++ b/src/stt-engine.js
@@ -93,6 +93,71 @@ class SttEngine {
     return promise;
   }
 
+  /**
+   * Transcribe raw 16-bit PCM. The int16->float32 conversion is deferred to the
+   * worker thread (see stt-worker.js) so the server event loop never runs the
+   * per-sample loop. Accepts an Int16Array, an ArrayBuffer, or any ArrayBuffer
+   * view (e.g. a Node Buffer) of raw little-endian 16-bit samples.
+   *
+   * @param {Int16Array|ArrayBuffer|ArrayBufferView} int16
+   * @returns {Promise<string>}
+   */
+  transcribePcm16(int16) {
+    const int16arr = this._toInt16Array(int16);
+
+    if (this._sttEndpoint) {
+      // External endpoint has no worker — convert here and reuse the float32 path.
+      const float32 = new Float32Array(int16arr.length);
+      for (let i = 0; i < int16arr.length; i++) {
+        float32[i] = int16arr[i] / 32768.0;
+      }
+      return this._transcribeExternal(float32);
+    }
+
+    if (this._status !== 'ready') {
+      throw new Error(`STT engine not ready (status: ${this._status})`);
+    }
+
+    if (this._queue.length >= MAX_QUEUE_SIZE) {
+      throw new Error('STT busy, try again later');
+    }
+
+    const id = ++this._requestIdCounter;
+
+    const promise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this._removeFromQueue(id);
+        reject(new Error('Transcription timed out'));
+      }, TRANSCRIPTION_TIMEOUT_MS);
+
+      this._queue.push({ id, pcm16: int16arr, resolve, reject, timer });
+    });
+
+    this._processQueue();
+    return promise;
+  }
+
+  // Copy an int16 input into a fresh, offset-0, even-length Int16Array. Always
+  // copies (even an Int16Array input) so the queued buffer is solely owned and
+  // can be safely TRANSFERRED to the worker. A Node Buffer slice can have an odd
+  // byteOffset (a direct `new Int16Array(buf.buffer, off)` would throw); an odd
+  // byteLength is floored to whole 16-bit samples — callers already reject odd
+  // lengths, this is defense-in-depth so the method never throws RangeError.
+  _toInt16Array(int16) {
+    let bytes;
+    if (int16 instanceof Int16Array || ArrayBuffer.isView(int16)) {
+      bytes = new Uint8Array(int16.buffer, int16.byteOffset, int16.byteLength);
+    } else if (int16 instanceof ArrayBuffer) {
+      bytes = new Uint8Array(int16);
+    } else {
+      throw new Error('transcribePcm16 expects an Int16Array, ArrayBuffer, or typed-array view');
+    }
+    const evenLen = bytes.byteLength - (bytes.byteLength % 2);
+    const copy = new Uint8Array(evenLen);
+    copy.set(bytes.subarray(0, evenLen));
+    return new Int16Array(copy.buffer);
+  }
+
   _processQueue() {
     if (this._currentRequest || this._queue.length === 0 || !this._worker) {
       return;
@@ -101,11 +166,23 @@ class SttEngine {
     const request = this._queue[0];
     this._currentRequest = request;
 
-    this._worker.postMessage({
-      type: 'transcribe',
-      id: request.id,
-      samples: request.samples
-    });
+    // pcm16 path: TRANSFER the (solely-owned, freshly-copied by _toInt16Array)
+    // buffer to the worker — avoids a multi-MB structured-clone copy on the event
+    // loop. Safe because each request is posted exactly once (on worker crash the
+    // queue is rejected + cleared, so a posted/detached buffer is never requeued).
+    if (request.pcm16 !== undefined) {
+      this._worker.postMessage({
+        type: 'transcribe',
+        id: request.id,
+        pcm16: request.pcm16
+      }, [request.pcm16.buffer]);
+    } else {
+      this._worker.postMessage({
+        type: 'transcribe',
+        id: request.id,
+        samples: request.samples
+      });
+    }
   }
 
   _onWorkerMessage(msg) {

--- a/src/stt-worker.js
+++ b/src/stt-worker.js
@@ -3,6 +3,7 @@
 const { parentPort, workerData } = require('worker_threads');
 const path = require('path');
 const os = require('os');
+const { pcm16ToFloat32 } = require('./utils/pcm.js');
 
 // Set platform-specific library paths BEFORE requiring sherpa-onnx-node.
 // The native .node addon dynamically loads shared libraries (onnxruntime.dll,
@@ -74,10 +75,22 @@ try {
 parentPort.on('message', (msg) => {
   if (msg.type === 'transcribe') {
     try {
-      // msg.samples is a Float32Array (transferred or copied from main thread)
-      const samples = msg.samples instanceof Float32Array
-        ? msg.samples
-        : new Float32Array(msg.samples);
+      // Two input shapes:
+      //  - msg.pcm16: raw 16-bit PCM (Int16Array). Conversion to Float32 runs
+      //    HERE, in the worker thread, so the server event loop never does the
+      //    per-sample loop (HOL-blocking input/ping for long clips).
+      //  - msg.samples: a Float32Array (legacy / external-endpoint callers).
+      let samples;
+      if (msg.pcm16 !== undefined && msg.pcm16 !== null) {
+        const int16 = msg.pcm16 instanceof Int16Array
+          ? msg.pcm16
+          : new Int16Array(msg.pcm16);
+        samples = pcm16ToFloat32(int16);
+      } else {
+        samples = msg.samples instanceof Float32Array
+          ? msg.samples
+          : new Float32Array(msg.samples);
+      }
 
       const stream = recognizer.createStream();
       stream.acceptWaveform({ samples, sampleRate: 16000 });

--- a/src/utils/pcm.js
+++ b/src/utils/pcm.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Convert 16-bit PCM samples to normalized Float32 [-1, 1).
+ *
+ * Divisor is 32768.0 for every sample (matching the original server-side
+ * conversion): positive full-scale 32767 maps to ~0.99997, negative full-scale
+ * -32768 maps to exactly -1.0. Used by the STT worker (off the server event
+ * loop) and exercised directly in unit tests.
+ *
+ * @param {Int16Array} int16
+ * @returns {Float32Array}
+ */
+function pcm16ToFloat32(int16) {
+  const out = new Float32Array(int16.length);
+  for (let i = 0; i < int16.length; i++) {
+    out[i] = int16[i] / 32768.0;
+  }
+  return out;
+}
+
+module.exports = { pcm16ToFloat32 };

--- a/src/utils/ws-voice-frame.js
+++ b/src/utils/ws-voice-frame.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/**
+ * Inbound binary voice-frame framing (client mic -> server STT).
+ *
+ * Wire format:
+ *   [4 bytes ASCII "VUP1"][1 byte version][1 byte type][raw 16-bit PCM @16kHz mono]
+ *
+ * Pure (no I/O) so the dispatcher logic in server.js can be unit-tested without
+ * a live socket — in particular the Buffer[] (fragmented frame) normalization,
+ * which is the one genuinely platform-dependent receive path.
+ */
+
+const VOICE_MAGIC = Buffer.from('VUP1', 'ascii');
+const VOICE_PROTO_VERSION = 1;
+const VOICE_FRAME_TYPE_PCM = 0x01;
+const VOICE_HEADER_BYTES = 6; // magic(4) + version(1) + type(1)
+const MAX_VOICE_PCM_BYTES = 3840000; // 120 s @ 16 kHz / 16-bit / mono
+const MAX_VOICE_BINARY_FRAME_BYTES = VOICE_HEADER_BYTES + MAX_VOICE_PCM_BYTES;
+
+/**
+ * Normalize ws RawData to a single Buffer. ws delivers a Buffer when the frame
+ * is un-fragmented, a Buffer[] when it arrived in multiple WS continuation
+ * fragments (1-4 MB voice frames fragment variably across browsers/proxies/
+ * tunnels), or an ArrayBuffer under non-default options. Always size-check the
+ * RESULT of this, never the raw message (whose `.length` is the fragment count
+ * for an array).
+ *
+ * The concatenation is bounded: the ws server's `maxPayload` (8 MiB) caps the
+ * total message length during fragment reassembly and closes 1009 before the
+ * 'message' event fires, so this never concatenates more than 8 MiB.
+ *
+ * @param {Buffer|Buffer[]|ArrayBuffer|ArrayBufferView} message
+ * @returns {Buffer}
+ */
+function normalizeBinaryMessage(message) {
+  if (Buffer.isBuffer(message)) return message;
+  if (Array.isArray(message)) return Buffer.concat(message);
+  return Buffer.from(message);
+}
+
+/**
+ * Classify a normalized binary frame.
+ *  - { action: 'oversize' }    -> caller closes 1009 (message too big)
+ *  - { action: 'unsupported' } -> caller closes 1003 (bad/short/unknown header)
+ *  - { action: 'pcm', pcm }    -> caller hands `pcm` (Buffer) to the STT core
+ *
+ * @param {Buffer} buf  Normalized frame (see normalizeBinaryMessage).
+ * @returns {{action: string, pcm?: Buffer}}
+ */
+function classifyVoiceFrame(buf) {
+  if (buf.length > MAX_VOICE_BINARY_FRAME_BYTES) {
+    return { action: 'oversize' };
+  }
+  if (buf.length < VOICE_HEADER_BYTES
+    || !buf.subarray(0, 4).equals(VOICE_MAGIC)
+    || buf[4] !== VOICE_PROTO_VERSION
+    || buf[5] !== VOICE_FRAME_TYPE_PCM) {
+    return { action: 'unsupported' };
+  }
+  return { action: 'pcm', pcm: buf.subarray(VOICE_HEADER_BYTES) };
+}
+
+module.exports = {
+  VOICE_MAGIC,
+  VOICE_PROTO_VERSION,
+  VOICE_FRAME_TYPE_PCM,
+  VOICE_HEADER_BYTES,
+  MAX_VOICE_PCM_BYTES,
+  MAX_VOICE_BINARY_FRAME_BYTES,
+  normalizeBinaryMessage,
+  classifyVoiceFrame,
+};

--- a/test/fs-watch-cleanup.test.js
+++ b/test/fs-watch-cleanup.test.js
@@ -12,7 +12,7 @@
 // Tests:
 //   1. DELETE /api/sessions/:id cleans up the watcher entry.
 //   2. _cleanupFsWatchSession is idempotent.
-//   3. _voiceUploadCounts.delete fires on DELETE.
+//   3. Session voice rate-limit state (session._voiceUploadTimestamps) drops on DELETE.
 //   4. server.close() cleans up all live watchers.
 //   5. Eviction-sweep path cleans up the watcher entry.
 //   6. Race guard: opening a watcher for a non-existent sessionId bails
@@ -272,25 +272,26 @@ function openSseAndWaitForStart(port, sessionId, watchRoot, timeoutMs) {
   });
 
   // ───────────────────────────────────────────────────────────────────
-  // Test 3: _voiceUploadCounts also drops on DELETE
+  // Test 3: voice rate-limit state drops on DELETE
+  //
+  // The history now lives on the session object (session._voiceUploadTimestamps),
+  // so removing the session on delete drops it — no separate Map to leak.
   // ───────────────────────────────────────────────────────────────────
-  it('DELETE /api/sessions/:id clears _voiceUploadCounts (smaller cousin leak)', async function () {
+  it('DELETE /api/sessions/:id drops the session voice rate-limit state (smaller cousin leak)', async function () {
     const created = await request(port, 'POST', '/api/sessions/create', {
       name: 'voice-test', workingDir: tmpDir,
     });
     const sessionId = created.body.sessionId;
 
-    // Populate the voice-upload bucket directly (the rate-limiter helper
-    // is internal; we just need the Map entry).
-    server._voiceUploadCounts.set(sessionId, [Date.now(), Date.now()]);
-    assert.strictEqual(server._voiceUploadCounts.has(sessionId), true,
-      'pre-condition: voice bucket present');
+    const session = server.claudeSessions.get(sessionId);
+    assert.ok(session, 'pre-condition: session exists');
+    session._voiceUploadTimestamps = [Date.now(), Date.now()];
 
     const del = await request(port, 'DELETE', '/api/sessions/' + sessionId);
     assert.strictEqual(del.status, 200);
 
-    assert.strictEqual(server._voiceUploadCounts.has(sessionId), false,
-      '_voiceUploadCounts must be cleared on session delete');
+    assert.strictEqual(server.claudeSessions.has(sessionId), false,
+      'session (and its voice rate-limit state) must be dropped on delete');
   });
 
   // ───────────────────────────────────────────────────────────────────
@@ -353,32 +354,31 @@ function openSseAndWaitForStart(port, sessionId, watchRoot, timeoutMs) {
   //
   // The 7-day eviction timer fires every 5 min — too slow for a test.
   // Inline the same cleanup contract the timer body uses (verifying the
-  // load-bearing call: _cleanupFsWatchSession + _voiceUploadCounts.delete
-  // BEFORE claudeSessions.delete).
+  // load-bearing call: _cleanupFsWatchSession BEFORE claudeSessions.delete;
+  // the voice rate-limit state rides on the session object and is dropped with
+  // it).
   // ───────────────────────────────────────────────────────────────────
-  it('eviction-equivalent cleanup also closes the watcher + clears voice map', async function () {
+  it('eviction-equivalent cleanup also closes the watcher + drops the session', async function () {
     const created = await request(port, 'POST', '/api/sessions/create', {
       name: 'evict-test', workingDir: tmpDir,
     });
     const sessionId = created.body.sessionId;
     const sse = await openSseAndWaitForStart(port, sessionId, tmpDir);
     assert.strictEqual(sse.status, 200);
-    server._voiceUploadCounts.set(sessionId, [Date.now()]);
+    const evSession = server.claudeSessions.get(sessionId);
+    if (evSession) evSession._voiceUploadTimestamps = [Date.now()];
 
     const watcherRef = server._fsWatchSessions.get(sessionId).watcher;
     assert.strictEqual(watcherRef._isClosed, false);
 
     // Simulate the timer body — the same cleanup contract DELETE uses.
     server._cleanupFsWatchSession(sessionId, 'session_evicted');
-    server._voiceUploadCounts.delete(sessionId);
     server.claudeSessions.delete(sessionId);
 
     assert.strictEqual(server._fsWatchSessions.has(sessionId), false,
       'eviction cleanup must drop the fs-watch entry');
-    assert.strictEqual(server._voiceUploadCounts.has(sessionId), false,
-      'eviction cleanup must drop the voice-upload bucket');
     assert.strictEqual(server.claudeSessions.has(sessionId), false,
-      'eviction cleanup must drop the session itself');
+      'eviction cleanup must drop the session itself (and its voice rate-limit state)');
 
     await new Promise((r) => setTimeout(r, 50));
     assert.strictEqual(watcherRef._isClosed, true,

--- a/test/https-upgrade.test.js
+++ b/test/https-upgrade.test.js
@@ -1,0 +1,152 @@
+'use strict';
+
+// HTTPS auto-upgrade: when the server runs with --https, the single listening
+// port serves TLS normally AND redirects plaintext HTTP requests to https (so a
+// user who reaches http://host:PORT is upgraded instead of getting an opaque
+// TLS-handshake error). Verified end to end: plaintext HTTP -> 307, real HTTPS
+// still works, and wss:// upgrades still complete through the sniffer.
+
+const assert = require('assert');
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const WebSocket = require('ws');
+const selfsigned = require('selfsigned');
+const { ClaudeCodeWebServer } = require('../src/server');
+
+function httpGet(opts) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(opts, (res) => {
+      let body = '';
+      res.on('data', (c) => { body += c; });
+      res.on('end', () => resolve({ statusCode: res.statusCode, headers: res.headers, body }));
+    });
+    req.on('error', reject);
+    req.setTimeout(5000, () => req.destroy(new Error('http timeout')));
+  });
+}
+
+// http GET with an explicit (possibly hostile) Host header.
+function httpGetWithHost(hostHeader, port) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path: '/', method: 'GET', headers: { Host: hostHeader } },
+      (res) => {
+        res.resume();
+        resolve({ statusCode: res.statusCode, headers: res.headers });
+      }
+    );
+    req.on('error', reject);
+    req.setTimeout(5000, () => req.destroy(new Error('http timeout')));
+    req.end();
+  });
+}
+
+function httpsGet(opts) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(Object.assign({ rejectUnauthorized: false }, opts), (res) => {
+      let body = '';
+      res.on('data', (c) => { body += c; });
+      res.on('end', () => resolve({ statusCode: res.statusCode, headers: res.headers, body }));
+    });
+    req.on('error', reject);
+    req.setTimeout(5000, () => req.destroy(new Error('https timeout')));
+  });
+}
+
+describe('https auto-upgrade: http on the tls port redirects to https', function () {
+  this.timeout(30000);
+
+  let server;
+  let port;
+  let tmpDir;
+  let certPath;
+  let keyPath;
+
+  before(async function () {
+    // Throwaway self-signed cert written to a temp dir (NOT ~/.ai-or-die) so the
+    // test never touches the user's real cert cache.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'https-upgrade-'));
+    const pems = selfsigned.generate(
+      [{ name: 'commonName', value: 'test-localhost' }],
+      {
+        keySize: 2048,
+        days: 1,
+        algorithm: 'sha256',
+        extensions: [{
+          name: 'subjectAltName',
+          altNames: [{ type: 2, value: 'localhost' }, { type: 7, ip: '127.0.0.1' }],
+        }],
+      }
+    );
+    certPath = path.join(tmpDir, 'test.cert');
+    keyPath = path.join(tmpDir, 'test.key');
+    fs.writeFileSync(certPath, pems.cert);
+    fs.writeFileSync(keyPath, pems.private);
+
+    server = new ClaudeCodeWebServer({
+      port: 0,
+      noAuth: true,
+      https: true,
+      cert: certPath,
+      key: keyPath,
+    });
+    const httpServer = await server.start();
+    port = httpServer.address().port;
+  });
+
+  after(function () {
+    try { server.close(); } catch (_) { /* ignore */ }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+  });
+
+  it('redirects a plaintext HTTP request to https on the same port (307)', async function () {
+    const res = await httpGet({ host: '127.0.0.1', port, path: '/api/config' });
+    assert.strictEqual(res.statusCode, 307, `expected 307, got ${res.statusCode}`);
+    assert.strictEqual(
+      res.headers.location,
+      `https://127.0.0.1:${port}/api/config`,
+      `unexpected Location: ${res.headers.location}`
+    );
+  });
+
+  it('preserves the request path + query in the redirect', async function () {
+    const res = await httpGet({ host: '127.0.0.1', port, path: '/foo/bar?x=1&y=2' });
+    assert.strictEqual(res.statusCode, 307);
+    assert.strictEqual(res.headers.location, `https://127.0.0.1:${port}/foo/bar?x=1&y=2`);
+  });
+
+  it('does not honor a hostile Host header (no open redirect)', async function () {
+    const res = await httpGetWithHost('user:pass@evil.com', port);
+    assert.strictEqual(res.statusCode, 307);
+    assert.ok(!/evil\.com/.test(res.headers.location || ''),
+      `open redirect leaked off-origin: ${res.headers.location}`);
+    assert.ok((res.headers.location || '').startsWith(`https://localhost:${port}`),
+      `expected localhost fallback, got: ${res.headers.location}`);
+  });
+
+  it('still serves real HTTPS on the same port', async function () {
+    const res = await httpsGet({ host: '127.0.0.1', port, path: '/api/config' });
+    assert.strictEqual(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert(body.voiceInput, 'expected a real config response over TLS');
+  });
+
+  it('still completes a wss:// WebSocket upgrade over TLS', async function () {
+    const ws = new WebSocket(`wss://127.0.0.1:${port}/`, { rejectUnauthorized: false });
+    const connected = await new Promise((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('wss connect timeout')), 5000);
+      ws.on('open', () => {
+        ws.once('message', (raw) => {
+          clearTimeout(t);
+          try { resolve(JSON.parse(raw.toString())); } catch (e) { reject(e); }
+        });
+      });
+      ws.on('error', (e) => { clearTimeout(t); reject(e); });
+    });
+    assert.strictEqual(connected.type, 'connected', 'expected the connected frame over wss');
+    ws.close();
+  });
+});

--- a/test/longevity/process/eviction-sublinear.test.js
+++ b/test/longevity/process/eviction-sublinear.test.js
@@ -78,8 +78,9 @@ function injectSessions(server, count, lastActivityMs, opts) {
   before(async function () {
     // Construct an in-process server without binding a port. We never call
     // .start() — eviction is a pure-in-memory algorithm that touches
-    // `claudeSessions`, `_evictionHeap`, `_voiceUploadCounts`,
-    // `activityBroadcastTimestamps`, `_fsWatchSessions`, and `sessionStore`.
+    // `claudeSessions` (which carries per-session voice rate-limit state),
+    // `_evictionHeap`, `activityBroadcastTimestamps`, `_fsWatchSessions`, and
+    // `sessionStore`.
     // Isolated session-store dir so the test doesn't clobber
     // ~/.ai-or-die/sessions.json on the host.
     const raw = fs.mkdtempSync(path.join(os.tmpdir(), 'proc-04-eviction-'));

--- a/test/voice-binary.test.js
+++ b/test/voice-binary.test.js
@@ -1,0 +1,210 @@
+'use strict';
+
+// Integration tests for the binary voice-frame path (client mic -> server STT).
+// The success-path cases need a "ready" STT engine, but STT is force-disabled
+// under test (server.js underTest), so we swap server.sttEngine for a ready stub
+// after start() — the injection seam. Close-code cases (1009/1003) fire in the
+// ws dispatcher BEFORE any session/STT logic, so they need neither.
+
+const assert = require('assert');
+const WebSocket = require('ws');
+const { ClaudeCodeWebServer } = require('../src/server');
+const {
+  MAX_VOICE_BINARY_FRAME_BYTES,
+} = require('../src/utils/ws-voice-frame');
+
+const VOICE_HEADER = Buffer.from([0x56, 0x55, 0x50, 0x31, 0x01, 0x01]); // "VUP1" v1 type1
+
+function buildFrame(pcm) {
+  return Buffer.concat([VOICE_HEADER, pcm]);
+}
+
+function wsSend(ws, data) {
+  ws.send(JSON.stringify(data));
+}
+
+function connectWs(port) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+    const timer = setTimeout(() => { ws.terminate(); reject(new Error('connect timeout')); }, 5000);
+    ws.on('open', () => {
+      ws.once('message', (raw) => {
+        clearTimeout(timer);
+        const msg = JSON.parse(raw.toString());
+        if (msg.type === 'connected') resolve(ws);
+        else reject(new Error(`expected connected, got ${msg.type}`));
+      });
+    });
+    ws.on('error', (err) => { clearTimeout(timer); reject(err); });
+  });
+}
+
+function waitForMessage(ws, type, timeoutMs = 8000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { cleanup(); reject(new Error(`timeout waiting for ${type}`)); }, timeoutMs);
+    function onMessage(raw, isBinary) {
+      if (isBinary) return;
+      let msg;
+      try { msg = JSON.parse(raw.toString()); } catch (_) { return; }
+      if (msg.type === type) { cleanup(); resolve(msg); }
+    }
+    function onClose() { cleanup(); reject(new Error(`closed while waiting for ${type}`)); }
+    function cleanup() {
+      clearTimeout(timer);
+      ws.removeListener('message', onMessage);
+      ws.removeListener('close', onClose);
+    }
+    ws.on('message', onMessage);
+    ws.on('close', onClose);
+  });
+}
+
+// Resolve with the WS close code; register the listener BEFORE sending so the
+// close can never be missed (avoids the close-vs-message ordering race).
+function expectClose(ws, frame, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('no close within timeout')), timeoutMs);
+    ws.once('close', (code) => { clearTimeout(timer); resolve(code); });
+    ws.send(frame);
+  });
+}
+
+async function setupActiveSession(ws) {
+  wsSend(ws, { type: 'create_session', name: 'Voice Binary' });
+  await waitForMessage(ws, 'session_created');
+  wsSend(ws, { type: 'start_terminal' });
+  await waitForMessage(ws, 'terminal_started', 15000);
+}
+
+function closeWs(ws) {
+  return new Promise((resolve) => {
+    if (!ws || ws.readyState === WebSocket.CLOSED) return resolve();
+    ws.on('close', () => resolve());
+    try { ws.close(); } catch (_) {}
+    setTimeout(() => { try { ws.terminate(); } catch (_) {} resolve(); }, 2000);
+  });
+}
+
+describe('voice-binary: inbound binary voice frame', function () {
+  this.timeout(30000);
+
+  let server;
+  let port;
+
+  before(async function () {
+    server = new ClaudeCodeWebServer({ port: 0, noAuth: true });
+    const httpServer = await server.start();
+    port = httpServer.address().port;
+    // Injection seam: a ready STT stub so the success paths are reachable.
+    server.sttEngine = {
+      isReady: () => true,
+      getStatus: () => 'ready',
+      transcribePcm16: async () => 'ok-binary',
+      transcribe: async () => 'ok-binary',
+    };
+  });
+
+  after(function () {
+    server.close();
+  });
+
+  it('transcribes a ~30 s binary frame and keeps the socket open (the case that crashed)', async function () {
+    const ws = await connectWs(port);
+    await setupActiveSession(ws);
+
+    const pcm = Buffer.alloc(30 * 16000 * 2); // 30 s @ 16 kHz / 16-bit = 960,000 bytes
+    ws.send(buildFrame(pcm));
+
+    const msg = await waitForMessage(ws, 'voice_transcription');
+    assert.strictEqual(msg.text, 'ok-binary');
+    assert.strictEqual(ws.readyState, WebSocket.OPEN, 'socket must stay open');
+
+    wsSend(ws, { type: 'stop' });
+    await waitForMessage(ws, 'terminal_stopped', 10000).catch(() => {});
+    await closeWs(ws);
+  });
+
+  it('closes 1009 on an over-size binary frame', async function () {
+    const ws = await connectWs(port);
+    const frame = Buffer.alloc(MAX_VOICE_BINARY_FRAME_BYTES + 1);
+    VOICE_HEADER.copy(frame, 0);
+    const code = await expectClose(ws, frame);
+    assert.strictEqual(code, 1009);
+    await closeWs(ws);
+  });
+
+  it('closes 1003 on a bad-magic binary frame', async function () {
+    const ws = await connectWs(port);
+    const frame = Buffer.concat([Buffer.from([0x58, 0x58, 0x58, 0x58, 1, 1]), Buffer.from([0, 0])]);
+    const code = await expectClose(ws, frame);
+    assert.strictEqual(code, 1003);
+    await closeWs(ws);
+  });
+
+  it('closes 1003 on a too-short binary frame (< 6 bytes)', async function () {
+    const ws = await connectWs(port);
+    const code = await expectClose(ws, Buffer.from([0x56, 0x55, 0x50, 0x31]));
+    assert.strictEqual(code, 1003);
+    await closeWs(ws);
+  });
+
+  it('returns "too short" (socket open) for a valid header with zero PCM', async function () {
+    const ws = await connectWs(port);
+    await setupActiveSession(ws);
+
+    ws.send(buildFrame(Buffer.alloc(0)));
+
+    const err = await waitForMessage(ws, 'voice_transcription_error');
+    assert.ok(/too short/i.test(err.message), `got: ${err.message}`);
+    assert.strictEqual(ws.readyState, WebSocket.OPEN);
+
+    wsSend(ws, { type: 'stop' });
+    await waitForMessage(ws, 'terminal_stopped', 10000).catch(() => {});
+    await closeWs(ws);
+  });
+
+  it('returns "invalid" (socket open) for odd-length PCM', async function () {
+    const ws = await connectWs(port);
+    await setupActiveSession(ws);
+
+    ws.send(buildFrame(Buffer.from([1, 2, 3]))); // 3 bytes = odd
+
+    const err = await waitForMessage(ws, 'voice_transcription_error');
+    assert.ok(/even|invalid/i.test(err.message), `got: ${err.message}`);
+    assert.strictEqual(ws.readyState, WebSocket.OPEN);
+
+    wsSend(ws, { type: 'stop' });
+    await waitForMessage(ws, 'terminal_stopped', 10000).catch(() => {});
+    await closeWs(ws);
+  });
+
+  it('rate-limits the binary path (11th upload errors on an OPEN socket)', async function () {
+    const ws = await connectWs(port);
+    await setupActiveSession(ws);
+
+    const pcm = Buffer.alloc(0.5 * 16000 * 2); // 0.5 s
+    let rateLimited = false;
+    const onMsg = (raw, isBinary) => {
+      if (isBinary) return;
+      try {
+        const m = JSON.parse(raw.toString());
+        if (m.type === 'voice_transcription_error' && /Rate limit/i.test(m.message)) rateLimited = true;
+      } catch (_) { /* ignore */ }
+    };
+    ws.on('message', onMsg);
+
+    for (let i = 0; i < 11; i++) {
+      ws.send(buildFrame(pcm));
+      await new Promise((r) => setTimeout(r, 40));
+    }
+    await new Promise((r) => setTimeout(r, 1500));
+    ws.removeListener('message', onMsg);
+
+    assert.ok(rateLimited, 'expected a Rate limit error on the 11th binary upload');
+    assert.strictEqual(ws.readyState, WebSocket.OPEN, 'rate limit must not close the socket');
+
+    wsSend(ws, { type: 'stop' });
+    await waitForMessage(ws, 'terminal_stopped', 10000).catch(() => {});
+    await closeWs(ws);
+  });
+});

--- a/test/voice-frame.test.js
+++ b/test/voice-frame.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+// Pure-function unit tests for the binary voice path. No server / socket — these
+// cover the client frame builder, the close-code classifier, the server-side
+// frame normalize/classify (incl. the Buffer[] fragmented-frame path), and the
+// int16->float32 conversion.
+
+const assert = require('assert');
+const VoiceFrame = require('../src/public/voice-frame.js');
+const {
+  normalizeBinaryMessage,
+  classifyVoiceFrame,
+  VOICE_MAGIC,
+  MAX_VOICE_BINARY_FRAME_BYTES,
+  MAX_VOICE_PCM_BYTES,
+} = require('../src/utils/ws-voice-frame.js');
+const { pcm16ToFloat32 } = require('../src/utils/pcm.js');
+
+function header() {
+  // "VUP1" + version 1 + type 1
+  return Buffer.from([0x56, 0x55, 0x50, 0x31, 0x01, 0x01]);
+}
+
+describe('voice-frame: client buildVoiceFrame', function () {
+  it('prepends the 6-byte VUP1 header and the PCM bytes', function () {
+    const samples = new Int16Array([1, -1, 32767, -32768]);
+    const frame = VoiceFrame.buildVoiceFrame(samples);
+
+    assert.strictEqual(frame.length, 6 + samples.byteLength);
+    assert.deepStrictEqual(
+      Array.from(frame.subarray(0, 6)),
+      [0x56, 0x55, 0x50, 0x31, 0x01, 0x01]
+    );
+    // PCM bytes match the samples' raw little-endian bytes.
+    const expected = new Uint8Array(samples.buffer);
+    assert.deepStrictEqual(Array.from(frame.subarray(6)), Array.from(expected));
+  });
+
+  it('copies a subarray-backed Int16Array correctly (nonzero byteOffset)', function () {
+    const big = new Int16Array([9, 9, 1, 2, 3, 9]);
+    const sub = big.subarray(2, 5); // [1, 2, 3], byteOffset = 4
+    assert.strictEqual(sub.byteOffset, 4);
+
+    const frame = VoiceFrame.buildVoiceFrame(sub);
+    assert.strictEqual(frame.length, 6 + 6); // 3 samples * 2 bytes
+    const expected = new Uint8Array(new Int16Array([1, 2, 3]).buffer);
+    assert.deepStrictEqual(Array.from(frame.subarray(6)), Array.from(expected));
+  });
+});
+
+describe('voice-frame: client classifyVoiceClose', function () {
+  it('flags 1009 and 1003 as recoverable server rejections', function () {
+    assert.strictEqual(VoiceFrame.classifyVoiceClose(1009).rejected, true);
+    assert.strictEqual(VoiceFrame.classifyVoiceClose(1003).rejected, true);
+    assert.strictEqual(typeof VoiceFrame.classifyVoiceClose(1009).message, 'string');
+  });
+
+  it('does not flag normal/abnormal network closes', function () {
+    assert.strictEqual(VoiceFrame.classifyVoiceClose(1000).rejected, false);
+    assert.strictEqual(VoiceFrame.classifyVoiceClose(1006).rejected, false);
+    assert.strictEqual(VoiceFrame.classifyVoiceClose(4000).rejected, false);
+  });
+});
+
+describe('ws-voice-frame: normalizeBinaryMessage', function () {
+  it('passes a Buffer through unchanged', function () {
+    const b = Buffer.from([1, 2, 3]);
+    assert.strictEqual(normalizeBinaryMessage(b), b);
+  });
+
+  it('concatenates a Buffer[] (fragmented frame) into one Buffer', function () {
+    const parts = [Buffer.from([1, 2]), Buffer.from([3, 4, 5])];
+    const out = normalizeBinaryMessage(parts);
+    assert.ok(Buffer.isBuffer(out));
+    assert.strictEqual(out.length, 5);
+    assert.deepStrictEqual(Array.from(out), [1, 2, 3, 4, 5]);
+  });
+
+  it('wraps an ArrayBuffer into a Buffer', function () {
+    const ab = new Uint8Array([7, 8, 9]).buffer;
+    const out = normalizeBinaryMessage(ab);
+    assert.ok(Buffer.isBuffer(out));
+    assert.deepStrictEqual(Array.from(out), [7, 8, 9]);
+  });
+});
+
+describe('ws-voice-frame: classifyVoiceFrame', function () {
+  it('accepts a well-formed frame and returns the PCM slice', function () {
+    const pcm = Buffer.from([0x10, 0x20, 0x30, 0x40]);
+    const frame = Buffer.concat([header(), pcm]);
+    const v = classifyVoiceFrame(frame);
+    assert.strictEqual(v.action, 'pcm');
+    assert.deepStrictEqual(Array.from(v.pcm), Array.from(pcm));
+  });
+
+  it('classifies an over-size frame as oversize (-> 1009)', function () {
+    const frame = Buffer.alloc(MAX_VOICE_BINARY_FRAME_BYTES + 1);
+    assert.strictEqual(classifyVoiceFrame(frame).action, 'oversize');
+  });
+
+  it('accepts a frame at exactly the max and rejects one byte over', function () {
+    const atMax = Buffer.alloc(MAX_VOICE_BINARY_FRAME_BYTES);
+    header().copy(atMax, 0);
+    assert.strictEqual(classifyVoiceFrame(atMax).action, 'pcm');
+    assert.strictEqual(classifyVoiceFrame(atMax).pcm.length, MAX_VOICE_PCM_BYTES);
+  });
+
+  it('rejects a short frame (< 6 bytes) as unsupported (-> 1003)', function () {
+    assert.strictEqual(classifyVoiceFrame(Buffer.from(VOICE_MAGIC)).action, 'unsupported');
+  });
+
+  it('rejects bad magic, wrong version, and wrong type', function () {
+    const badMagic = Buffer.concat([Buffer.from([0x58, 0x58, 0x58, 0x58, 1, 1]), Buffer.from([0, 0])]);
+    assert.strictEqual(classifyVoiceFrame(badMagic).action, 'unsupported');
+
+    const badVer = Buffer.concat([Buffer.from([0x56, 0x55, 0x50, 0x31, 2, 1]), Buffer.from([0, 0])]);
+    assert.strictEqual(classifyVoiceFrame(badVer).action, 'unsupported');
+
+    const badType = Buffer.concat([Buffer.from([0x56, 0x55, 0x50, 0x31, 1, 9]), Buffer.from([0, 0])]);
+    assert.strictEqual(classifyVoiceFrame(badType).action, 'unsupported');
+  });
+});
+
+describe('pcm: pcm16ToFloat32', function () {
+  it('normalizes 16-bit samples to [-1, 1) using /32768', function () {
+    const out = pcm16ToFloat32(new Int16Array([0, 32767, -32768, 16384]));
+    assert.strictEqual(out.length, 4);
+    assert.ok(Math.abs(out[0] - 0) < 1e-9);
+    assert.ok(Math.abs(out[1] - 32767 / 32768) < 1e-9);
+    assert.ok(Math.abs(out[2] - -1.0) < 1e-9);
+    assert.ok(Math.abs(out[3] - 0.5) < 1e-9);
+  });
+});
+
+describe('stt-engine: _toInt16Array', function () {
+  const SttEngine = require('../src/stt-engine.js');
+  const engine = new SttEngine({}); // not initialized — no worker/model
+
+  it('copies into a fresh, solely-owned buffer (safe to transfer)', function () {
+    const src = new Int16Array([5, 6]);
+    const out = engine._toInt16Array(src);
+    assert.deepStrictEqual(Array.from(out), [5, 6]);
+    assert.notStrictEqual(out.buffer, src.buffer, 'must own a fresh buffer');
+    assert.strictEqual(out.byteOffset, 0);
+  });
+
+  it('floors an odd-length input to whole 16-bit samples (no RangeError)', function () {
+    const out = engine._toInt16Array(Buffer.from([1, 2, 3])); // 3 bytes -> 1 sample
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0], 1 | (2 << 8)); // little-endian 0x0201 = 513
+  });
+
+  it('reads only the viewed region of a subarray-backed Buffer', function () {
+    const big = Buffer.from([9, 9, 1, 0, 2, 0, 9, 9]);
+    const view = big.subarray(2, 6); // bytes [1,0,2,0] -> int16 [1, 2]
+    const out = engine._toInt16Array(view);
+    assert.deepStrictEqual(Array.from(out), [1, 2]);
+  });
+});


### PR DESCRIPTION
Two changes bundled per request.

---

## 1. Voice recording crash fix (binary WS frame)

**Problem:** mic recording crashed the page after ~25-45 s ("refresh / reconnect" banner). Local-mode audio was buffered and sent as one base64-JSON WebSocket frame on stop; base64's 33% inflation crossed the server's 1 MiB frame guard at **~24.6 s**, triggering `ws.close(1009)`. That 1009 is a *clean* close (`wasClean === true`), so the client `onclose` skipped reconnect and dead-ended on "refresh the page".

**Fix:** send raw Int16 PCM as a single **binary** WebSocket frame (`"VUP1"` + version + type + PCM), routed past the 1 MiB JSON guard to a dedicated voice-frame cap (oversize → `1009`, bad header → `1003`). Framing/validation lives in a pure, unit-tested `src/utils/ws-voice-frame.js`. The base64 `voice_upload` handler stays a thin shim over a shared `_processVoicePcm` core.

**Recording-path robustness:**
- `onclose` branches on the close code, clears the mic spinner/timeout, logs the code, and reconnects on `1009`/`1003` instead of dead-ending
- Heartbeat pong-timeout suspended while recording (a busy capture thread can briefly miss a pong → spurious `close(4000)`)
- int16→float32 conversion moved to the STT worker thread (off the event loop, transferred not cloned)
- Voice rate-limit state moved onto the session object
- `sendBinary` fails fast on a closed socket; zero-sample + in-flight-recording guards

Docs: ADR-0026, voice-input spec, `docs/history` entry.

---

## 2. HTTP→HTTPS auto-upgrade on the same port

When the server runs with `--https`, a plaintext `http://host:PORT` request is auto-upgraded to `https://host:PORT` on the **same port** instead of failing with an opaque TLS-handshake error.

**How:** the listening socket is a tiny `net` server that **sniffs the first byte** — `0x16` (TLS ClientHello) → the real `https` app server; anything else → a small redirect server answering **`307`** with `Location: https://<host>:<port><url>`. The WebSocket server attaches to the inner TLS server, so `wss://` still arrives over an encrypted `TLSSocket`.

**Hardening (from adversarial review):**
- **Open-redirect guard:** redirect host validated to a bare `hostname[:port]` / `[ipv6][:port]` (rejects userinfo `@`, paths, control chars), falls back to `localhost` — a forged `Host: user:pass@evil.com` can't bounce a victim off-origin
- `307` is method-preserving and not cached permanent
- plaintext `ws://` upgrade gets the same `307` instead of an abrupt RST
- pre-handoff 10 s timeout + error-listener cleanup drop scanner/slowloris connections
- `close()` destroys proxied sockets + inner servers (they bypass internal connection tracking)

Docs: ADR-0027, server spec (`docs/specs/server.md`).

---

## Tests
- 28 new tests across both features; each feature also verified against the full suite (**0 failing**)
- Voice: pure framing/conversion units (incl. fragmented `Buffer[]`, `_toInt16Array`) + binary integration (30 s transcribes & socket stays open — the crash case; `1009`/`1003` closes; rate limit)
- HTTPS: HTTP → 307 to https; path/query preserved; **hostile `Host` → no open redirect**; real HTTPS still serves; `wss://` upgrade completes over TLS
- Regression green: base64 shim paths, the 1 MiB text guard, heartbeat, non-HTTPS path

## Note
Both changes touch `src/server.js` in non-overlapping regions (voice: WS dispatcher + handlers; https: `start()`/`close()`).

## Deferred (documented)
Pre-existing voice tab-misrouting (`wsInfo.claudeSessionId` swaps on tab-switch) and a per-IP WebSocket connection cap.