### PR TITLE
feat: auto-upgrade http requests to https on the same port

### DIFF
--- a/docs/adrs/0027-http-to-https-auto-upgrade.md
+++ b/docs/adrs/0027-http-to-https-auto-upgrade.md
@@ -1,0 +1,69 @@
+# 0027 - HTTP→HTTPS auto-upgrade on a single port
+
+## Status
+
+Accepted (2026-06).
+
+## Context
+
+Running with `--https`, the server listened only for TLS on `PORT`. A user who
+reached `http://host:PORT` (typed the scheme, followed a bookmark from a prior
+plain-HTTP run, or omitted the scheme so the browser tried HTTP first) hit the
+TLS listener with a plaintext request → an opaque TLS-handshake error / hang,
+not a helpful redirect. We want plaintext HTTP on the port to auto-upgrade to
+HTTPS.
+
+Options considered:
+
+1. **Separate HTTP redirect port** (e.g. also bind 80, or `PORT-1`). Rejected:
+   port 80 needs root and is often taken (IIS/`http.sys` on the Windows-first
+   target); an arbitrary companion port adds CLI surface and a second thing for
+   the user to know. It also doesn't help the user who typed `http://host:PORT`.
+2. **Same-port byte sniffing** (chosen): one listening socket serves both. The
+   user types either scheme on the one port and it works — no extra config, and
+   it directly fixes the `http://host:PORT` case.
+
+## Decision
+
+In HTTPS mode the listening socket is a `net` server that **peeks the first
+byte** of each connection: a TLS ClientHello begins with `0x16` (handshake
+record), so those connections are handed (`emit('connection')`) to the real
+`https` app server; any other first byte is plaintext HTTP and is handed to a
+small redirect server that answers `307` with `Location: https://<host>:<port><url>`.
+
+Key properties:
+
+- **307** (temporary, method-preserving) rather than `301`/`308`: a POST stays a
+  POST, and it is not cached as permanent — so flipping the port back to plain
+  HTTP later isn't poisoned by a stale permanent redirect.
+- **Open-redirect guard:** the redirect host derives from the client `Host`
+  header but is validated to a bare `hostname[:port]` / `[ipv6][:port]` (userinfo
+  `@`, path, control chars rejected), falling back to `localhost`. The port comes
+  from `req.socket.localPort` (correct even on an ephemeral `port: 0`).
+- The **WebSocket server attaches to the inner TLS server**, so a `wss://`
+  upgrade still arrives over an encrypted `TLSSocket` (`req.socket.encrypted`
+  stays true for the secure-context / voice checks). A plaintext `ws://` upgrade
+  to the port gets the same `307` written raw instead of an abrupt reset.
+- **Pre-handoff guards:** a connection that errors or sends no data within 10 s
+  (port scanner / slowloris) is destroyed before routing; the timer + error
+  listener are cleared on handoff so the target server owns the socket lifecycle.
+- **Shutdown:** `close()` destroys the tracked proxied sockets and closes both
+  inner servers (they receive connections via `emit('connection')`, which
+  bypasses their internal connection tracking, so they wouldn't otherwise drain).
+
+The non-HTTPS path is unchanged (a plain `http` server).
+
+## Consequences
+
+- One port, both schemes — simplest UX, no new flags or privileged ports.
+- A tiny per-connection cost (one `readable` + 1-byte read + an `unshift`) and an
+  extra in-process hop for every connection in HTTPS mode.
+- Inbound connections are injected into the inner servers, bypassing their
+  connection tracking — handled explicitly in `close()`.
+- No HSTS is sent (would conflict with self-signed certs and with switching the
+  port between http/https modes); the redirect alone is the upgrade mechanism.
+
+## References
+
+- Spec: `docs/specs/server.md` (HTTPS and HTTP→HTTPS auto-upgrade)
+- Tests: `test/https-upgrade.test.js`

--- a/docs/specs/server.md
+++ b/docs/specs/server.md
@@ -14,7 +14,7 @@ new ClaudeCodeWebServer(options)
 | `auth` | string | `undefined` | Bearer token for authentication; when set, all HTTP and WebSocket requests must provide it |
 | `noAuth` | boolean | `false` | Disable authentication entirely (`--disable-auth`) |
 | `dev` | boolean | `false` | Enable verbose console logging |
-| `https` | boolean | `false` | Start an HTTPS server instead of HTTP |
+| `https` | boolean | `false` | Start an HTTPS server instead of HTTP. Plaintext `http://` requests to the same port auto-upgrade (307) to `https://` (see below) |
 | `cert` | string | -- | Path to PEM certificate file (required when `https` is true) |
 | `key` | string | -- | Path to PEM private key file (required when `https` is true) |
 | `folderMode` | boolean | `true` | Enable folder-selection UI (defaults to true; always enabled in current CLI) |
@@ -190,6 +190,37 @@ Returns persistence metadata from `SessionStore.getSessionMetadata()`.
 
 #### `GET /`
 Serves `src/public/index.html`.
+
+---
+
+## HTTPS and HTTP→HTTPS auto-upgrade
+
+When `https` is enabled, the single listening port serves both TLS and a
+plaintext-HTTP redirect, so `http://host:PORT` and `https://host:PORT` both work
+(a user who reaches the port over plain HTTP is upgraded instead of getting an
+opaque TLS-handshake error).
+
+- The listening socket is a `net` server that **sniffs the first byte**: a TLS
+  ClientHello starts with `0x16`, so those connections are handed to the real
+  `https` app server; anything else is plaintext HTTP and is handed to a small
+  redirect server.
+- The redirect server answers **`307`** (method-preserving; not cached as
+  permanent, so switching the port back to plain-HTTP mode later isn't poisoned
+  by a stale `301`) with `Location: https://<host>:<port><url>`. A plaintext
+  `ws://` upgrade gets the same `307` written raw instead of an abrupt reset.
+- The redirect host comes from the client `Host` header but is **validated to a
+  bare `hostname[:port]` / `[ipv6][:port]`** (userinfo `@`, paths, and control
+  chars rejected) and falls back to `localhost` — preventing an open redirect to
+  an external origin via a forged `Host`.
+- The WebSocket server attaches to the inner TLS server, so a `wss://` upgrade
+  still arrives over an encrypted `TLSSocket` (`req.socket.encrypted` stays true
+  for the secure-context / voice checks).
+- Self-signed certs (no `cert`/`key` given) are generated/cached at
+  `~/.ai-or-die/certs/`; for a trusted, installable origin use `--tunnel`.
+
+`close()` destroys the proxied sockets and closes both inner servers (they
+receive connections via `emit('connection')`, which bypasses their own
+connection tracking).
 
 ---
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const http = require('http');
 const https = require('https');
+const net = require('net');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
@@ -3151,6 +3152,7 @@ class ClaudeCodeWebServer {
     this._ensureStickyNoteEngine();
 
     let server;
+    let wsHost; // the server the WebSocket server attaches to (TLS server in HTTPS mode)
 
     if (this.useHttps) {
       let cert, key;
@@ -3177,13 +3179,90 @@ class ClaudeCodeWebServer {
         console.log('        Browsers will show a security warning on first visit.');
         console.log('        For a trusted, installable origin use \x1b[1m--tunnel\x1b[0m.');
       }
-      server = https.createServer({ cert, key }, this.app);
+
+      // The real TLS app server. The WebSocket server attaches HERE so a wss://
+      // upgrade arrives over an encrypted TLSSocket (req.socket.encrypted stays
+      // true for the secure-context / voice checks).
+      const tlsServer = https.createServer({ cert, key }, this.app);
+
+      // Build the https redirect target from the SAME host:port the client
+      // reached. The Host header is client-controlled, so accept ONLY a bare
+      // hostname[:port] (or [ipv6][:port]) — reject userinfo (`@`), paths, and
+      // control chars to prevent an open redirect to an external origin
+      // (e.g. Host: user:pass@evil.com). Fall back to localhost otherwise.
+      const redirectLocation = (req) => {
+        const raw = String(req.headers.host || '');
+        const validHost = /^[A-Za-z0-9.-]+(?::\d+)?$/.test(raw)
+          || /^\[[0-9a-fA-F:]+\](?::\d+)?$/.test(raw);
+        const hostname = validHost ? raw.replace(/:\d+$/, '') : 'localhost';
+        const port = req.socket.localPort || this.port;
+        // req.url is parser-validated (no CR/LF in a valid request target).
+        return `https://${hostname}:${port}${req.url}`.replace(/[\r\n]/g, '');
+      };
+
+      // Plaintext HTTP on the SAME port -> redirect to https. A user who reaches
+      // http://host:PORT is auto-upgraded instead of getting an opaque
+      // TLS-handshake error. 307 keeps the method and is not cached as permanent
+      // (switching the port back to http mode later isn't poisoned by a stale 301).
+      const httpRedirectServer = http.createServer((req, res) => {
+        const location = redirectLocation(req);
+        res.writeHead(307, { Location: location, 'Content-Type': 'text/plain' });
+        res.end(`Redirecting to ${location}\n`);
+      });
+      // A plaintext ws:// upgrade to the TLS port: answer with the same redirect
+      // (written raw — an upgrade has no res object) instead of an abrupt RST.
+      httpRedirectServer.on('upgrade', (req, socket) => {
+        const location = redirectLocation(req);
+        try {
+          socket.end(
+            'HTTP/1.1 307 Temporary Redirect\r\n' +
+            `Location: ${location}\r\n` +
+            'Connection: close\r\n\r\n'
+          );
+        } catch (_) { try { socket.destroy(); } catch (__) { /* ignore */ } }
+      });
+
+      // Front both with a 1-byte sniffer: a TLS ClientHello starts with 0x16
+      // (handshake record); anything else is plaintext HTTP. One listening port
+      // therefore serves both — http:// and https:// to PORT both work.
+      this._proxySockets = new Set();
+      server = net.createServer((socket) => {
+        this._proxySockets.add(socket);
+        socket.once('close', () => this._proxySockets.delete(socket));
+        // Pre-handoff guards: drop a connection that errors or sends no data
+        // (port scanner / slowloris) before we know which server owns it. Both
+        // are cleared the moment we route, so the target server's own lifecycle
+        // and timeouts take over cleanly.
+        const sniffTimer = setTimeout(() => { try { socket.destroy(); } catch (_) { /* ignore */ } }, 10000);
+        const onSniffError = () => {
+          clearTimeout(sniffTimer);
+          try { socket.destroy(); } catch (_) { /* ignore */ }
+        };
+        socket.on('error', onSniffError);
+        socket.once('readable', () => {
+          clearTimeout(sniffTimer);
+          socket.removeListener('error', onSniffError);
+          const chunk = socket.read(1);
+          if (!chunk) { socket.destroy(); return; }
+          socket.unshift(chunk);
+          const target = chunk[0] === 0x16 ? tlsServer : httpRedirectServer;
+          target.emit('connection', socket);
+        });
+      });
+
+      this._tlsServer = tlsServer;
+      this._httpRedirectServer = httpRedirectServer;
+      wsHost = tlsServer;
+      console.log('        http:// requests on this port auto-upgrade to https.');
     } else {
       server = http.createServer(this.app);
+      this._tlsServer = null;
+      this._httpRedirectServer = null;
+      wsHost = server;
     }
 
     this.wss = new WebSocket.Server({
-      server,
+      server: wsHost,
       maxPayload: 8 * 1024 * 1024,
       // Compression disabled — binary frames already send with compress:false,
       // and JSON control messages are small/infrequent. Saves ~300KB per connection
@@ -5224,6 +5303,23 @@ class ClaudeCodeWebServer {
     }
     if (this.server) {
       this.server.close();
+    }
+    // In HTTPS mode `this.server` is the TLS-sniffing proxy that owns the
+    // listening port; the TLS app server and the http->https redirect server sit
+    // behind it. Sockets are handed to them via emit('connection'), bypassing
+    // their internal connection tracking, so destroy the proxied sockets here
+    // (and close the inner servers) to avoid keep-alive connections lingering.
+    if (this._proxySockets) {
+      for (const s of this._proxySockets) {
+        try { s.destroy(); } catch (_) { /* ignore */ }
+      }
+      this._proxySockets.clear();
+    }
+    if (this._tlsServer) {
+      try { this._tlsServer.close(); } catch (_) { /* ignore */ }
+    }
+    if (this._httpRedirectServer) {
+      try { this._httpRedirectServer.close(); } catch (_) { /* ignore */ }
     }
 
     // Flush pending output and stop all sessions with a 5-second timeout

--- a/test/https-upgrade.test.js
+++ b/test/https-upgrade.test.js
@@ -1,0 +1,152 @@
+'use strict';
+
+// HTTPS auto-upgrade: when the server runs with --https, the single listening
+// port serves TLS normally AND redirects plaintext HTTP requests to https (so a
+// user who reaches http://host:PORT is upgraded instead of getting an opaque
+// TLS-handshake error). Verified end to end: plaintext HTTP -> 307, real HTTPS
+// still works, and wss:// upgrades still complete through the sniffer.
+
+const assert = require('assert');
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const WebSocket = require('ws');
+const selfsigned = require('selfsigned');
+const { ClaudeCodeWebServer } = require('../src/server');
+
+function httpGet(opts) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(opts, (res) => {
+      let body = '';
+      res.on('data', (c) => { body += c; });
+      res.on('end', () => resolve({ statusCode: res.statusCode, headers: res.headers, body }));
+    });
+    req.on('error', reject);
+    req.setTimeout(5000, () => req.destroy(new Error('http timeout')));
+  });
+}
+
+// http GET with an explicit (possibly hostile) Host header.
+function httpGetWithHost(hostHeader, port) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path: '/', method: 'GET', headers: { Host: hostHeader } },
+      (res) => {
+        res.resume();
+        resolve({ statusCode: res.statusCode, headers: res.headers });
+      }
+    );
+    req.on('error', reject);
+    req.setTimeout(5000, () => req.destroy(new Error('http timeout')));
+    req.end();
+  });
+}
+
+function httpsGet(opts) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(Object.assign({ rejectUnauthorized: false }, opts), (res) => {
+      let body = '';
+      res.on('data', (c) => { body += c; });
+      res.on('end', () => resolve({ statusCode: res.statusCode, headers: res.headers, body }));
+    });
+    req.on('error', reject);
+    req.setTimeout(5000, () => req.destroy(new Error('https timeout')));
+  });
+}
+
+describe('https auto-upgrade: http on the tls port redirects to https', function () {
+  this.timeout(30000);
+
+  let server;
+  let port;
+  let tmpDir;
+  let certPath;
+  let keyPath;
+
+  before(async function () {
+    // Throwaway self-signed cert written to a temp dir (NOT ~/.ai-or-die) so the
+    // test never touches the user's real cert cache.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'https-upgrade-'));
+    const pems = selfsigned.generate(
+      [{ name: 'commonName', value: 'test-localhost' }],
+      {
+        keySize: 2048,
+        days: 1,
+        algorithm: 'sha256',
+        extensions: [{
+          name: 'subjectAltName',
+          altNames: [{ type: 2, value: 'localhost' }, { type: 7, ip: '127.0.0.1' }],
+        }],
+      }
+    );
+    certPath = path.join(tmpDir, 'test.cert');
+    keyPath = path.join(tmpDir, 'test.key');
+    fs.writeFileSync(certPath, pems.cert);
+    fs.writeFileSync(keyPath, pems.private);
+
+    server = new ClaudeCodeWebServer({
+      port: 0,
+      noAuth: true,
+      https: true,
+      cert: certPath,
+      key: keyPath,
+    });
+    const httpServer = await server.start();
+    port = httpServer.address().port;
+  });
+
+  after(function () {
+    try { server.close(); } catch (_) { /* ignore */ }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+  });
+
+  it('redirects a plaintext HTTP request to https on the same port (307)', async function () {
+    const res = await httpGet({ host: '127.0.0.1', port, path: '/api/config' });
+    assert.strictEqual(res.statusCode, 307, `expected 307, got ${res.statusCode}`);
+    assert.strictEqual(
+      res.headers.location,
+      `https://127.0.0.1:${port}/api/config`,
+      `unexpected Location: ${res.headers.location}`
+    );
+  });
+
+  it('preserves the request path + query in the redirect', async function () {
+    const res = await httpGet({ host: '127.0.0.1', port, path: '/foo/bar?x=1&y=2' });
+    assert.strictEqual(res.statusCode, 307);
+    assert.strictEqual(res.headers.location, `https://127.0.0.1:${port}/foo/bar?x=1&y=2`);
+  });
+
+  it('does not honor a hostile Host header (no open redirect)', async function () {
+    const res = await httpGetWithHost('user:pass@evil.com', port);
+    assert.strictEqual(res.statusCode, 307);
+    assert.ok(!/evil\.com/.test(res.headers.location || ''),
+      `open redirect leaked off-origin: ${res.headers.location}`);
+    assert.ok((res.headers.location || '').startsWith(`https://localhost:${port}`),
+      `expected localhost fallback, got: ${res.headers.location}`);
+  });
+
+  it('still serves real HTTPS on the same port', async function () {
+    const res = await httpsGet({ host: '127.0.0.1', port, path: '/api/config' });
+    assert.strictEqual(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert(body.voiceInput, 'expected a real config response over TLS');
+  });
+
+  it('still completes a wss:// WebSocket upgrade over TLS', async function () {
+    const ws = new WebSocket(`wss://127.0.0.1:${port}/`, { rejectUnauthorized: false });
+    const connected = await new Promise((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('wss connect timeout')), 5000);
+      ws.on('open', () => {
+        ws.once('message', (raw) => {
+          clearTimeout(t);
+          try { resolve(JSON.parse(raw.toString())); } catch (e) { reject(e); }
+        });
+      });
+      ws.on('error', (e) => { clearTimeout(t); reject(e); });
+    });
+    assert.strictEqual(connected.type, 'connected', 'expected the connected frame over wss');
+    ws.close();
+  });
+});


### PR DESCRIPTION
## What

When the server runs with `--https`, a plaintext `http://host:PORT` request is now auto-upgraded to `https://host:PORT` on the **same port**, instead of failing with an opaque TLS-handshake error. `http://` and `https://` to the port both work.

## How

The listening socket becomes a tiny `net` server that **sniffs the first byte** of each connection:
- `0x16` (TLS ClientHello) → handed to the real `https` app server
- anything else (plaintext HTTP) → handed to a small redirect server that answers **`307`** with `Location: https://<host>:<port><url>`

The WebSocket server attaches to the inner TLS server, so a `wss://` upgrade still arrives over an encrypted `TLSSocket` (`req.socket.encrypted` stays true for the secure-context / voice checks).

### Hardening (from adversarial review)
- **Open-redirect guard:** the redirect host derives from the client `Host` header but is validated to a bare `hostname[:port]` / `[ipv6][:port]` (rejects userinfo `@`, paths, control chars) and falls back to `localhost` — a forged `Host: user:pass@evil.com` can't bounce a victim off-origin
- `307` is method-preserving and not cached as permanent (flipping the port back to http mode later isn't poisoned by a stale `301`)
- a plaintext `ws://` upgrade gets the same `307` written raw instead of an abrupt RST
- pre-handoff 10 s timeout + error-listener cleanup drop port-scanner/slowloris connections; both cleared on handoff so the target server owns the socket lifecycle
- `close()` destroys the tracked proxied sockets and the inner servers (they receive connections via `emit('connection')`, which bypasses their own connection tracking)

The non-HTTPS path is unchanged.

## Tests
- Full suite: **1379 passing, 0 failing**
- New `test/https-upgrade.test.js`: HTTP → 307 to https on the same port; path/query preserved; **hostile `Host` → no open redirect** (localhost fallback); real HTTPS still serves; `wss://` upgrade still completes over TLS

## Docs
ADR-0027, server spec (`docs/specs/server.md`).