### PR TITLE
fix: sticky notes & auto-titles broken on Windows (drive-letter slug)

### DIFF
--- a/docs/history/sticky-notes-2026.md
+++ b/docs/history/sticky-notes-2026.md
@@ -191,6 +191,34 @@ by serialising the worker), and an unpinned model hash (now SHA-256-pinned).
 Also: graceful worker dispose before `terminate()` (a bare terminate with the
 model loaded aborts the process / holds a Windows file lock). All fixed pre-merge.
 
+## Windows regression: drive-letter colon broke the transcript binding (2026-06)
+
+Symptom on Windows 11: the sticky-note card stayed empty AND the tab title never
+updated — both at once, even though the model downloaded, loaded, and the engine
+reached `ready`.
+
+Root cause was the cwd→project-dir slug. claude writes transcripts under
+`~/.claude/projects/<slug>/` where the slug replaces **every non-alphanumeric
+char** with `-`, so `C:\Users\me\proj` → `C--Users-me-proj` (the drive-letter `:`
+becomes a dash too). `slugForCwd` (`src/sticky-note-jsonl.js`) only replaced path
+separators (`/[\\/]/g`), leaving `C:-Users-me-proj`. That directory never exists,
+so `findActiveSessions`' `readdir` threw, `candidates` came back empty, and the
+binder (`server.js _pumpStickyJsonl`) returned early without ever creating a
+binding. No binding means the always-on title tail (`readNewAiTitle`) and the
+expand-gated note inference both never run — hence both symptoms from one bug.
+POSIX paths have no colon, so it only bit Windows (the primary target). The model,
+native binding (win-x64 `llama-addon.node`), and `getLlama→loadModel→createContext`
+were all verified healthy on the affected machine — the break was purely the path.
+
+Fix: `slugForCwd` now mirrors claude exactly — `replace(/[^a-zA-Z0-9]/g, '-')`.
+Separator-agnostic, so `\` and `/` cwd forms resolve identically; POSIX slugs are
+unchanged. The same latent bug lived in `src/usage-reader.js`
+(`getMostRecentSessionFile`, project-usage lookup) and was fixed the same way.
+Regression covered by Windows drive-letter cases in
+`test/sticky-note-jsonl.test.js` (slug parity + a `findActiveSession` resolve).
+The rule is lossy by design (two distinct cwds can collide on one slug) — that is
+claude's own folder-naming behavior, and matching it is mandatory.
+
 ## Files
 
 Engine/worker/summarizer/transcript/prompt under `src/sticky-note-*.js`;

--- a/src/sticky-note-jsonl.js
+++ b/src/sticky-note-jsonl.js
@@ -39,9 +39,16 @@ function cleanProse(s) {
     .trim();
 }
 
-/** Claude's project-dir slug for a cwd: all path separators → '-'. */
+/**
+ * Claude's project-dir slug for a cwd: every non-alphanumeric char → '-'
+ * (drive-letter colon, path separators, spaces, dots, etc.). Matches the folder
+ * claude writes under ~/.claude/projects/. A separator-only replace leaves the
+ * Windows drive-letter colon in place (`C:-Users-...`) and never matches claude's
+ * `C--Users-...`, so the transcript binding — and with it the tab title and the
+ * sticky note — silently fail on Windows.
+ */
 function slugForCwd(cwd) {
-  return String(cwd || '').replace(/[\\/]/g, '-');
+  return String(cwd || '').replace(/[^a-zA-Z0-9]/g, '-');
 }
 
 /** The claude session id is the JSONL basename (the --resume key). */

--- a/src/usage-reader.js
+++ b/src/usage-reader.js
@@ -321,8 +321,11 @@ class UsageReader {
     try {
       // Get the current working directory to find the right project folder
       const cwd = process.cwd();
-      // Claude uses format: -home-user-Development-project
-      const projectDirName = cwd.replace(/[\\/]/g, '-'); // Handle both Unix / and Windows \ separators
+      // Claude uses format: -home-user-Development-project. It replaces EVERY
+      // non-alphanumeric char with '-', so on Windows the drive-letter colon
+      // becomes a dash too (`C:\Users\me` -> `C--Users-me`). A separator-only
+      // replace leaves the colon and never matches the real folder.
+      const projectDirName = cwd.replace(/[^a-zA-Z0-9]/g, '-');
       let projectPath = path.join(this.claudeProjectsPath, projectDirName);
       
       // Check if the project directory exists

--- a/test/sticky-note-jsonl.test.js
+++ b/test/sticky-note-jsonl.test.js
@@ -29,6 +29,32 @@ describe('sticky-note JSONL reader', function () {
     assert.strictEqual(J.slugForCwd('/Users/x/proj'), '-Users-x-proj');
   });
 
+  it('slugForCwd matches claude on Windows drive-letter paths (colon → dash)', function () {
+    // claude replaces EVERY non-alphanumeric char with '-', so the drive-letter
+    // colon and the separators both become dashes. A separator-only slug would
+    // leave `C:-Users-...` and never find the transcript dir on Windows.
+    assert.strictEqual(
+      J.slugForCwd('C:\\Users\\anikundu\\Software\\ai-or-die'),
+      'C--Users-anikundu-Software-ai-or-die'
+    );
+    assert.strictEqual(
+      J.slugForCwd('C:/Users/anikundu/Software/ai-or-die'),
+      'C--Users-anikundu-Software-ai-or-die'
+    ); // forward-slash form resolves identically
+  });
+
+  it('findActiveSession resolves a Windows-style cwd to its dashed project dir', async function () {
+    const winCwd = 'C:\\Users\\anikundu\\Software\\ai-or-die';
+    const winDir = path.join(projects, J.slugForCwd(winCwd));
+    fs.mkdirSync(winDir, { recursive: true });
+    const f = path.join(winDir, 'sess.jsonl');
+    fs.writeFileSync(f, line({ type: 'user' }));
+    const r = await J.findActiveSession(winCwd, { projectsDir: projects });
+    assert.ok(r, 'binding resolves for a Windows drive-letter cwd');
+    assert.strictEqual(r.file, f);
+    assert.strictEqual(r.sessionId, 'sess');
+  });
+
   it('findActiveSession returns the newest .jsonl; null when no project dir', async function () {
     const a = path.join(projDir, 'a.jsonl');
     const b = path.join(projDir, 'b.jsonl');


### PR DESCRIPTION
## Problem

On Windows 11 the sticky-notes card stays empty **and** the tab title never updates — both at once — even though the model downloads, loads, and the engine reaches `ready`.

## Root cause

Both symptoms share one cause: the per-tab binder can't find claude's session transcript.

`slugForCwd` (`src/sticky-note-jsonl.js`) turns the working directory into claude's `~/.claude/projects/<slug>/` folder name with `replace(/[\/]/g, '-')` — separators only. claude replaces **every non-alphanumeric character**, so `C:\Users\me\proj` becomes `C--Users-me-proj` (the drive-letter colon is also dashed). The old code produced `C:-Users-...`, a directory that doesn't exist → `findActiveSessions`' `readdir` throws → `candidates` is empty → the binder returns early at `server.js:4276` and **never creates a binding**.

With no binding, neither the always-on ai-title tail (`readNewAiTitle`) nor the expand-gated note inference ever runs. POSIX paths have no colon, so this only affects Windows (the primary target).

The model, native binding (win-x64 `llama-addon.node`), and a full `getLlama → loadModel → createContext` were all verified healthy on the affected machine — the break is purely the path slug.

## Fix

- **`src/sticky-note-jsonl.js`** — `slugForCwd` now mirrors claude exactly: `replace(/[^a-zA-Z0-9]/g, '-')`. Separator-agnostic (handles `\` and `/`); POSIX slugs unchanged.
- **`src/usage-reader.js`** — the identical latent bug in `getMostRecentSessionFile` (per-project usage stats also came back empty on Windows) is fixed the same way.
- **`test/sticky-note-jsonl.test.js`** — Windows drive-letter slug parity + a `findActiveSession` resolve case.
- **`docs/history/sticky-notes-2026.md`** — regression write-up.

## Verification (run on Windows 11)

- **Runtime, real data:** the patched `findActiveSession` resolves the live transcript for the current project, and `readNewAiTitle` reads its actual ai-title — proving both the note input and the title tail fire.
- **Unit:** new Windows cases green; **61** sticky-note unit tests + **30** server-wiring tests (binding / ownership / resume / expand-gating) pass.

## Note

The rule is lossy by design (two distinct cwds can collide on one slug) — that matches claude's own folder-naming behavior, which we must mirror to find the directory it actually created.