### PR TITLE
fix: bind sticky notes to the right claude session (per-tab sidecar)

### DIFF
--- a/docs/adrs/0026-sticky-note-deterministic-session-binding.md
+++ b/docs/adrs/0026-sticky-note-deterministic-session-binding.md
@@ -1,0 +1,70 @@
+# 0026 - Sticky-Note Deterministic Session Binding via github-router's SessionStart hook
+
+## Status
+
+Accepted (2026-06). Supersedes the deferred `--session-id` consequence of
+[ADR-0024](0024-sticky-note-binding-resume.md). ADR-0024's newest-mtime inference is
+retained as a FALLBACK only; the primary binding is now deterministic.
+
+## Context
+
+ADR-0024 bound each tab to a claude transcript by scanning the tab's project dir
+(`~/.claude/projects/<cwd-slug>/`) and choosing the newest-mtime, unowned `.jsonl`. The
+project dir is derived from `cwd = session.liveCwd || session.workingDir`.
+
+In the primary real-world setup the user runs `npx github-router@latest claude` inside an
+ai-or-die **Terminal** tab (github-router launches the real claude CLI against GitHub
+Copilot APIs). For terminal tabs `liveCwd` is populated only from OSC 7, which `cmd.exe`
+cannot emit and which otherwise needs a prompt hook. When `liveCwd` is null, every tab
+falls back to the same folder-mode `workingDir` base, all scan one project dir, and the
+newest-mtime heuristic hands every tab whichever single session is actively growing — so
+multiple tabs surface the same session's note/title (the reported bug). ADR-0024 itself
+named the fix and deferred it: "`--session-id` if ai-or-die ever launches claude". ai-or-die
+still doesn't launch claude on this path, but github-router does, and the user owns it.
+
+The user also relies on in-session `/resume` frequently and `/clear` occasionally, so any
+binding must be auto-maintained across those transitions, not frozen at launch.
+
+## Decision
+
+Make **claude itself** the authoritative source of the active session, surfaced over a
+per-tab **sidecar file**, and bind by exact transcript path:
+
+- **github-router** registers a Claude Code `SessionStart`/`SessionEnd` hook (reusing its
+  existing `injectStopHookIntoSettingsFile` machinery) whenever `AIORDIE_CLAUDE_BIND` (a
+  per-tab sidecar path) is present in its env. The hook (`internal-session-bind`) reads the
+  hook payload and atomically writes `{schema, claudeSessionId, transcriptPath, cwd, event,
+  source?, reason?, at}` to that sidecar on every startup / `/resume` / `/clear` / `/compact`.
+  `transcriptPath` is realpath-resolved to the real `~/.claude/projects/...`. The hook
+  **skips subagent/teammate payloads** (`agent_id`/`agent_type`) so only the tab's top-level
+  session drives the binding. github-router **strips `AIORDIE_CLAUDE_BIND`** from the env it
+  passes to claude (the sidecar path is baked into the hook command, not the env), so a
+  nested `github-router claude` can't hijack the parent tab.
+- **ai-or-die** sets `AIORDIE_CLAUDE_BIND` = `<dataDir>/claude-bindings/<sessionId>.json` in
+  every Terminal tab's shell env (via a new `base-bridge` `extraEnv` option). In
+  `_pumpStickyJsonl`, when a sidecar exists it is AUTHORITATIVE: bind the tab directly to
+  `transcriptPath` by exact path (no cwd, no mtime), rebinding when `claudeSessionId` changes.
+  A stale sidecar is cleared on each terminal (re)start; pinned ids are reserved in
+  `_ownedClaudeSessions`; `claudePinnedSessionId` is persisted; orphan sidecars are swept on
+  startup and removed on tab close.
+- **Fallback:** tabs with no sidecar (claude launched without github-router) keep ADR-0024's
+  newest-mtime inference, so that path is regression-free.
+
+The cross-repo contract is one env var (`AIORDIE_CLAUDE_BIND`) plus the versioned sidecar
+JSON `schema`.
+
+## Consequences
+
+- The reported bug is fixed structurally: each tab binds the exact transcript its own claude
+  reports, independent of cwd, mtime, shell, or OSC 7 availability (works on `cmd.exe`).
+- `/resume`, `/clear`, `/compact`, and exit→relaunch are first-class (the hook fires on each,
+  reporting the now-active session). No `--session-id` forcing, so no argv-grammar fragility.
+- No phantom pin: a tab is bound only after claude actually reports a session, so a failed
+  launch or an old claude without SessionStart simply leaves the tab on the fallback.
+- Depends on github-router's `projects` mirror entry staying SHARED (a junction to the real
+  `~/.claude/projects`); if it ever becomes ISOLATED, ai-or-die's reads would need the mirror
+  path. The hook realpath's the transcript so reads don't depend on the per-launch junction
+  surviving github-router shutdown.
+- Two binding codepaths (sidecar + inference fallback) are maintained; both are unit-tested.
+- Load-bearing assumption verified against Claude Code docs and tested: subagent/teammate
+  SessionStart payloads carry `agent_id`/`agent_type` (env-strip is the backstop).

--- a/docs/history/sticky-notes-2026.md
+++ b/docs/history/sticky-notes-2026.md
@@ -226,3 +226,40 @@ Engine/worker/summarizer/transcript/prompt under `src/sticky-note-*.js`;
 `src/public/sticky-note-card.js` + `components/sticky-note.css`. Tests:
 `test/sticky-note-*.test.js` (78 cases, no model download — real inference is
 manual).
+
+## Cross-tab contamination fix: deterministic sidecar binding (ADR-0026)
+
+**Symptom (reported):** with multiple Terminal tabs each running `npx github-router@latest
+claude` across distinct projects, several tabs showed the SAME (growing) session's note/title
+instead of their own.
+
+**Root cause:** the binder scoped by `cwd = liveCwd || workingDir` then picked newest-mtime.
+For terminal-launched claude, `liveCwd` comes only from OSC 7, which `cmd.exe` cannot emit and
+which otherwise needs a prompt hook. With `liveCwd` null, every tab collapsed onto the same
+folder-mode `workingDir` base, all scanned one `~/.claude/projects/<base-slug>/`, and the one
+actively-growing session won everywhere. (The user never runs two claude in one folder, so it
+was pure cwd-collapse + mtime-guess, not a same-dir collision.)
+
+**Fix (two repos, contract = one env var + a JSON sidecar):**
+- github-router (`src/internal-session-bind.ts`, registered in `src/claude.ts`): a Claude Code
+  `SessionStart`/`SessionEnd` hook writes `{schema, claudeSessionId, transcriptPath, cwd,
+  event, source?, reason?, at}` to the per-tab sidecar named by `AIORDIE_CLAUDE_BIND`, on every
+  startup / `/resume` / `/clear` / `/compact`. Skips subagent/teammate payloads
+  (`agent_id`/`agent_type`); strips `AIORDIE_CLAUDE_BIND` from claude's env (nested-launch
+  safety); realpaths `transcriptPath` through the per-launch mirror's SHARED `projects`
+  junction to the real `~/.claude/projects`.
+- ai-or-die (`src/base-bridge.js` `extraEnv`; `src/server.js` `_pumpStickyJsonl`): sets the env
+  on Terminal shells, then binds the tab DIRECTLY to `transcriptPath` by exact path when a
+  sidecar exists (authoritative; no cwd/mtime), rebinding on id change. Newest-mtime inference
+  (ADR-0024) is retained only as the no-sidecar fallback.
+
+**Why a hook, not a launch-time `--session-id`:** the hook fires on every transition, so
+in-session `/resume` and `/clear` are auto-maintained (the user resumes frequently). It also
+removes all `--session-id`/argv-grammar fragility and avoids a phantom pin (a tab binds only
+after claude actually reports a session). An earlier OSC-marker-over-PTY idea was rejected in
+cross-lab review (terminal-stream injection / false positives / chunk-buffering / tap race).
+
+**Gotchas:** the read-cache in `_readClaudeBindSidecar` keys on the sidecar mtime, so a same-ms
+rewrite needs a bumped mtime (tests `utimes` to force it). A restored tab clears its stale
+sidecar on terminal restart so it never binds a dead session before the first SessionStart.
+Depends on github-router's `projects` mirror entry staying `SHARED` (`paths.ts`).

--- a/docs/specs/sticky-notes.md
+++ b/docs/specs/sticky-notes.md
@@ -76,10 +76,26 @@ read via `src/sticky-note-jsonl.js`, bound per-tab by a 2s poll in `server.js`) 
 user/assistant turns, not the Ink-TUI scrape. Plain shells fall back to the rendered-output
 scrape (`@xterm/headless`). Legacy notes migrate on load (`progress→done`, `waitingOn→remaining`).
 
-### Binding & resume (`_pumpStickyJsonl`, ADR-0024)
+### Binding & resume (`_pumpStickyJsonl`, ADR-0024 + ADR-0026)
 
-A tab binds to the claude session transcript for its `cwd`, keyed by **claude
-sessionId** (the JSONL basename / `--resume` key), so notes are durable and resume:
+A tab binds to the claude session transcript, keyed by **claude sessionId** (the JSONL
+basename / `--resume` key), so notes are durable and resume. Binding is resolved two ways:
+
+**PRIMARY — deterministic sidecar (ADR-0026).** When github-router launches claude inside a
+Terminal tab, ai-or-die sets `AIORDIE_CLAUDE_BIND=<dataDir>/claude-bindings/<sessionId>.json`
+in the shell env. github-router's `SessionStart`/`SessionEnd` hook (`internal-session-bind`)
+atomically writes `{schema, claudeSessionId, transcriptPath, cwd, event, source?, reason?,
+at}` there on every startup / `/resume` / `/clear` / `/compact`. When a sidecar exists it is
+AUTHORITATIVE: the tab binds directly to `transcriptPath` by exact path (no cwd, no mtime),
+rebinding when `claudeSessionId` changes. This survives in-session `/resume`, `/clear` and
+exit→relaunch, and works when `liveCwd` is null (`cmd.exe` / no OSC 7). The hook skips
+subagent/teammate payloads (`agent_id`/`agent_type`); github-router strips
+`AIORDIE_CLAUDE_BIND` from claude's env so a nested launch can't hijack the tab. A stale
+sidecar is cleared on each terminal (re)start; orphans are swept on startup and on tab close;
+`claudePinnedSessionId` is persisted and reserved in `_ownedClaudeSessions`.
+
+**FALLBACK — newest-mtime inference (ADR-0024).** When no sidecar exists (claude launched
+without github-router), bind to the active, unowned writer in the tab's project dir:
 
 - **Skips `agent-*.jsonl`** subagent logs (`findActiveSessions`).
 - **Per-tab ownership:** a tab never binds a session already owned by another tab,

--- a/src/base-bridge.js
+++ b/src/base-bridge.js
@@ -262,7 +262,8 @@ class BaseBridge {
       onExit = () => {},
       onError = () => {},
       cols = 80,
-      rows = 24
+      rows = 24,
+      extraEnv = null
     } = options;
 
     try {
@@ -280,7 +281,8 @@ class BaseBridge {
         ...process.env,
         TERM: 'xterm-256color',
         FORCE_COLOR: '1',
-        COLORTERM: 'truecolor'
+        COLORTERM: 'truecolor',
+        ...((extraEnv && typeof extraEnv === 'object') ? extraEnv : {})
       };
 
       const ptyProcess = spawn(this.command, args, {

--- a/src/server.js
+++ b/src/server.js
@@ -277,6 +277,8 @@ class ClaudeCodeWebServer {
         }
       }
       this._capClaudeNotes();
+      // Remove orphan claude-bind sidecars whose tab no longer exists.
+      this._sweepClaudeBindSidecars();
       if (sessions.size > 0) {
         console.log(`Loaded ${sessions.size} persisted sessions`);
       }
@@ -1351,6 +1353,7 @@ class ClaudeCodeWebServer {
       // Stop + tear down the summariser so an in-flight inference is discarded.
       this.stickyNoteSummarizer.cancel(sessionId);
       this._stickyJsonl.delete(sessionId);
+      this._removeClaudeBindSidecar(session);
       if (this._foregroundSessionId === sessionId) this._foregroundSessionId = null;
 
       this.claudeSessions.delete(sessionId);
@@ -3963,6 +3966,12 @@ class ClaudeCodeWebServer {
       // process; their session.liveCwd stays null. We pass the OSC 7
       // hooks only when starting a Terminal session so the other bridges
       // remain a true no-op.
+      const terminalExtraEnv = {};
+      if (toolName === 'terminal') {
+        const sidecarPath = this._prepareClaudeBindSidecar(sessionId, session);
+        if (sidecarPath) terminalExtraEnv.AIORDIE_CLAUDE_BIND = sidecarPath;
+      }
+
       const osc7Hooks = (toolName === 'terminal') ? {
         validatePath: (p) => this.validatePath(p),
         onCwdChange: (cwd, prev) => {
@@ -4039,7 +4048,13 @@ class ClaudeCodeWebServer {
           this.broadcastToSession(sessionId, { type: 'error', message: error.message });
           this.broadcastSessionActivity(sessionId, 'session_error');
         },
-        ...options
+        ...options,
+        extraEnv: toolName === 'terminal'
+          ? {
+              ...((options.extraEnv && typeof options.extraEnv === 'object') ? options.extraEnv : {}),
+              ...terminalExtraEnv,
+            }
+          : options.extraEnv
       });
 
       session.lastActivity = new Date();
@@ -4256,13 +4271,57 @@ class ClaudeCodeWebServer {
   async _pumpStickyJsonl(sessionId, cwd) {
     let binding = this._stickyJsonl.get(sessionId);
     binding && (binding._ticks = (binding._ticks || 0) + 1);
+    const session = this.claudeSessions.get(sessionId);
 
-    // Periodically (or while unbound) reconcile the binding. A tab STAYS on its
-    // bound session while that file is alive and not owned by another tab; it
-    // only moves to a newer unowned session once its own has gone quiet (an
-    // in-session /resume) — so a third, unrelated session can't steal an active
-    // tab. agent-*.jsonl is excluded by findActiveSessions.
-    if (!binding || binding._ticks % 5 === 0) {
+    // DETERMINISTIC SIDECAR BINDING (terminal tabs launched via github-router).
+    // ai-or-die set AIORDIE_CLAUDE_BIND=<sidecar> on the shell; github-router's
+    // SessionStart/SessionEnd hook writes the ACTIVE claude session id +
+    // transcript path there on every startup / resume / clear / compact. When a
+    // sidecar exists it is AUTHORITATIVE: bind directly to that transcript by
+    // exact path and skip the cwd+mtime inference entirely. Survives in-session
+    // /resume, /clear and exit→relaunch, and works even when liveCwd is null
+    // (cmd.exe / no OSC 7) — the case the inference path gets wrong.
+    const sidecar = session ? await this._readClaudeBindSidecar(session) : null;
+    if (sidecar) {
+      session._sidecarSeen = true;
+      // A SessionEnd record is intentionally NOT acted on: an in-session /resume
+      // or /clear writes end-then-start, and the following start drives the
+      // rebind; a terminal end (logout / prompt_input_exit) means claude exited,
+      // and the PTY onExit flips session.active=false so _pollStickyJsonl stops
+      // pumping this tab. So we keep the current binding (note frozen at its last
+      // state) and only (re)bind on a start with a NEW claude session id.
+      if (
+        sidecar.event !== 'end' &&
+        sidecar.claudeSessionId &&
+        sidecar.transcriptPath &&
+        (!binding || binding.claudeSessionId !== sidecar.claudeSessionId)
+      ) {
+        const stp = await this._statQuiet(sidecar.transcriptPath);
+        if (stp) {
+          this._bindStickyJsonl(sessionId, {
+            file: sidecar.transcriptPath,
+            sessionId: sidecar.claudeSessionId,
+            mtimeMs: stp.mtimeMs,
+            size: stp.size,
+          });
+          binding = this._stickyJsonl.get(sessionId);
+          session.claudePinnedSessionId = sidecar.claudeSessionId;
+          this.sessionStore.markDirty();
+        }
+        // transcript not created yet → wait for a later tick (never inference).
+      }
+      // Pinned tabs never run the mtime inference / resume-follow below.
+    } else if (session && session._sidecarSeen) {
+      // Previously sidecar-managed but the file is momentarily absent/unreadable
+      // → keep the current binding; do NOT fall back to mtime inference (which
+      // could grab a stranger session). Wait for the next sidecar write.
+    } else if (!binding || binding._ticks % 5 === 0) {
+      // INFERENCE FALLBACK (no sidecar — e.g. claude launched without
+      // github-router). Periodically (or while unbound) reconcile the binding. A
+      // tab STAYS on its bound session while that file is alive and not owned by
+      // another tab; it only moves to a newer unowned session once its own has
+      // gone quiet (an in-session /resume) — so a third, unrelated session can't
+      // steal an active tab. agent-*.jsonl is excluded by findActiveSessions.
       const candidates = await StickyNoteJsonl.findActiveSessions(cwd, { projectsDir: this._stickyProjectsDir });
       const ownedByOthers = this._ownedClaudeSessions(sessionId);
       // Only (re)bind to a session being ACTIVELY written (recent mtime). A fresh
@@ -4275,7 +4334,6 @@ class ClaudeCodeWebServer {
       // the recency gate, so a restart / lost binding can re-resume an idle-but-
       // live session. A FRESH tab has no own-session, so it still won't adopt a
       // stale stranger session in the project.
-      const session = this.claudeSessions.get(sessionId);
       const ownClaudeSession = session && session.stickyClaudeSessionId;
       const eligible = (c) => !ownedByOthers.has(c.sessionId) && (freshlyActive(c) || c.sessionId === ownClaudeSession);
       const currentValid =
@@ -4384,8 +4442,98 @@ class ClaudeCodeWebServer {
     for (const [sid, b] of this._stickyJsonl) {
       if (sid !== exceptSessionId && b && b.claudeSessionId) owned.add(b.claudeSessionId);
     }
+    // Also reserve every OTHER tab's pinned (sidecar) claude session, so an
+    // unpinned tab's inference fallback can never adopt a pinned tab's session
+    // even in the window before that tab has finished binding.
+    for (const [sid, s] of this.claudeSessions) {
+      if (sid !== exceptSessionId && s && s.claudePinnedSessionId) owned.add(s.claudePinnedSessionId);
+    }
     return owned;
   }
+
+  /** Absolute path to this server's per-tab claude-bind sidecar directory. */
+  _claudeBindSidecarDir() {
+    const base = (this.sessionStore && this.sessionStore.storageDir) || path.join(os.homedir(), '.ai-or-die');
+    return path.join(base, 'claude-bindings');
+  }
+
+  /**
+   * Allocate (and record on the session) the per-tab sidecar path that
+   * github-router's SessionStart/SessionEnd hook writes the active claude
+   * session id + transcript path into. Returns the absolute path, or null on
+   * failure (the tab then degrades to the inference fallback). Best-effort mkdir.
+   */
+  _prepareClaudeBindSidecar(sessionId, session) {
+    try {
+      const dir = this._claudeBindSidecarDir();
+      try { fs.mkdirSync(dir, { recursive: true }); } catch (_) { /* best-effort */ }
+      const file = path.join(dir, `${sessionId}.json`);
+      // Clear any stale sidecar from a previous run/launch so this fresh terminal
+      // start waits for github-router's next SessionStart write instead of binding
+      // to a dead session's transcript. (Runs before any github-router launch in
+      // this shell, so it can't race the hook.)
+      try { fs.unlinkSync(file); } catch (_) { /* none / best-effort */ }
+      if (session) {
+        session.claudeBindSidecar = file;
+        session._sidecarSeen = false;
+      }
+      return file;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /**
+   * Read + parse the tab's sidecar (written atomically by github-router's hook).
+   * Returns the parsed record `{claudeSessionId, transcriptPath, cwd, event,
+   * source?, reason?}` or null (no file / unreadable / malformed). The file is
+   * tiny, so we re-read every tick (no mtime cache: a SessionEnd→SessionStart
+   * rewrite on /resume can land in the same mtime tick, and a cache keyed on
+   * mtime would then serve the stale record and never rebind). Never throws — any
+   * error yields null so the poll is unaffected.
+   */
+  async _readClaudeBindSidecar(session) {
+    if (!session || !session.claudeBindSidecar) return null;
+    let raw;
+    try {
+      raw = await fs.promises.readFile(session.claudeBindSidecar, 'utf8');
+    } catch (_) {
+      return null; // no sidecar yet (claude not launched via github-router, or pending)
+    }
+    try {
+      const obj = JSON.parse(raw);
+      if (!obj || typeof obj !== 'object' || typeof obj.claudeSessionId !== 'string') return null;
+      return obj;
+    } catch (_) {
+      return null; // mid-write / malformed → skip this tick
+    }
+  }
+
+  /** Best-effort: delete a tab's sidecar file (on session close). */
+  _removeClaudeBindSidecar(session) {
+    const file = session && session.claudeBindSidecar;
+    if (!file) return;
+    try { fs.unlinkSync(file); } catch (_) { /* already gone / best-effort */ }
+  }
+
+  /**
+   * Startup sweep: remove orphan sidecar files (`<sessionId>.json`) whose tab is
+   * no longer in the active session set. Best-effort, bounded, never fatal.
+   */
+  _sweepClaudeBindSidecars() {
+    try {
+      const dir = this._claudeBindSidecarDir();
+      let entries;
+      try { entries = fs.readdirSync(dir); } catch (_) { return; } // no dir → nothing to sweep
+      for (const name of entries) {
+        if (!name.endsWith('.json')) continue;
+        const sid = name.slice(0, -'.json'.length);
+        if (this.claudeSessions.has(sid)) continue; // live tab → keep
+        try { fs.unlinkSync(path.join(dir, name)); } catch (_) { /* best-effort */ }
+      }
+    } catch (_) { /* never fatal */ }
+  }
+
 
   /**
    * Bind a tab to a claude transcript and resume its durable note. Binds near the

--- a/src/sticky-note-jsonl.js
+++ b/src/sticky-note-jsonl.js
@@ -2,10 +2,20 @@
 
 // Read clean conversation turns from a Claude Code session JSONL transcript.
 //
-// `github-router claude` runs the normal claude CLI with CLAUDE_CONFIG_DIR=$HOME/.claude,
-// so each session writes ~/.claude/projects/<cwd-slug>/<sessionId>.jsonl — a complete,
-// structured log (the same source claude uses for --resume). We summarise THIS instead
-// of scraping the Ink TUI (which repaints in place and can't be scraped).
+// claude writes ~/.claude/projects/<cwd-slug>/<sessionId>.jsonl — a complete,
+// structured log (the same source claude uses for --resume). We summarise THIS
+// instead of scraping the Ink TUI (which repaints in place and can't be scraped).
+// When launched under github-router, CLAUDE_CONFIG_DIR points at a per-launch
+// mirror whose `projects` subdir is a junction back to the real ~/.claude/projects,
+// so transcripts still land here.
+//
+// Binding a tab to ITS transcript is done two ways (see src/server.js
+// `_pumpStickyJsonl`): (1) PRIMARY — a per-tab sidecar written by github-router's
+// SessionStart/SessionEnd hook names the exact active session id + transcript
+// path (deterministic; survives /resume, /clear, relaunch); (2) FALLBACK — when
+// no sidecar exists (claude launched without github-router), newest-mtime
+// inference over the cwd's project dir. This module only READS a resolved file;
+// `findActiveSessions`/`findActiveSession` serve the fallback path.
 //
 // Signal we keep: user `string`/`text` prompts, assistant `text` replies, and the NAMES
 // of tools the assistant ran. We skip `thinking`, `tool_result`, metadata line types, and

--- a/src/utils/session-store.js
+++ b/src/utils/session-store.js
@@ -232,6 +232,11 @@ class SessionStore {
                 // the durable per-claude-session note store can be rebuilt after a
                 // restart and resume when that session reopens.
                 stickyClaudeSessionId: session.stickyClaudeSessionId || null,
+                // The claude sessionId pinned via the github-router SessionStart
+                // hook sidecar (terminal tabs). Persisted so the ownership
+                // reservation (_ownedClaudeSessions) survives a restart; the
+                // durable note itself resumes via stickyClaudeSessionId above.
+                claudePinnedSessionId: session.claudePinnedSessionId || null,
                 autoTitle: session.autoTitle || null,
                 nameIsUserSet: session.nameIsUserSet || false,
                 stickyNotesEnabled: session.stickyNotesEnabled !== false

--- a/test/sticky-note-server-wiring.test.js
+++ b/test/sticky-note-server-wiring.test.js
@@ -282,6 +282,7 @@ describe('sticky-note JSONL binding (ownership + resume)', function () {
       broadcastToSession: (id, data) => broadcasts.push({ id, data }),
       sessionStore: { markDirty() {} },
       _ownedClaudeSessions: ClaudeCodeWebServer.prototype._ownedClaudeSessions,
+      _readClaudeBindSidecar: ClaudeCodeWebServer.prototype._readClaudeBindSidecar,
       _bindStickyJsonl: ClaudeCodeWebServer.prototype._bindStickyJsonl,
       _capClaudeNotes: ClaudeCodeWebServer.prototype._capClaudeNotes,
       _statQuiet: ClaudeCodeWebServer.prototype._statQuiet,
@@ -302,6 +303,77 @@ describe('sticky-note JSONL binding (ownership + resume)', function () {
   });
   afterEach(function () {
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+  });
+
+  // --- Deterministic sidecar binding (github-router SessionStart hook) ---
+  it('SIDECAR: binds to the sidecar transcript, ignoring a newer growing unowned session', async function () {
+    const cwd = '/Users/x/proj';
+    const mine = writeSession(cwd, 'mine-session.jsonl', null, 30);   // the tab's own (older)
+    writeSession(cwd, 'other-session.jsonl', null, 1);                // newer, growing, unowned
+    const self = makeBindStub();
+    const sidecar = path.join(dir, 'tab1.json');
+    fs.writeFileSync(sidecar, JSON.stringify({
+      schema: 1, claudeSessionId: 'mine-session', transcriptPath: mine, cwd, event: 'start', source: 'startup', at: Date.now(),
+    }));
+    self.claudeSessions.set('tab1', { nameIsUserSet: false, claudeBindSidecar: sidecar });
+    await self._pumpStickyJsonl('tab1', cwd);
+    const b = self._stickyJsonl.get('tab1');
+    assert.ok(b, 'tab is bound');
+    assert.strictEqual(b.claudeSessionId, 'mine-session', 'binds the sidecar session, not the newest-mtime one');
+    assert.strictEqual(b.file, mine);
+    assert.strictEqual(self.claudeSessions.get('tab1').claudePinnedSessionId, 'mine-session');
+  });
+
+  it('SIDECAR: a changed session id rebinds the tab (in-session /resume)', async function () {
+    const cwd = '/Users/x/proj';
+    const a = writeSession(cwd, 'sess-a.jsonl', null, 30);
+    const bfile = writeSession(cwd, 'sess-b.jsonl', null, 30);
+    const self = makeBindStub();
+    const sidecar = path.join(dir, 'tab1.json');
+    self.claudeSessions.set('tab1', { nameIsUserSet: false, claudeBindSidecar: sidecar });
+    fs.writeFileSync(sidecar, JSON.stringify({ schema: 1, claudeSessionId: 'sess-a', transcriptPath: a, cwd, event: 'start', at: Date.now() }));
+    await self._pumpStickyJsonl('tab1', cwd);
+    assert.strictEqual(self._stickyJsonl.get('tab1').claudeSessionId, 'sess-a');
+    // /resume → sidecar now names sess-b. Force a newer mtime so the read-cache re-parses.
+    fs.writeFileSync(sidecar, JSON.stringify({ schema: 1, claudeSessionId: 'sess-b', transcriptPath: bfile, cwd, event: 'start', source: 'resume', at: Date.now() }));
+    const t = Date.now() / 1000 + 5; fs.utimesSync(sidecar, t, t);
+    await self._pumpStickyJsonl('tab1', cwd);
+    assert.strictEqual(self._stickyJsonl.get('tab1').claudeSessionId, 'sess-b', 'follows the resumed session');
+    assert.strictEqual(self._stickyJsonl.get('tab1').file, bfile);
+  });
+
+  it('SIDECAR: waits (no inference) when the transcript file does not exist yet', async function () {
+    const cwd = '/Users/x/proj';
+    writeSession(cwd, 'stranger.jsonl', null, 1); // a stranger session that inference would grab
+    const self = makeBindStub();
+    const sidecar = path.join(dir, 'tab1.json');
+    fs.writeFileSync(sidecar, JSON.stringify({
+      schema: 1, claudeSessionId: 'pending', transcriptPath: path.join(dir, 'nope', 'pending.jsonl'), cwd, event: 'start', at: Date.now(),
+    }));
+    self.claudeSessions.set('tab1', { nameIsUserSet: false, claudeBindSidecar: sidecar });
+    await self._pumpStickyJsonl('tab1', cwd);
+    assert.strictEqual(self._stickyJsonl.get('tab1'), undefined, 'does NOT bind to the stranger session while waiting');
+  });
+
+  it('SIDECAR: _ownedClaudeSessions reserves a tab pinned via sidecar', function () {
+    const self = makeBindStub();
+    self.claudeSessions.set('tab1', { claudePinnedSessionId: 'pinned-x' });
+    assert.ok(self._ownedClaudeSessions('tab2').has('pinned-x'), 'reserved against other tabs');
+    assert.ok(!self._ownedClaudeSessions('tab1').has('pinned-x'), 'excludes the asking tab');
+  });
+
+  it('SIDECAR: an UNCHANGED sidecar does not re-bind every tick (no churn)', async function () {
+    const cwd = '/Users/x/proj';
+    const a = writeSession(cwd, 'sess-a.jsonl', null, 30);
+    const self = makeBindStub();
+    const sidecar = path.join(dir, 'tab1.json');
+    fs.writeFileSync(sidecar, JSON.stringify({ schema: 1, claudeSessionId: 'sess-a', transcriptPath: a, cwd, event: 'start', at: Date.now() }));
+    self.claudeSessions.set('tab1', { nameIsUserSet: false, claudeBindSidecar: sidecar });
+    await self._pumpStickyJsonl('tab1', cwd);
+    const first = self._stickyJsonl.get('tab1');
+    assert.ok(first && first.claudeSessionId === 'sess-a');
+    await self._pumpStickyJsonl('tab1', cwd); // same sidecar, same id → must NOT rebind
+    assert.strictEqual(self._stickyJsonl.get('tab1'), first, 'binding object is the SAME (no re-bind)');
   });
 
   it('binds a tab to its claude session and skips agent-*.jsonl', async function () {


### PR DESCRIPTION
## Problem
Running `npx github-router@latest claude` in multiple **Terminal** tabs across distinct projects, the sticky note tends to show the **one growing** claude session across all tabs.

**Root cause:** the binder scopes by `liveCwd || workingDir` then picks newest-mtime. Terminal-launched claude has `liveCwd` null (`cmd.exe` / no OSC 7 prompt hook), so every tab collapses onto the same folder-mode base dir, all scan one `~/.claude/projects/<base-slug>/`, and the single actively-growing session wins everywhere.

## Fix
Make claude itself authoritative via its **SessionStart/SessionEnd hook** (auto-maintained across `/resume`, `/clear`, `/compact`, exit→relaunch):
- ai-or-die sets `AIORDIE_CLAUDE_BIND=<dataDir>/claude-bindings/<sessionId>.json` on each Terminal shell (via a new `base-bridge` `extraEnv`).
- github-router's hook atomically writes `{claudeSessionId, transcriptPath, event, …}` there.
- The tab binds **directly to that transcript by exact path** (`_pumpStickyJsonl`); pinned ids are reserved in `_ownedClaudeSessions`; stale sidecars are cleared on terminal (re)start and swept on startup / removed on close.
- Newest-mtime inference (ADR-0024) stays **only** as the no-sidecar fallback (regression-free for claude launched without github-router).

See **ADR-0026** (supersedes the deferred `--session-id` fix in ADR-0024), `docs/specs/sticky-notes.md`, `docs/history/sticky-notes-2026.md`.

## ⚠️ Cross-repo dependency
Needs the producer side: **animeshkundu/github-router#70** (`feat/aiordie-session-bind-hook`). This PR alone only improves the fallback. Ship together. Contract = one env var + a versioned JSON sidecar.

## Verification
- ✅ Sticky-note unit tests pass (45; incl. contamination repro, `/resume` rebind, no-churn regression). Full suite 1323 passing; the only 3 failures are pre-existing `ripgrep`-not-installed env failures in `search-utils.test.js`, unrelated.
- ✅ **Cross-repo integration run**: the real compiled github-router hook binary produced sidecars that the real `_pumpStickyJsonl` consumed correctly — bound its own session, ignored a newer stranger session, and followed `/resume`.
- ✅ Cross-lab line-level review (OpenAI + Google); 2 real findings fixed (mtime read-cache dropped to avoid a same-ms `/resume` miss; realpath walk-up).
- ❌ **Not** verified live: an actual interactive Claude Code session firing the hooks on `/resume`/`/clear` on Windows (payload shape is from official docs; couldn't drive an interactive TTY). This is the remaining manual check.