### PR TITLE
feat: deterministic process shutdown (no zombie node/bun processes)

### DIFF
--- a/bin/supervisor.js
+++ b/bin/supervisor.js
@@ -5,6 +5,7 @@
 const { spawn } = require('child_process');
 const path = require('path');
 const { RESTART_EXIT_CODE } = require('../src/restart-manager');
+const jobGuard = require('../src/job-guard');
 
 // ---------------------------------------------------------------------------
 // Tunables — all overridable via env vars so the regression test can shrink
@@ -14,7 +15,12 @@ const { RESTART_EXIT_CODE } = require('../src/restart-manager');
 
 const RESTART_DELAY_MS         = parseInt(process.env.RESTART_DELAY_MS, 10)         || 1000;     // clean RESTART_EXIT_CODE respawn
 const CRASH_RESTART_DELAY_MS   = parseInt(process.env.CRASH_RESTART_DELAY_MS, 10)   || 3000;     // normal crash respawn
-const SHUTDOWN_TIMEOUT_MS      = parseInt(process.env.SHUTDOWN_TIMEOUT_MS, 10)      || 10000;    // SIGINT/SIGTERM hard-kill fallback
+// Must stay strictly GREATER than the server's own 15s force-exit budget
+// (src/server.js handleShutdown) so a hung graceful shutdown lets the server
+// finish (or self-force-exit) its own ordered teardown — including killing its
+// PTY trees — before the supervisor hard-kills it. A supervisor SIGKILL that
+// preempted the server would orphan the server's PTY/grandchild tree.
+const SHUTDOWN_TIMEOUT_MS      = parseInt(process.env.SHUTDOWN_TIMEOUT_MS, 10)      || 20000;    // SIGINT/SIGTERM hard-kill fallback
 
 // Tier 1 — tight crash loop. 3 crashes in 30 s historically tripped a hard
 // process.exit(1). The fix replaces that with an extended restart delay
@@ -48,6 +54,12 @@ let shuttingDown = false;
 let spawnCount = 0;
 let crashTimestamps = [];
 let pendingRestartTimer = null;
+
+// Windows Job Object guard. Set up once at startup (below, before the first spawn).
+// `jobGuardHandle` is held for the supervisor's entire life and intentionally NEVER
+// closed by us — process death closes it, which is exactly what fires KILL_ON_JOB_CLOSE.
+let jobGuardHandle = null;
+let jobGuardActive = false;
 
 // Queued IPC message delivered to the NEXT spawned child once its IPC channel
 // is open. Used to forward tier-2 escalation downstream so the in-process
@@ -121,6 +133,9 @@ function startServer() {
     env: {
       ...process.env,
       SUPERVISED: '1',
+      // Tell the server whether the kill-on-close job guard is active, so it can
+      // surface the unprotected state in /api/diagnostics (jobGuard:false).
+      AOD_JOB_GUARD: jobGuardActive ? '1' : '0',
       ...(isRestart ? { AOD_SUPERVISOR_RESTART: '1' } : {})
     }
   });
@@ -252,4 +267,39 @@ process.on('message', (msg) => {
   if (msg && msg.type === 'shutdown') shutdownGracefully();
 });
 
+// Establish the Windows Job Object guard BEFORE the first spawn so the server and its
+// entire future tree (PTYs, the CLI's node/bun MCP grandchildren) auto-join the job.
+// AssignProcessToJobObject is forward-looking: future children join, so the supervisor
+// must be assigned while it still has no descendants — i.e. before startServer(). When
+// the supervisor dies for ANY reason (Ctrl+C, crash, taskkill /F, console close), the OS
+// closes the in-process handle and the kernel atomically terminates the whole job.
+// No-op on non-Windows / when koffi is unavailable (jobGuardActive stays false →
+// best-effort teardown, surfaced as jobGuard:false in /api/diagnostics).
+function setupJobGuard() {
+  try {
+    if (!jobGuard.isAvailable()) {
+      if (process.platform === 'win32') {
+        console.warn('[supervisor] ⚠ process-guard: koffi unavailable; using best-effort teardown. ' +
+          'Child node/bun processes may survive an uncatchable kill (taskkill /F).');
+      }
+      return;
+    }
+    jobGuardHandle = jobGuard.createKillOnCloseJob();
+    if (jobGuardHandle && jobGuard.assignSelf(jobGuardHandle)) {
+      jobGuardActive = true;
+      console.log('[supervisor] process-guard: kill-on-close job active — the whole tree dies with the supervisor.');
+    } else {
+      jobGuardHandle = null;
+      console.warn('[supervisor] ⚠ process-guard: could not create/assign the job object ' +
+        '(outer job UI limits / EDR / silo?); using best-effort teardown. ' +
+        'Child node/bun processes may survive an uncatchable kill.');
+    }
+  } catch (e) {
+    jobGuardHandle = null;
+    jobGuardActive = false;
+    console.warn('[supervisor] ⚠ process-guard: setup failed (' + (e && e.message) + '); continuing without it.');
+  }
+}
+
+setupJobGuard();
 startServer();

--- a/docs/adrs/0031-deterministic-process-shutdown.md
+++ b/docs/adrs/0031-deterministic-process-shutdown.md
@@ -1,0 +1,84 @@
+# ADR-0031: Deterministic process shutdown (no zombie node/bun processes)
+
+## Status
+
+Accepted — 2026-06-19.
+
+## Context
+
+ai-or-die runs a deep process tree. `bin/supervisor.js` (the top "main" process) forks
+`bin/ai-or-die.js` (the server) and restarts it on crash/memory-restart (exit code 75). The
+server spawns PTYs via `@lydell/node-pty` (ConPTY on Windows) plus worker threads, tunnel
+children, a keepalive helper, and ripgrep. Inside each PTY runs a CLI (claude/codex/gemini)
+that spawns **its own** children — MCP servers that are `node`/`bun` processes, ripgrep,
+hooks. The server does not own that grandchild layer.
+
+The graceful shutdown path (SIGINT/SIGTERM/IPC) was already mature. The gap was **orphans**:
+when the tree was torn down non-gracefully, the CLI's `node`/`bun` grandchildren survived.
+Root causes (all verified):
+
+- node-pty's Windows `kill()` (ConPTY path) does not walk the console process list, so the
+  CLI's grandchildren outlive a PTY kill.
+- `BaseBridge.stopSession()` had no force-kill escalation (it waited 3s then stopped waiting).
+- The supervisor force-SIGKILLed the server at 10s while the server's own force-exit was 15s,
+  so a hung shutdown killed the server before it could tear down its tree.
+- On IPC `disconnect` the server logged "continuing standalone" and kept running — killing
+  the supervisor orphaned the whole tree.
+- `uncaughtException` exited without tearing down PTYs.
+
+An adversarial design review (multiple independent reviewers across Windows-internals,
+POSIX/Node, and scope/maintainability perspectives) shaped the design. Key confirmed facts:
+
+- A Win32 Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` terminates **every** process
+  in the job atomically when the last handle closes — even on `taskkill /F` — with no user
+  code running. `AssignProcessToJobObject` is forward-looking: future descendants auto-join.
+- Current node-pty/ConPTY sets **no** `CREATE_BREAKAWAY_FROM_JOB`, so the shell + its
+  `node`/`bun`/`rg` descendants stay in an ancestor job. (Implementation gate: clear the
+  job's `BREAKAWAY_OK`, and the grandchild-dies integration test is the live proof.)
+- POSIX has no equivalent that survives an uncatchable parent kill short of cgroup v2
+  delegation. Process groups + watchdogs are best-effort (`setsid`/daemonized children escape).
+
+## Decision
+
+1. **Windows (primary) — kernel-enforced via Job Objects, held in-process with the koffi FFI.**
+   - The **supervisor** creates a kill-on-close job and assigns **itself** before forking the
+     server (`bin/supervisor.js`, `src/job-guard.js`). Its whole future tree joins; supervisor
+     death by any means closes the in-process handle and the kernel reaps the tree. The job
+     persists across server restarts (only supervisor death closes the handle), so the exit-75
+     memory restart is unaffected.
+   - Each **PTY** gets its own nested kill-on-close job (`src/base-bridge.js`); closing that
+     handle on `stopSession`/exit atomically kills the PTY + its grandchildren — deterministic
+     per-session teardown that also satisfies "subprocesses restart independently while alive."
+   - Held in-process via **koffi** (a vetted FFI), not a separate helper (which would be a
+     single point of failure) and not PowerShell (whose `Add-Type`→`csc.exe` is blocked by
+     CLM/WDAC/AMSI on hardened corporate boxes — the primary audience).
+   - **Degraded mode** (koffi/job create/assign fails: EDR/CLM/silo/outer-job UI limits): start
+     anyway, log a prominent warning, surface `jobGuard:false` in `/api/diagnostics`, and fall
+     back to best-effort `taskkill /T /F` teardown.
+
+2. **POSIX (best-effort).** PTYs are session leaders (node-pty `forkpty`→`setsid`); teardown
+   escalates to a process-group kill (`kill(-pgid, SIGKILL)`) on every controlled path. The
+   `setsid`/daemonized-grandchild crash-path gap is documented; cgroup v2 (`systemd-run --user
+   --scope -p Delegate=yes`) is the opt-in hard path. The PDEATHSIG/subreaper/getppid stack was
+   considered and **cut** as fragile + low-value for a secondary platform.
+
+3. **Cross-cutting.** The server's IPC `disconnect` handler now tears down its PTY trees and
+   exits when the supervisor dies (gated on `isShuttingDown` so it never races the exit-75
+   restart), replacing "continue standalone." `uncaughtException` reaps PTY subtrees before
+   exit. The supervisor hard-kill window was raised to 20s (strictly above the server's 15s
+   force-exit) so the server always finishes its own teardown first.
+
+4. **No startup reaper / no PID-identity machinery.** The Job Objects make prior-run orphans
+   near-impossible on Windows; on POSIX a reaper can't reach `setsid`'d grandchildren anyway;
+   and killing by recorded PID carries PID-reuse wrong-kill risk. Cut.
+
+## Consequences
+
+- **Windows**: the whole tree (server, PTYs, `node`/`bun` MCP grandchildren) dies deterministically
+  whenever the supervisor dies, for any reason. Adds one dependency (`koffi`, prebuilt FFI).
+- **POSIX**: honest best-effort — solves the grandchild case in the graceful path and the
+  in-group crash path; daemonized escapees can survive without cgroup delegation (documented).
+- A new native-FFI dependency means SEA-binary packaging must bundle koffi's prebuilt `.node`
+  (follow-up; the build already handles node-pty/sherpa/llama natives).
+- See `docs/specs/process-shutdown.md` for the mechanism detail, the breakaway re-verification
+  gate (re-run on every node-pty upgrade), and the test matrix.

--- a/docs/audits/proc-child-processes.md
+++ b/docs/audits/proc-child-processes.md
@@ -276,6 +276,23 @@ shutdown/restart APIs in earnest.
   `vscode-tunnel.js:327–346` and the login teardown at `:232–235`)
   into a single helper. Pure code-hygiene; no behavior change.
 
+## Update (2026-06-19): deterministic shutdown / PTY-grandchild gap closed
+
+This memo audited the app's OWN child-process owners (STT worker, tunnels, vscode-tunnel).
+A separate, larger gap — the CLI's `node`/`bun` MCP **grandchildren** spawned *inside* a PTY,
+which node-pty's Windows `kill()` does not reap — is now addressed by the deterministic-shutdown
+work in **ADR-0031** / `docs/specs/process-shutdown.md`:
+
+- Windows: a kill-on-close Job Object held in-process by the supervisor (whole tree dies with
+  it) plus per-PTY nested jobs (`src/job-guard.js`, `src/base-bridge.js`).
+- POSIX: process-group escalation, best-effort (`src/utils/process-tree.js`); honest `setsid`
+  crash-path limitation documented in the spec.
+- Cross-cutting: the server's IPC `disconnect` handler now reaps + exits on supervisor death
+  (was "continue standalone"), `uncaughtException` reaps PTY subtrees, and the supervisor
+  shutdown timeout (20s) was ordered above the server force-exit (15s).
+
+The `_loginProcess.kill()` no-follow-up-wait item below remains open (low severity).
+
 ## References
 
 - `src/stt-engine.js:148–195` — `_onWorkerExit` and `_restartWorker`

--- a/docs/specs/process-shutdown.md
+++ b/docs/specs/process-shutdown.md
@@ -46,10 +46,23 @@ No-op on non-Windows and whenever koffi is unavailable. Never throws into the ca
    still in the **supervisor** job, so it dies on supervisor death regardless. The per-PTY job is
    per-session convenience + defense in depth, not the primary guarantee.
 
-**Degraded mode**: if koffi won't load or job create/assign fails (EDR / Constrained Language
-Mode / Server Silo / outer-job UI limits → `ERROR_ACCESS_DENIED`), the supervisor still starts,
-logs a prominent warning, and the server reports `process_guard.job_guard_active = false` in
-`/api/diagnostics`. Teardown then falls back to best-effort `taskkill /T /F` (`src/utils/process-tree.js`).
+**Degraded mode**: the deterministic kernel guarantee needs koffi + a usable Job Object. When
+that's unavailable — koffi fails to load (e.g. the **SEA single-file binary**, where koffi is
+left as an external runtime require and there is no `node_modules`), `AssignProcessToJobObject`
+is denied (EDR / Constrained Language Mode / Server Silo / outer-job UI limits), or the operator
+sets `AOD_DISABLE_JOB_GUARD=1` — `isAvailable()` returns false and **every** teardown path falls
+back to the best-effort `src/utils/process-tree.js` helper: `taskkill /T /F /PID` on Windows, a
+`kill(-pgid)` process-group kill on POSIX. This fires on the spawn-watchdog, error, `stopSession`,
+`uncaughtException`, and IPC-disconnect paths (gated on "no job was closed", so it never
+double-kills when the kernel job already reaped the subtree). The supervisor logs a prominent
+warning and the server reports `process_guard.job_guard_active=false` in `/api/diagnostics`.
+
+> **SEA binary note:** `sea-bootstrap.js` runs `bin/ai-or-die.js` **directly** (no supervisor),
+> and koffi is externalized out of the bundle, so the packaged binary always runs in degraded
+> mode: best-effort `taskkill` teardown on the paths it controls, no kernel guarantee against an
+> uncatchable kill. Wiring full koffi-in-SEA (extracting `@koromix/koffi-<platform>-<arch>` as a
+> SEA asset + a load shim, mirroring `pty-sea-shim.js`) is a tracked follow-up. The npm-install
+> path (the supervisor + koffi) gets the full kernel guarantee.
 
 ### POSIX (best-effort)
 

--- a/docs/specs/process-shutdown.md
+++ b/docs/specs/process-shutdown.md
@@ -1,0 +1,101 @@
+# Spec: Deterministic process shutdown
+
+Status: implemented (2026-06-19). See ADR-0031.
+
+Goal: **no live orphaned `node`/`bun` processes.** When the top process (the supervisor)
+dies for ANY reason — Ctrl+C, crash, `taskkill /F`, SIGKILL, console close — the entire
+descendant tree (server, PTYs, and the CLI's MCP `node`/`bun` grandchildren) must die. While
+the system is alive, individual subprocesses (tunnels, workers, the server itself) keep
+restarting independently; only top-process death brings everything down.
+
+("Zombie" here means a *live orphan*, not a POSIX `<defunct>` entry — those are auto-reaped
+by init/launchd.)
+
+## Mechanism
+
+### Windows (primary) — Job Objects (`src/job-guard.js`, koffi FFI)
+
+`src/job-guard.js` wraps the Win32 job APIs via `koffi`:
+- `createKillOnCloseJob()` — `CreateJobObjectW` + `SetInformationJobObject`
+  (`JOBOBJECT_EXTENDED_LIMIT_INFORMATION` with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`;
+  `BREAKAWAY_OK` deliberately **off**). Non-inheritable handle.
+- `assignSelf(job)` — `AssignProcessToJobObject(GetCurrentProcess())`.
+- `assignPid(job, pid)` — `OpenProcess(PROCESS_TERMINATE|PROCESS_SET_QUOTA)` → assign → close
+  the process handle (not the job).
+- `closeJob(job)` — `CloseHandle`; on a kill-on-close job this is the teardown trigger.
+
+No-op on non-Windows and whenever koffi is unavailable. Never throws into the caller.
+
+**Two jobs:**
+1. **Supervisor-level** (`bin/supervisor.js`): created and self-assigned **before** the first
+   `startServer()` fork, so the server and every future descendant auto-join. The handle is
+   held for the supervisor's life and **never closed by us** — process death closes it, firing
+   `KILL_ON_JOB_CLOSE`. Persists across server restarts (only supervisor death closes it).
+2. **Per-PTY nested** (`src/base-bridge.js`): each PTY is assigned to its own kill-on-close job
+   right after spawn (before the CLI boots, so the CLI's future grandchildren auto-join).
+   `stopSession`, natural exit, the error path, and the spawn-watchdog all close the handle →
+   the PTY + its grandchildren die atomically; the handle is freed.
+
+   *Natural-exit behavior (intentional):* when a PTY exits on its own, `_disposePtyJob` still
+   closes the job, which reaps any descendants the CLI left running (e.g. detached MCP/helper
+   `node`/`bun` processes). This is a deliberate change from the prior behavior where such
+   descendants survived the PTY — the goal is no orphans.
+   the assignment. A child the shell spawns in the sub-tick between node-pty's `spawn()` and
+   `_attachPtyJob` would miss the per-PTY job. In practice the PTYs run interactive CLIs that
+   take seconds to boot before spawning MCP servers, so the window is empty; and any escapee is
+   still in the **supervisor** job, so it dies on supervisor death regardless. The per-PTY job is
+   per-session convenience + defense in depth, not the primary guarantee.
+
+**Degraded mode**: if koffi won't load or job create/assign fails (EDR / Constrained Language
+Mode / Server Silo / outer-job UI limits → `ERROR_ACCESS_DENIED`), the supervisor still starts,
+logs a prominent warning, and the server reports `process_guard.job_guard_active = false` in
+`/api/diagnostics`. Teardown then falls back to best-effort `taskkill /T /F` (`src/utils/process-tree.js`).
+
+### POSIX (best-effort)
+
+node-pty PTYs are session leaders (`forkpty`→`setsid`), so teardown escalates with
+`kill(-pgid, SIGKILL)` (`src/utils/process-tree.js`) on the spawn-watchdog, error, and
+`stopSession`-timeout paths. This reaches grandchildren that stayed in the group.
+
+**Honest limitation**: a grandchild that calls `setsid()` / daemonizes starts its own group
+and escapes `kill(-pgid)`. After a server crash there is no record of its pid, so it can
+survive. The only airtight POSIX option is cgroup v2 `cgroup.kill`, which needs a delegated
+subtree — launch via `systemd-run --user --scope -p Delegate=yes` to get one. macOS has no
+PDEATHSIG and no cgroups; daemonized grandchildren can survive there.
+
+### Cross-cutting
+
+- **Supervisor-death watchdog** (`src/server.js`): the IPC `disconnect` handler, when
+  `isShuttingDown` is false, reaps all PTY subtrees and shuts the server down (replacing the
+  old "continue standalone"). On Windows the kernel job usually kills the server first; this is
+  the cross-platform / degraded-mode backstop. Gated on `isShuttingDown` so it never fires
+  during the legitimate exit-75 memory restart (where the channel close is expected).
+- **uncaughtException** (`src/server.js`): synchronously reaps PTY subtrees before `exit(1)`.
+- **Timeout ordering**: supervisor hard-kill window = 20s (`SHUTDOWN_TIMEOUT_MS`), strictly
+  greater than the server's 15s force-exit, so the server always completes its own teardown.
+
+## Re-verification gate (run on every node-pty upgrade)
+
+The Windows guarantee depends on nothing in the tree setting `CREATE_BREAKAWAY_FROM_JOB`.
+- Grep the vendored native source/binary for `CREATE_BREAKAWAY_FROM_JOB` / `0x01000000`.
+- The job sets `BREAKAWAY_OK` off, so a breakaway *request* is ignored.
+- `test/longevity/process/job-tree-kill.test.js` (a real grandchild that must die) is the live
+  proof; treat its failure after an upgrade as "node-pty reintroduced breakaway."
+
+## Tests
+
+- `test/job-guard.test.js` — unit: non-win32 no-op; on win32, create+assign+close kills an
+  assigned child (proves koffi struct marshaling + KILL_ON_JOB_CLOSE).
+- `test/process-tree.test.js` — unit: taskkill arg shape + POSIX group-kill order (injected mocks).
+- `test/longevity/process/job-tree-kill.test.js` — per-PTY job close kills a grandchild; an
+  uncatchable `taskkill /F` of a self-assigned parent reaps a grandchild. (Windows; skips elsewhere.)
+- `test/longevity/process/supervisor-tree-kill.test.js` — the real `bin/supervisor.js`: an
+  uncatchable `taskkill /F` of the supervisor reaps its forked child via the job. (Windows.)
+
+## Files
+
+- `src/job-guard.js` — koffi Win32 job wrappers (no-op off win32).
+- `src/utils/process-tree.js` — `taskkill /T /F` (Windows degraded) + `kill(-pgid)` (POSIX).
+- `bin/supervisor.js` — supervisor job self-assign before fork; 20s shutdown timeout.
+- `src/base-bridge.js` — per-PTY job attach/close across all teardown paths; POSIX pgid escalation.
+- `src/server.js` — IPC `disconnect` watchdog, `uncaughtException` reap, `process_guard` diagnostics.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "fuzzysort": "^3.1.0",
-        "node-llama-cpp": "^3.18.1",
+        "koffi": "^3.0.2",
         "open": "^10.1.0",
         "selfsigned": "^2.4.1",
         "sherpa-onnx-node": "^1.12.24",
@@ -635,6 +635,230 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-OaL5EViEvsdbc8Ut90zY44AKF3mq6JBqkK/xLkGaSXcLsOJUsD+XaPAZb/WOWcKVg7On31wP+4hB7MwHQPdiUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-ZkBKudZkIOy5yVcp8cUTFCrE5DSgxkcH26mUxV6m8JgUtvtps4iMIGAAZLSq5aouvQQKhbKpXtZ3YdzpcytM+g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.0.2.tgz",
+      "integrity": "sha512-eVHMjYL6yMc7GOdH0juDVEYFU4D9Az6cqyI7+ytWwovwAjHNtf96S17Ag/aI2qs7WVCoHceKDdMUATzs5grvMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.0.2.tgz",
+      "integrity": "sha512-qiSkR5fF/oa8MIukjsXMmFPC/FWGfUtw3ee+jgURg0R+Tuhlvqlfh50W4rQ0Y0faITJcF+3wmCI6WSt7p4iCkA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.0.2.tgz",
+      "integrity": "sha512-RDqoD8tBiRoe1C/lZEdMWETKk2dTR298XgJ9PBXbw2ETMVpIX+ci++X+j+4e7J3kVldxHLdFCykNei6d1wmhTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-zIm5NlzFuxt4f6mDjwTDgfzu8oZngcALTmOkWbp7HSeWdjQeiy8JRaSOEpfzlIlqWoPxhRUX5Yniqkt8564VnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.0.2.tgz",
+      "integrity": "sha512-Le3JxJswxBhO3OeeSWA400/v2sTPwTWz/IIc6ARc4SbTGUcz2jm6jXXQviW01r5OvCQ+w2Q2T4PxP+eaRa2+fQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.0.2.tgz",
+      "integrity": "sha512-TiPOFy4OX0tLhKwL6oSOhDIhwd5b48x7nxCBT8u6IW+nLXMIo2j+jla1h9niQ8HVGknGOzu48k55KVl0YMsaew==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.0.2.tgz",
+      "integrity": "sha512-U44szVAHW4WKTV0s6K6rjeZEURJ0CFHbZC0Ik3lpzvEidbOu8dTft7OGNr4hhBvx/XaeLMCCebPLBoYZZNW2Dg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.0.2.tgz",
+      "integrity": "sha512-bm4qT+e59KWn4V/jK8uF1RV2k0/JJvmGPUj4qCJ3E9663H+6ZLqz1rpCdgXSEA95f5CNR3RWcgjQwxgKO9xFtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.0.2.tgz",
+      "integrity": "sha512-tUu2LMSyeCSe1DbJKZrjGOKRQzDhj/RAw4rVdlHXlU/B26sdyKZjEwE3GxVlYDdEBX4FiYYmoVuG3BwGWSefCw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.0.2.tgz",
+      "integrity": "sha512-o4QZwsKIQvlMSIJaCXsu8d2sz4bbKEJrZhmnCeT/SKEU1VEiegmDn/I6DYrg5mOMDC15GWlUP1qP6AsVlrxqXA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.0.2.tgz",
+      "integrity": "sha512-Yz/iP2xLaq8t3TFy5+f2Oww7rBpXgZ4YRexdYffSm2EwcnDeCtPudQSjIiKyEBdvDsU2vQetTrxyqDHStXXocw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-zozoHzvSi61jch4sKqFi3ATsDC7lviFthoivzPKVk4VeJvFeSdqueKoYGHNXEzfhIXn9Y5K85l9a59nwfutkUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
     "node_modules/@kwsites/file-exists": {
@@ -3244,6 +3468,32 @@
       "optional": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.0.2.tgz",
+      "integrity": "sha512-YS4sGzlVMhFNNkKbkB3tcLKJxH9WGP3jHTxi4Eyx+ieMRKVz4K2i+6rebYr9ngHN36jhIW6YXnxkzBeOQ51lsw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-darwin-arm64": "3.0.2",
+        "@koromix/koffi-darwin-x64": "3.0.2",
+        "@koromix/koffi-freebsd-arm64": "3.0.2",
+        "@koromix/koffi-freebsd-ia32": "3.0.2",
+        "@koromix/koffi-freebsd-x64": "3.0.2",
+        "@koromix/koffi-linux-arm64": "3.0.2",
+        "@koromix/koffi-linux-ia32": "3.0.2",
+        "@koromix/koffi-linux-loong64": "3.0.2",
+        "@koromix/koffi-linux-riscv64": "3.0.2",
+        "@koromix/koffi-linux-x64": "3.0.2",
+        "@koromix/koffi-openbsd-ia32": "3.0.2",
+        "@koromix/koffi-openbsd-x64": "3.0.2",
+        "@koromix/koffi-win32-ia32": "3.0.2",
+        "@koromix/koffi-win32-x64": "3.0.2"
       }
     },
     "node_modules/lifecycle-utils": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "fuzzysort": "^3.1.0",
+    "koffi": "^3.0.2",
     "open": "^10.1.0",
     "selfsigned": "^2.4.1",
     "sherpa-onnx-node": "^1.12.24",

--- a/scripts/build-sea.js
+++ b/scripts/build-sea.js
@@ -52,6 +52,19 @@ async function bundle() {
       'sherpa-onnx-darwin-arm64',
       // open uses dynamic import() — lazy-loaded in bin/ai-or-die.js
       'open',
+      // koffi (Windows Job Object FFI) loads a per-platform native addon
+      // (@koromix/koffi-<platform>-<arch>/.../koffi.node) that esbuild can't
+      // bundle ("No loader for .node"). Leave it as a runtime require: in a
+      // normal npm install it loads fully; in the SEA binary (no node_modules)
+      // the require throws and src/job-guard.js degrades to best-effort teardown
+      // (jobGuard:false). See docs/specs/process-shutdown.md.
+      'koffi',
+      '@koromix/koffi-win32-x64',
+      '@koromix/koffi-win32-arm64',
+      '@koromix/koffi-linux-x64',
+      '@koromix/koffi-linux-arm64',
+      '@koromix/koffi-darwin-x64',
+      '@koromix/koffi-darwin-arm64',
     ],
   });
 

--- a/src/base-bridge.js
+++ b/src/base-bridge.js
@@ -343,9 +343,11 @@ class BaseBridge {
           try { ptyProcess.kill(); } catch (e) { /* ignore */ }
           // Reap the PTY subtree (Windows job close / POSIX group kill) so a hung-at-startup
           // shell + any children it already spawned don't leak.
-          this._disposePtyJob(session);
-          if (process.platform !== 'win32' && ptyProcess && ptyProcess.pid) {
-            try { killProcessTreeSync(ptyProcess.pid); } catch (_) { /* best-effort */ }
+          {
+            const jobClosed = this._disposePtyJob(session);
+            if (!jobClosed && ptyProcess && ptyProcess.pid) {
+              try { killProcessTreeSync(ptyProcess.pid); } catch (_) { /* best-effort */ }
+            }
           }
           onError(new Error(`${this.toolName} process did not respond within ${SPAWN_TIMEOUT_MS / 1000} seconds. The command may not be installed or may have hung during startup.`));
         }
@@ -463,9 +465,11 @@ class BaseBridge {
         try { ptyProcess.kill(); } catch (e) { /* ignore — may already be dead */ }
         // Reap the subtree (Windows job close / POSIX group kill) so the shell's
         // node/bun grandchildren don't outlive the failed session.
-        this._disposePtyJob(session);
-        if (process.platform !== 'win32' && ptyProcess && ptyProcess.pid) {
-          try { killProcessTreeSync(ptyProcess.pid); } catch (_) { /* best-effort */ }
+        {
+          const jobClosed = this._disposePtyJob(session);
+          if (!jobClosed && ptyProcess && ptyProcess.pid) {
+            try { killProcessTreeSync(ptyProcess.pid); } catch (_) { /* best-effort */ }
+          }
         }
         if (this.sessions.has(sessionId)) {
           session.active = false;
@@ -641,13 +645,17 @@ class BaseBridge {
    * Close a session's per-PTY job handle. On Windows this is the deterministic teardown:
    * KILL_ON_JOB_CLOSE terminates the PTY + every descendant still in the job (the node/bun
    * grandchildren). Also frees the kernel handle. Idempotent; no-op when no handle exists.
+   * Returns true when a job was actually closed (the subtree is reaped deterministically),
+   * false otherwise — callers use this to decide whether to escalate to the best-effort
+   * fallback (taskkill /T /F on Windows / process-group kill on POSIX) for the degraded
+   * path where no job exists (koffi unavailable: SEA binary, EDR/CLM-blocked, or POSIX).
    * @private
    */
   _disposePtyJob(session) {
-    if (!session || !session.jobHandle) return;
+    if (!session || !session.jobHandle) return false;
     const h = session.jobHandle;
     session.jobHandle = null;
-    try { jobGuard.closeJob(h); } catch (_) { /* ignore */ }
+    try { return !!jobGuard.closeJob(h); } catch (_) { return false; }
   }
 
   async stopSession(sessionId) {
@@ -701,16 +709,18 @@ class BaseBridge {
         if (waitDisposable && typeof waitDisposable.dispose === 'function') {
           try { waitDisposable.dispose(); } catch (_) { /* ignore */ }
         }
-        // Deterministic subtree teardown. On Windows, closing the per-PTY kill-on-close
-        // job terminates the shell + its node/bun grandchildren and frees the handle —
-        // this is what node-pty's own kill() cannot do (it doesn't walk the console
-        // process list). On POSIX, if the PTY did NOT exit on its own (the 3s timeout
-        // fired), escalate to a process-group kill; node-pty PTYs are session leaders so
-        // the negative-pid reaches in-group grandchildren. (We avoid group-killing after a
-        // clean exit to sidestep any pgid-reuse window.)
-        this._disposePtyJob(session);
-        if (!exited && process.platform !== 'win32' && ptyPid) {
-          try { killProcessTreeSync(ptyPid); } catch (_) { /* best-effort */ }
+        // Deterministic subtree teardown. On Windows with the job guard, closing the
+        // per-PTY kill-on-close job terminates the shell + its node/bun grandchildren and
+        // frees the handle — what node-pty's own kill() cannot do. When no job was closed
+        // (degraded: koffi unavailable in a SEA binary / EDR-blocked, or POSIX) AND the PTY
+        // did not exit on its own, escalate to the best-effort fallback: taskkill /T /F on
+        // Windows, or a process-group kill on POSIX (node-pty PTYs are session leaders). We
+        // skip the fallback after a clean exit to sidestep any pid/pgid-reuse window.
+        {
+          const jobClosed = this._disposePtyJob(session);
+          if (!jobClosed && !exited && ptyPid) {
+            try { killProcessTreeSync(ptyPid); } catch (_) { /* best-effort */ }
+          }
         }
         resolve();
       };
@@ -766,8 +776,11 @@ class BaseBridge {
    */
   killAllSubtreesSync() {
     for (const [, session] of this.sessions) {
-      try { this._disposePtyJob(session); } catch (_) { /* ignore */ }
-      if (process.platform !== 'win32' && session && session.process && session.process.pid) {
+      let jobClosed = false;
+      try { jobClosed = this._disposePtyJob(session); } catch (_) { jobClosed = false; }
+      // Degraded fallback (no job closed): taskkill /T /F on Windows, process-group kill
+      // on POSIX. When the job WAS closed the kernel already reaped the subtree.
+      if (!jobClosed && session && session.process && session.process.pid) {
         try { killProcessTreeSync(session.process.pid); } catch (_) { /* ignore */ }
       }
     }

--- a/src/base-bridge.js
+++ b/src/base-bridge.js
@@ -3,6 +3,8 @@ const { execFile } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
+const jobGuard = require('./job-guard');
+const { killProcessTreeSync } = require('./utils/process-tree');
 
 /** Chunk size for PTY writes — safely below ConPTY ~16KB kernel buffer */
 const PTY_WRITE_CHUNK_SIZE = 4096;
@@ -314,6 +316,11 @@ class BaseBridge {
 
       this.sessions.set(sessionId, session);
 
+      // Windows: enclose the PTY in its own kill-on-close Job Object now, before the CLI
+      // boots, so the CLI's future node/bun MCP grandchildren auto-join and can be reaped
+      // atomically on stopSession. No-op elsewhere.
+      this._attachPtyJob(session, ptyProcess);
+
       // Spawn watchdog: if no data, exit, or error arrives within 30s, treat as failure
       let receivedLifeSign = false;
       const ptyStartedAt = Date.now();
@@ -334,6 +341,12 @@ class BaseBridge {
           // the kill() below succeeds.
           this._disposePtyDisposables(session, sessionId);
           try { ptyProcess.kill(); } catch (e) { /* ignore */ }
+          // Reap the PTY subtree (Windows job close / POSIX group kill) so a hung-at-startup
+          // shell + any children it already spawned don't leak.
+          this._disposePtyJob(session);
+          if (process.platform !== 'win32' && ptyProcess && ptyProcess.pid) {
+            try { killProcessTreeSync(ptyProcess.pid); } catch (_) { /* best-effort */ }
+          }
           onError(new Error(`${this.toolName} process did not respond within ${SPAWN_TIMEOUT_MS / 1000} seconds. The command may not be installed or may have hung during startup.`));
         }
       }, SPAWN_TIMEOUT_MS);
@@ -390,6 +403,10 @@ class BaseBridge {
         // still hold references to the data-buffer closures. Skip onExit
         // self-disposal (node-pty already removed it on fire).
         this._disposePtyDisposables(session, sessionId);
+        // The PTY exited on its own, but the CLI's node/bun grandchildren may still be
+        // alive (node-pty doesn't walk the console process list). Closing the per-PTY
+        // kill-on-close job reaps them and frees the handle (Windows; no-op on POSIX).
+        this._disposePtyJob(session);
         if (this.sessions.has(sessionId)) {
           session.active = false;
           this.sessions.delete(sessionId);
@@ -444,6 +461,12 @@ class BaseBridge {
         // the shell is alive but unreadable) doesn't leak as a zombie process /
         // FD — mirrors the spawn-watchdog teardown. Harmless if already dead.
         try { ptyProcess.kill(); } catch (e) { /* ignore — may already be dead */ }
+        // Reap the subtree (Windows job close / POSIX group kill) so the shell's
+        // node/bun grandchildren don't outlive the failed session.
+        this._disposePtyJob(session);
+        if (process.platform !== 'win32' && ptyProcess && ptyProcess.pid) {
+          try { killProcessTreeSync(ptyProcess.pid); } catch (_) { /* best-effort */ }
+        }
         if (this.sessions.has(sessionId)) {
           session.active = false;
           this.sessions.delete(sessionId);
@@ -584,6 +607,49 @@ class BaseBridge {
     }
   }
 
+  /**
+   * Windows only: put a freshly-spawned PTY in its OWN kill-on-close Job Object so the
+   * PTY and the CLI's node/bun MCP grandchildren can be torn down atomically per session
+   * (see _disposePtyJob). Assigned right after spawn — before the CLI boots and spawns its
+   * children — so those future grandchildren auto-join the job. No-op on POSIX / when the
+   * job guard is unavailable (then teardown falls back to process-group / taskkill).
+   * Defence in depth: the PTY is also in the supervisor-level job, so supervisor death
+   * reaps it regardless.
+   * @private
+   */
+  _attachPtyJob(session, ptyProcess) {
+    if (process.platform !== 'win32' || !session) return;
+    try {
+      if (!jobGuard.isAvailable()) return;
+      const pid = ptyProcess && ptyProcess.pid;
+      if (!pid) return;
+      // Defensive: if a handle already exists for this session (re-entrant call), close it
+      // first so we never overwrite a live kernel handle and leak it.
+      if (session.jobHandle) this._disposePtyJob(session);
+      const handle = jobGuard.createKillOnCloseJob();
+      if (!handle) return;
+      if (jobGuard.assignPid(handle, pid)) {
+        session.jobHandle = handle;
+      } else {
+        // Assign failed (already-orphaned / access denied) — closing an empty job is harmless.
+        jobGuard.closeJob(handle);
+      }
+    } catch (_) { /* best-effort; never break session start */ }
+  }
+
+  /**
+   * Close a session's per-PTY job handle. On Windows this is the deterministic teardown:
+   * KILL_ON_JOB_CLOSE terminates the PTY + every descendant still in the job (the node/bun
+   * grandchildren). Also frees the kernel handle. Idempotent; no-op when no handle exists.
+   * @private
+   */
+  _disposePtyJob(session) {
+    if (!session || !session.jobHandle) return;
+    const h = session.jobHandle;
+    session.jobHandle = null;
+    try { jobGuard.closeJob(h); } catch (_) { /* ignore */ }
+  }
+
   async stopSession(sessionId) {
     const session = this.sessions.get(sessionId);
     if (!session) {
@@ -608,13 +674,20 @@ class BaseBridge {
     // runs.
     this._disposePtyDisposables(session, sessionId);
 
-    if (!session.process) return;
+    // No live process to wait on — close the per-PTY job (reaps any lingering grandchildren
+    // and frees the kernel handle) before returning, so this path can't leak the handle.
+    if (!session.process) { this._disposePtyJob(session); return; }
+
+    // Capture the pid before kill(): node-pty may clear it on exit, and we need it
+    // for the POSIX process-group escalation below.
+    const ptyPid = session.process.pid;
 
     // Return a promise that resolves when the PTY process actually exits
     // (or after a bounded timeout), so callers can await clean shutdown.
     return new Promise((resolve) => {
       let settled = false;
       let waitDisposable = null;
+      let exited = false;
 
       const cleanup = () => {
         if (settled) return;
@@ -628,11 +701,22 @@ class BaseBridge {
         if (waitDisposable && typeof waitDisposable.dispose === 'function') {
           try { waitDisposable.dispose(); } catch (_) { /* ignore */ }
         }
+        // Deterministic subtree teardown. On Windows, closing the per-PTY kill-on-close
+        // job terminates the shell + its node/bun grandchildren and frees the handle —
+        // this is what node-pty's own kill() cannot do (it doesn't walk the console
+        // process list). On POSIX, if the PTY did NOT exit on its own (the 3s timeout
+        // fired), escalate to a process-group kill; node-pty PTYs are session leaders so
+        // the negative-pid reaches in-group grandchildren. (We avoid group-killing after a
+        // clean exit to sidestep any pgid-reuse window.)
+        this._disposePtyJob(session);
+        if (!exited && process.platform !== 'win32' && ptyPid) {
+          try { killProcessTreeSync(ptyPid); } catch (_) { /* best-effort */ }
+        }
         resolve();
       };
 
       try {
-        const handle = session.process.onExit(() => cleanup());
+        const handle = session.process.onExit(() => { exited = true; cleanup(); });
         // node-pty returns an IDisposable; older mocks may return undefined.
         if (handle && typeof handle.dispose === 'function') waitDisposable = handle;
       } catch (_) {
@@ -670,6 +754,22 @@ class BaseBridge {
     const sessionIds = Array.from(this.sessions.keys());
     for (const sessionId of sessionIds) {
       await this.stopSession(sessionId);
+    }
+  }
+
+  /**
+   * Synchronous, best-effort reap of EVERY live PTY subtree this bridge owns. For the
+   * uncaughtException and supervisor-death (IPC disconnect) paths, where we are about to
+   * exit and cannot await async teardown. Windows: close each per-PTY kill-on-close job
+   * (terminates the shell + node/bun grandchildren). POSIX: process-group kill of each PTY.
+   * Never throws.
+   */
+  killAllSubtreesSync() {
+    for (const [, session] of this.sessions) {
+      try { this._disposePtyJob(session); } catch (_) { /* ignore */ }
+      if (process.platform !== 'win32' && session && session.process && session.process.pid) {
+        try { killProcessTreeSync(session.process.pid); } catch (_) { /* ignore */ }
+      }
     }
   }
 }

--- a/src/job-guard.js
+++ b/src/job-guard.js
@@ -100,7 +100,10 @@ function _ensureApi() {
 }
 
 // True only when the koffi-backed Win32 binding is usable on this platform.
+// `AOD_DISABLE_JOB_GUARD=1` forces it off (operator escape hatch if koffi/the FFI ever
+// misbehaves, and the hook that lets tests exercise the best-effort degraded teardown).
 function isAvailable() {
+  if (process.env.AOD_DISABLE_JOB_GUARD === '1') return false;
   return !!_ensureApi();
 }
 

--- a/src/job-guard.js
+++ b/src/job-guard.js
@@ -102,8 +102,12 @@ function _ensureApi() {
 // True only when the koffi-backed Win32 binding is usable on this platform.
 // `AOD_DISABLE_JOB_GUARD=1` forces it off (operator escape hatch if koffi/the FFI ever
 // misbehaves, and the hook that lets tests exercise the best-effort degraded teardown).
+// In the SEA single-file binary koffi is externalized out of the bundle and there is no
+// node_modules, so it can never load — short-circuit to degraded mode without attempting
+// the require (keeps the PTY-start hot path free of a doomed module lookup).
 function isAvailable() {
   if (process.env.AOD_DISABLE_JOB_GUARD === '1') return false;
+  if (typeof global !== 'undefined' && global.__SEA_MODE__) return false;
   return !!_ensureApi();
 }
 

--- a/src/job-guard.js
+++ b/src/job-guard.js
@@ -1,0 +1,242 @@
+'use strict';
+
+// Windows Job Object guard — deterministic process-tree teardown.
+//
+// The core mechanism for "no zombie node/bun processes": a Win32 Job Object with
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. When the last handle to such a job closes
+// (the holding process dies for ANY reason — Ctrl+C, crash, taskkill /F, console
+// close), the kernel terminates EVERY process in the job atomically, with no user
+// code running. This is the only Windows mechanism that survives an uncatchable kill.
+//
+// Two uses (see docs/specs/process-shutdown.md, ADR-00NN):
+//   1. Supervisor-level job: bin/supervisor.js creates a kill-on-close job and assigns
+//      ITSELF before forking the server. AssignProcessToJobObject is forward-looking, so
+//      every future descendant (server, PTYs, the CLI's node/bun MCP grandchildren) joins
+//      the job. Supervisor death closes the in-process handle → the whole tree dies. The
+//      job persists across server restarts (only supervisor death closes the handle), so
+//      the legitimate exit-75 memory restart is unaffected.
+//   2. Per-PTY nested job: src/base-bridge.js puts each PTY in its own kill-on-close job;
+//      closing that handle on stopSession atomically kills the PTY + its grandchildren —
+//      deterministic per-session teardown that also satisfies "restart independently".
+//
+// Held IN-PROCESS via the koffi FFI (not an external helper, which would be a single
+// point of failure, and not PowerShell, whose Add-Type→csc.exe is blocked by CLM/WDAC/
+// AMSI on the hardened corporate boxes that are the primary audience). The job's
+// BREAKAWAY_OK flag is deliberately left OFF so a child requesting CREATE_BREAKAWAY_FROM_JOB
+// is kept in the job rather than escaping it.
+//
+// Windows-only by design; a no-op on macOS/Linux and whenever koffi is unavailable
+// (e.g. under Bun, or a locked-down box). Never throws into the caller — the guard must
+// never break startup; failure degrades to best-effort taskkill (jobGuard:false).
+
+const IS_WIN = process.platform === 'win32';
+
+// JOBOBJECTINFOCLASS
+const JobObjectExtendedLimitInformation = 9;
+// JOBOBJECT_BASIC_LIMIT_INFORMATION.LimitFlags
+const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+// OpenProcess access rights needed to assign a foreign pid to a job
+const PROCESS_TERMINATE = 0x0001;
+const PROCESS_SET_QUOTA = 0x0100;
+
+let _koffi = null;
+let _api = null;
+let _loadError = null;
+
+// Lazily bind kernel32 via koffi. Returns the bound API or null (cached).
+function _ensureApi() {
+  if (_api || _loadError) return _api;
+  if (!IS_WIN) { _loadError = new Error('not win32'); return null; }
+  try {
+    _koffi = require('koffi');
+
+    const JOBOBJECT_BASIC_LIMIT_INFORMATION = _koffi.struct('JOBOBJECT_BASIC_LIMIT_INFORMATION', {
+      PerProcessUserTimeLimit: 'int64',
+      PerJobUserTimeLimit: 'int64',
+      LimitFlags: 'uint32',
+      MinimumWorkingSetSize: 'size_t',
+      MaximumWorkingSetSize: 'size_t',
+      ActiveProcessLimit: 'uint32',
+      Affinity: 'size_t',
+      PriorityClass: 'uint32',
+      SchedulingClass: 'uint32',
+    });
+    const IO_COUNTERS = _koffi.struct('IO_COUNTERS', {
+      ReadOperationCount: 'uint64',
+      WriteOperationCount: 'uint64',
+      OtherOperationCount: 'uint64',
+      ReadTransferCount: 'uint64',
+      WriteTransferCount: 'uint64',
+      OtherTransferCount: 'uint64',
+    });
+    const JOBOBJECT_EXTENDED_LIMIT_INFORMATION = _koffi.struct('JOBOBJECT_EXTENDED_LIMIT_INFORMATION', {
+      BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION,
+      IoInfo: IO_COUNTERS,
+      ProcessMemoryLimit: 'size_t',
+      JobMemoryLimit: 'size_t',
+      PeakProcessMemoryUsed: 'size_t',
+      PeakJobMemoryUsed: 'size_t',
+    });
+
+    const k = _koffi.load('kernel32.dll');
+    _api = {
+      sizeofExtLimit: _koffi.sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION),
+      CreateJobObjectW: k.func('void* __stdcall CreateJobObjectW(void* lpJobAttributes, void* lpName)'),
+      // The struct is registered in koffi's type registry under its name, so the C
+      // prototype can reference it by that name (passed by pointer → marshaled from a JS object).
+      SetInformationJobObject: k.func('int __stdcall SetInformationJobObject(void* hJob, int JobObjectInformationClass, ' +
+        'JOBOBJECT_EXTENDED_LIMIT_INFORMATION* lpJobObjectInformation, uint32 cbJobObjectInformationLength)'),
+      AssignProcessToJobObject: k.func('int __stdcall AssignProcessToJobObject(void* hJob, void* hProcess)'),
+      OpenProcess: k.func('void* __stdcall OpenProcess(uint32 dwDesiredAccess, int bInheritHandle, uint32 dwProcessId)'),
+      GetCurrentProcess: k.func('void* __stdcall GetCurrentProcess()'),
+      CloseHandle: k.func('int __stdcall CloseHandle(void* hObject)'),
+      GetLastError: k.func('uint32 __stdcall GetLastError()'),
+    };
+  } catch (err) {
+    _loadError = err;
+    _api = null;
+  }
+  return _api;
+}
+
+// True only when the koffi-backed Win32 binding is usable on this platform.
+function isAvailable() {
+  return !!_ensureApi();
+}
+
+// Explicit NULL-handle predicate. koffi 3.x returns JS `null` for a NULL pointer and a
+// BigInt for a valid HANDLE (verified on koffi 3.0.2), so a bare `!h` already works; this
+// guards the common shapes explicitly so a future koffi representation of NULL (0 / 0n /
+// undefined) can't slip an invalid handle into a WinAPI call.
+function _isNullHandle(h) {
+  return h === null || h === undefined || h === 0 || h === 0n;
+}
+
+// Create a job object with KILL_ON_JOB_CLOSE set (BREAKAWAY_OK deliberately OFF).
+// Returns the job handle (opaque, pass back to assign*/closeJob) or null on any failure.
+function createKillOnCloseJob() {
+  const api = _ensureApi();
+  if (!api) return null;
+  let job = null;
+  try {
+    job = api.CreateJobObjectW(null, null);
+    if (_isNullHandle(job)) return null;
+    const info = {
+      BasicLimitInformation: {
+        PerProcessUserTimeLimit: 0n,
+        PerJobUserTimeLimit: 0n,
+        LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        MinimumWorkingSetSize: 0,
+        MaximumWorkingSetSize: 0,
+        ActiveProcessLimit: 0,
+        Affinity: 0,
+        PriorityClass: 0,
+        SchedulingClass: 0,
+      },
+      IoInfo: {
+        ReadOperationCount: 0n, WriteOperationCount: 0n, OtherOperationCount: 0n,
+        ReadTransferCount: 0n, WriteTransferCount: 0n, OtherTransferCount: 0n,
+      },
+      ProcessMemoryLimit: 0,
+      JobMemoryLimit: 0,
+      PeakProcessMemoryUsed: 0,
+      PeakJobMemoryUsed: 0,
+    };
+    const ok = api.SetInformationJobObject(job, JobObjectExtendedLimitInformation, info, api.sizeofExtLimit);
+    if (!ok) {
+      // Could not arm kill-on-close — a job without it is useless (worse: it would
+      // hold processes without ever reaping them). Close and fail closed to null.
+      try { api.CloseHandle(job); } catch (_) { /* ignore */ }
+      return null;
+    }
+    return job;
+  } catch (_) {
+    if (job) { try { api.CloseHandle(job); } catch (__) { /* ignore */ } }
+    return null;
+  }
+}
+
+// Assign the CURRENT process to the job (used by the supervisor before forking).
+// Returns true on success. After this, all future descendants auto-join the job.
+function assignSelf(job) {
+  const api = _ensureApi();
+  if (!api || _isNullHandle(job)) return false;
+  try {
+    const self = api.GetCurrentProcess(); // pseudo-handle (-1); valid for AssignProcessToJobObject
+    return !!api.AssignProcessToJobObject(job, self);
+  } catch (_) {
+    return false;
+  }
+}
+
+// Assign a foreign process (by pid) to the job (used per-PTY). Opens a scoped handle
+// with exactly the rights needed, assigns, then closes that process handle (NOT the job).
+// Returns true on success.
+//
+// PID-reuse safety: callers must pass the pid of a process they KNOW is currently alive
+// and call this synchronously after spawning it (base-bridge._attachPtyJob runs in the same
+// synchronous tick as node-pty's spawn() that produced the pid), so there is no async window
+// in which the pid could be recycled before OpenProcess. Do NOT call this with a pid that
+// may have already exited.
+function assignPid(job, pid) {
+  const api = _ensureApi();
+  if (!api || _isNullHandle(job) || !pid) return false;
+  let h = null;
+  try {
+    h = api.OpenProcess(PROCESS_TERMINATE | PROCESS_SET_QUOTA, 0, pid >>> 0);
+    if (_isNullHandle(h)) return false;
+    return !!api.AssignProcessToJobObject(job, h);
+  } catch (_) {
+    return false;
+  } finally {
+    if (!_isNullHandle(h)) { try { api.CloseHandle(h); } catch (_) { /* ignore */ } }
+  }
+}
+
+// Close a job handle. For a per-PTY kill-on-close job this is the teardown trigger:
+// it terminates every process still in the job. Idempotent-safe to call with null.
+// NEVER call this on the supervisor-level job (its close = kill the whole tree); the
+// supervisor holds it for life and lets process death close it.
+function closeJob(job) {
+  const api = _ensureApi();
+  if (!api || _isNullHandle(job)) return false;
+  try {
+    return !!api.CloseHandle(job);
+  } catch (_) {
+    return false;
+  }
+}
+
+module.exports = {
+  isAvailable,
+  createKillOnCloseJob,
+  assignSelf,
+  assignPid,
+  closeJob,
+  // exposed for diagnostics/tests
+  _loadError: () => _loadError,
+};
+
+// --- self-test: `node src/job-guard.js` ------------------------------------------
+// Proves the koffi bindings + struct marshaling work end to end on this host:
+// create a kill-on-close job, assign a spawned child, close the job, assert the child dies.
+if (require.main === module) {
+  if (!IS_WIN) { console.log('job-guard self-test: non-win32, no-op OK'); process.exit(0); }
+  const { spawn } = require('child_process');
+  console.log('koffi available:', isAvailable(), 'loadError:', _loadError && _loadError.message);
+  const job = createKillOnCloseJob();
+  console.log('createKillOnCloseJob ->', job ? 'OK' : 'FAIL');
+  if (!job) process.exit(1);
+  // Long-lived child that does nothing but stay alive.
+  const child = spawn(process.execPath, ['-e', 'setInterval(()=>{}, 1e9)'], { stdio: 'ignore' });
+  console.log('spawned child pid', child.pid);
+  setTimeout(() => {
+    const assigned = assignPid(job, child.pid);
+    console.log('assignPid ->', assigned ? 'OK' : 'FAIL');
+    closeJob(job);
+    console.log('closeJob called; waiting to see if child dies...');
+    let exited = false;
+    child.on('exit', (code, sig) => { exited = true; console.log(`child exited code=${code} sig=${sig} -> KILL-ON-CLOSE OK`); process.exit(0); });
+    setTimeout(() => { if (!exited) { console.log('child STILL ALIVE -> FAIL'); try { child.kill(); } catch (_) {} process.exit(2); } }, 2000);
+  }, 300);
+}

--- a/src/server.js
+++ b/src/server.js
@@ -384,6 +384,10 @@ class ClaudeCodeWebServer {
       } catch (saveErr) {
         console.error('Failed to save sessions on crash:', saveErr);
       }
+      // Reap PTY subtrees so the CLI's node/bun grandchildren don't outlive this crashed
+      // server. Synchronous (the event loop is unsafe here). Windows closes each per-PTY
+      // job; POSIX group-kills. Best-effort; never rethrows.
+      try { this._reapAllPtySubtreesSync(); } catch (_) { /* ignore */ }
       process.exit(1);
     });
     process.on('unhandledRejection', (reason) => {
@@ -401,10 +405,21 @@ class ClaudeCodeWebServer {
         this.handleShutdown();
       }
     });
-    // If the supervisor crashes, continue running standalone
+    // If the supervisor's IPC channel drops, the supervisor died. Per the
+    // "everything dies when the main process dies" contract, this server must NOT
+    // keep running standalone (the old behavior) — it tears down its own PTY trees
+    // (incl. the CLI's node/bun grandchildren) and shuts down.
     process.on('disconnect', () => {
-      console.warn('IPC channel disconnected (supervisor may have crashed). Continuing standalone.');
-      this.supervised = false;
+      // Expected channel close: a graceful shutdown / memory-restart we initiated is
+      // already in flight (the supervisor sent {type:'shutdown'} or we exited 75). No-op.
+      if (this.isShuttingDown) return;
+      console.warn('IPC channel disconnected (supervisor died). Tearing down this server and its process tree.');
+      // Reap PTY subtrees synchronously FIRST so the node/bun grandchildren die immediately,
+      // even if the ordered handleShutdown below is slow. On Windows with the job guard
+      // active the kernel has usually already killed us; this is the cross-platform /
+      // degraded-mode backstop.
+      try { this._reapAllPtySubtreesSync(); } catch (_) { /* best-effort */ }
+      this.handleShutdown(0);
     });
   }
   
@@ -3937,6 +3952,24 @@ class ClaudeCodeWebServer {
     return bridges[agentType] || null;
   }
 
+  /**
+   * Synchronously reap every PTY subtree across all bridges. For the crash / supervisor-
+   * death paths where we are exiting and cannot await async teardown. Windows closes each
+   * per-PTY kill-on-close job (terminates the shell + node/bun grandchildren); POSIX
+   * process-group kills. Best-effort; never throws.
+   */
+  _reapAllPtySubtreesSync() {
+    const bridges = [
+      this.claudeBridge, this.codexBridge, this.copilotBridge,
+      this.geminiBridge, this.terminalBridge,
+    ];
+    for (const b of bridges) {
+      if (b && typeof b.killAllSubtreesSync === 'function') {
+        try { b.killAllSubtreesSync(); } catch (_) { /* ignore */ }
+      }
+    }
+  }
+
   async startToolSession(wsId, toolName, bridge, options, cols, rows) {
     const wsInfo = this.webSocketConnections.get(wsId);
     if (!wsInfo) {
@@ -5225,6 +5258,15 @@ class ClaudeCodeWebServer {
         voice_upload_counts: Array.from(this.claudeSessions.values())
           .filter(s => s._voiceUploadTimestamps && s._voiceUploadTimestamps.length).length,
         activity_broadcast_timestamps: (this.activityBroadcastTimestamps && this.activityBroadcastTimestamps.size) || 0,
+      },
+      // Deterministic-shutdown guard status. On win32, job_guard_active reflects whether
+      // the supervisor established the kill-on-close Job Object (false ⇒ degraded:
+      // EDR/CLM/koffi unavailable ⇒ best-effort taskkill teardown). null off win32 (the
+      // job mechanism is Windows-only; POSIX uses process-group teardown). See
+      // docs/specs/process-shutdown.md.
+      process_guard: {
+        job_guard_active: process.platform === 'win32' ? (process.env.AOD_JOB_GUARD === '1') : null,
+        supervised: !!this.supervised,
       },
       // DISK-02/03: cached disk usage sample (60 s TTL, never blocks the
       // event loop). Populated by _sampleDiskUsage() — see method

--- a/src/utils/process-tree.js
+++ b/src/utils/process-tree.js
@@ -1,0 +1,95 @@
+'use strict';
+
+// Cross-platform best-effort process-tree teardown.
+//
+// This is the FALLBACK layer, used when the deterministic mechanism is unavailable:
+//   - Windows: the per-PTY / supervisor Job Object is the real teardown. taskkill /T /F
+//     is only the degraded-mode backstop (jobGuard:false — EDR/CLM blocked the job).
+//   - POSIX: there is no job-object equivalent, so process-group kill IS the primary
+//     teardown for PTYs. node-pty's Unix backend runs each PTY through forkpty→setsid,
+//     so the PTY is a session/group leader and its pid == pgid; killing the negative pid
+//     targets that whole group. Honest limitation: a grandchild that calls setsid() (some
+//     daemonized MCP servers) starts its own group and escapes -pgid; only cgroup v2
+//     delegation closes that gap (see docs/specs/process-shutdown.md).
+//
+// Never throws into the caller — teardown must not break shutdown.
+
+const childProcess = require('child_process');
+
+const IS_WIN = process.platform === 'win32';
+
+// Windows degraded-mode tree kill via taskkill. Async (spawns a child); resolves true
+// once taskkill exits 0, false otherwise. windowsHide + no shell (taskkill is a real exe).
+function _taskkillTree(pid, spawnImpl) {
+  return new Promise((resolve) => {
+    try {
+      const proc = spawnImpl('taskkill', ['/T', '/F', '/PID', String(pid)], {
+        windowsHide: true,
+        stdio: 'ignore',
+        shell: false,
+      });
+      let settled = false;
+      const done = (ok) => { if (!settled) { settled = true; resolve(ok); } };
+      proc.on('exit', (code) => done(code === 0));
+      proc.on('error', () => done(false));
+      // Bound the wait so a hung taskkill can't stall shutdown.
+      const t = setTimeout(() => done(false), 4000);
+      if (t.unref) t.unref();
+    } catch (_) {
+      resolve(false);
+    }
+  });
+}
+
+// POSIX: kill the process group led by `pid` (negative-pid), then the pid itself as a
+// fallback in case it is not actually a group leader.
+function _killGroup(pid, signal, killImpl) {
+  let any = false;
+  try { killImpl(-pid, signal); any = true; } catch (_) { /* ESRCH / EPERM */ }
+  try { killImpl(pid, signal); any = true; } catch (_) { /* may already be gone */ }
+  return any;
+}
+
+/**
+ * Best-effort tree-kill of `pid` and its descendants. Returns a Promise<boolean>.
+ * Windows uses taskkill /T /F; POSIX kills the process group.
+ * Injectable deps (`opts.spawn` / `opts.kill`) are for unit tests.
+ */
+function killProcessTree(pid, opts = {}) {
+  const signal = opts.signal || 'SIGKILL';
+  if (!pid || pid <= 0) return Promise.resolve(false);
+  if (IS_WIN) {
+    return _taskkillTree(pid, opts.spawn || childProcess.spawn);
+  }
+  return Promise.resolve(_killGroup(pid, signal, opts.kill || process.kill.bind(process)));
+}
+
+/**
+ * Synchronous best-effort tree-kill for the uncaughtException path, where the event loop
+ * is unsafe to rely on. Windows uses spawnSync(taskkill) with a short timeout; POSIX kills
+ * the process group synchronously. Returns boolean. Never throws.
+ */
+function killProcessTreeSync(pid, opts = {}) {
+  const signal = opts.signal || 'SIGKILL';
+  if (!pid || pid <= 0) return false;
+  if (IS_WIN) {
+    try {
+      const spawnSync = opts.spawnSync || childProcess.spawnSync;
+      const r = spawnSync('taskkill', ['/T', '/F', '/PID', String(pid)], {
+        windowsHide: true, stdio: 'ignore', shell: false, timeout: 3000,
+      });
+      return !!r && r.status === 0;
+    } catch (_) {
+      return false;
+    }
+  }
+  return _killGroup(pid, signal, opts.kill || process.kill.bind(process));
+}
+
+module.exports = {
+  killProcessTree,
+  killProcessTreeSync,
+  // internal, exposed for tests
+  _killGroup,
+  _taskkillTree,
+};

--- a/test/job-guard.test.js
+++ b/test/job-guard.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// Unit tests for src/job-guard.js — the Windows Job Object guard.
+//
+// On non-Windows CI the module is a documented no-op (isAvailable false, all calls
+// return falsy) — assert that. On Windows, exercise the real koffi-backed path end to
+// end: create a kill-on-close job, assign a spawned child, close the job, assert the
+// child dies. This is also the live proof that the koffi struct marshaling + Win32
+// bindings are correct on the runner.
+
+const assert = require('assert');
+const jobGuard = require('../src/job-guard');
+
+describe('job-guard', function () {
+  if (process.platform !== 'win32') {
+    it('is a no-op on non-Windows', function () {
+      assert.strictEqual(jobGuard.isAvailable(), false);
+      assert.strictEqual(jobGuard.createKillOnCloseJob(), null);
+      assert.strictEqual(jobGuard.assignSelf(null), false);
+      assert.strictEqual(jobGuard.assignPid(null, 123), false);
+      assert.strictEqual(jobGuard.closeJob(null), false);
+    });
+    return;
+  }
+
+  // --- Windows ---
+  it('reports available (koffi loads + kernel32 binds)', function () {
+    assert.strictEqual(jobGuard.isAvailable(), true, jobGuard._loadError() && String(jobGuard._loadError()));
+  });
+
+  it('creates a kill-on-close job handle', function () {
+    const job = jobGuard.createKillOnCloseJob();
+    assert.ok(job, 'expected a job handle');
+    // Cleanup: closing an empty job is harmless (no processes assigned).
+    jobGuard.closeJob(job);
+  });
+
+  it('kills an assigned child when the job handle closes (KILL_ON_JOB_CLOSE)', function (done) {
+    this.timeout(8000);
+    const { spawn } = require('child_process');
+    const job = jobGuard.createKillOnCloseJob();
+    assert.ok(job, 'job creation failed');
+
+    const child = spawn(process.execPath, ['-e', 'setInterval(()=>{}, 1e9)'], { stdio: 'ignore' });
+    let exited = false;
+    child.on('exit', () => { exited = true; });
+
+    setTimeout(() => {
+      assert.ok(child.pid, 'no child pid');
+      assert.strictEqual(jobGuard.assignPid(job, child.pid), true, 'assignPid failed');
+      jobGuard.closeJob(job); // fires KILL_ON_JOB_CLOSE
+      setTimeout(() => {
+        try {
+          assert.strictEqual(exited, true, 'child should have been killed by KILL_ON_JOB_CLOSE');
+          done();
+        } catch (e) {
+          try { child.kill(); } catch (_) { /* ignore */ }
+          done(e);
+        }
+      }, 1500);
+    }, 300);
+  });
+});

--- a/test/longevity/process/ctrlc-shutdown.test.js
+++ b/test/longevity/process/ctrlc-shutdown.test.js
@@ -93,6 +93,15 @@ describe('Ctrl+C native-worker shutdown (e2e)', function () {
   this.timeout(70000);
 
   before(async function () {
+    // POSIX-only: this drives a real terminal Ctrl+C via a process-group SIGINT
+    // (`process.kill(-pid, 'SIGINT')` on a detached child). Windows has no POSIX
+    // process groups / SIGINT delivery, so that mechanism is a no-op there and the
+    // child never receives the signal (the test would hang to its timeout). The
+    // Windows shutdown path is IPC-driven and is covered end-to-end by
+    // server-shutdown-e2e.test.js ("graceful shutdown exits cleanly").
+    if (process.platform === 'win32') {
+      this.skip();
+    }
     if (!(await modelsPresent())) {
       this.skip(); // models not downloaded — the native abort cannot occur
     }

--- a/test/longevity/process/fixtures/e2e-grandchild.js
+++ b/test/longevity/process/fixtures/e2e-grandchild.js
@@ -1,0 +1,7 @@
+'use strict';
+// Fixture for server-shutdown-e2e.test.js: a real grandchild process the terminal PTY
+// launches. Writes its pid to argv[2], then loops forever. If it survives the supervisor
+// going away, it's a leaked orphan — exactly what the deterministic-shutdown work prevents.
+const fs = require('fs');
+fs.writeFileSync(process.argv[2], String(process.pid));
+setInterval(() => {}, 1e9);

--- a/test/longevity/process/fixtures/jobguard-parent.js
+++ b/test/longevity/process/fixtures/jobguard-parent.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// Fixture for job-tree-kill.test.js. Mimics the supervisor: self-assign to a kill-on-close
+// Job Object, then spawn a child that spawns a grandchild. The grandchild writes its pid to
+// the file given as argv[2] and then loops forever. The parent loops forever until killed.
+//
+// argv[2] = path to write the grandchild pid to.
+
+const jobGuard = require('../../../../src/job-guard');
+const { spawn } = require('child_process');
+
+const gcOut = process.argv[2];
+
+const job = jobGuard.createKillOnCloseJob();
+if (!job || !jobGuard.assignSelf(job)) {
+  console.error('FIXTURE_SETUP_FAIL');
+  process.exit(1);
+}
+
+const gcScript = "const fs=require('fs');fs.writeFileSync(process.argv[1],String(process.pid));setInterval(()=>{},1e9);";
+const childScript =
+  "const{spawn}=require('child_process');" +
+  "spawn(process.execPath,['-e'," + JSON.stringify(gcScript) + ",process.argv[1]],{stdio:'ignore'});" +
+  "setInterval(()=>{},1e9);";
+
+spawn(process.execPath, ['-e', childScript, gcOut], { stdio: 'ignore' });
+
+console.log('FIXTURE_READY ' + process.pid);
+setInterval(() => {}, 1e9);

--- a/test/longevity/process/fixtures/supervised-child.js
+++ b/test/longevity/process/fixtures/supervised-child.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// Fixture child for supervisor-tree-kill.test.js. Plays the role of the server: prints its
+// pid and loops forever. It installs NO parent-death handling of its own, so if it survives
+// the supervisor being killed, the ONLY thing that can have reaped it is the supervisor's
+// kill-on-close Job Object. argv are ignored.
+
+console.log('CHILD_PID ' + process.pid);
+setInterval(() => {}, 1e9);

--- a/test/longevity/process/job-tree-kill.test.js
+++ b/test/longevity/process/job-tree-kill.test.js
@@ -1,0 +1,171 @@
+'use strict';
+
+// Integration regression for the deterministic-shutdown guarantee on Windows.
+//
+// Proves the kernel Job Object mechanism end to end against an UNCATCHABLE kill:
+//   1. Per-PTY style: create a kill-on-close job, assign a child that has a grandchild,
+//      close the job handle → assert the whole subtree (incl. the grandchild) dies.
+//   2. Supervisor style: a self-assigned parent spawns child→grandchild, then is killed
+//      with `taskkill /F` (no cleanup code runs) → assert the grandchild dies via the OS
+//      closing the in-process job handle on parent death.
+//
+// This is the live proof that node/bun grandchildren cannot survive supervisor death and
+// that nothing in the spawned tree breaks away from the job. Windows-only (the mechanism
+// is Windows-specific); auto-skips elsewhere.
+
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const { spawn, spawnSync } = require('child_process');
+
+const FIXTURE = path.join(__dirname, 'fixtures', 'jobguard-parent.js');
+
+function pidAlive(pid) {
+  // tasklist is the authoritative liveness check on Windows.
+  const r = spawnSync('tasklist', ['/FI', `PID eq ${pid}`, '/NH'], { encoding: 'utf8', windowsHide: true });
+  return !!r.stdout && new RegExp(`\\b${pid}\\b`).test(r.stdout);
+}
+
+function waitFor(fn, timeoutMs, intervalMs = 100) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const tick = () => {
+      let ok = false;
+      try { ok = fn(); } catch (_) { ok = false; }
+      if (ok) return resolve(true);
+      if (Date.now() - start >= timeoutMs) return resolve(false);
+      setTimeout(tick, intervalMs);
+    };
+    tick();
+  });
+}
+
+describe('deterministic shutdown: Job Object tree kill (Windows)', function () {
+  this.timeout(20000);
+
+  before(function () {
+    if (process.platform !== 'win32') this.skip();
+    const jg = require('../../../src/job-guard');
+    if (!jg.isAvailable()) this.skip(); // koffi/job unavailable on this runner
+  });
+
+  it('per-PTY job: closing the job handle kills the assigned subtree (grandchild)', function (done) {
+    const jg = require('../../../src/job-guard');
+    const gcFile = path.join(os.tmpdir(), `aod-gc-${process.pid}-${Date.now()}.pid`);
+    try { fs.rmSync(gcFile, { force: true }); } catch (_) { /* ignore */ }
+
+    const job = jg.createKillOnCloseJob();
+    assert.ok(job, 'job creation failed');
+
+    // Parent (not self-assigned; we assign it to the job) → child → grandchild.
+    const child = spawn(process.execPath, [FIXTURE, gcFile], { stdio: ['ignore', 'pipe', 'ignore'] });
+    let ready = '';
+    child.stdout.on('data', (d) => { ready += d.toString(); });
+
+    (async () => {
+      try {
+        const gotReady = await waitFor(() => /FIXTURE_READY/.test(ready) && fs.existsSync(gcFile), 8000);
+        assert.ok(gotReady, 'fixture did not become ready');
+        const gcPid = parseInt(fs.readFileSync(gcFile, 'utf8').trim(), 10);
+        assert.ok(gcPid > 0, 'no grandchild pid');
+        assert.ok(jg.assignPid(job, child.pid), 'assignPid(parent) failed');
+        assert.ok(pidAlive(gcPid), 'grandchild should be alive before close');
+
+        jg.closeJob(job); // KILL_ON_JOB_CLOSE
+
+        const dead = await waitFor(() => !pidAlive(gcPid), 6000);
+        assert.ok(dead, 'grandchild survived job close (FAIL: it broke away or was not in the job)');
+        done();
+      } catch (e) {
+        try { child.kill(); } catch (_) { /* ignore */ }
+        done(e);
+      } finally {
+        try { fs.rmSync(gcFile, { force: true }); } catch (_) { /* ignore */ }
+      }
+    })();
+  });
+
+  it('supervisor job: an uncatchable taskkill /F of the self-assigned parent reaps the grandchild', function (done) {
+    const gcFile = path.join(os.tmpdir(), `aod-gc-${process.pid}-${Date.now()}-2.pid`);
+    try { fs.rmSync(gcFile, { force: true }); } catch (_) { /* ignore */ }
+
+    // The fixture self-assigns to a kill-on-close job (like the supervisor does).
+    const parent = spawn(process.execPath, [FIXTURE, gcFile], { stdio: ['ignore', 'pipe', 'ignore'] });
+    let ready = '';
+    parent.stdout.on('data', (d) => { ready += d.toString(); });
+
+    (async () => {
+      let gcPid = 0;
+      try {
+        const gotReady = await waitFor(() => /FIXTURE_READY/.test(ready) && fs.existsSync(gcFile), 8000);
+        assert.ok(gotReady, 'fixture did not become ready');
+        gcPid = parseInt(fs.readFileSync(gcFile, 'utf8').trim(), 10);
+        assert.ok(gcPid > 0, 'no grandchild pid');
+        assert.ok(pidAlive(gcPid), 'grandchild should be alive before kill');
+
+        // Uncatchable kill of the parent — NO cleanup code in the parent runs.
+        spawnSync('taskkill', ['/F', '/PID', String(parent.pid)], { windowsHide: true });
+
+        const dead = await waitFor(() => !pidAlive(gcPid), 6000);
+        assert.ok(dead, 'grandchild survived an uncatchable parent kill (FAIL: job did not reap on process death)');
+        done();
+      } catch (e) {
+        if (gcPid) { try { spawnSync('taskkill', ['/F', '/PID', String(gcPid)], { windowsHide: true }); } catch (_) { /* ignore */ } }
+        done(e);
+      } finally {
+        try { fs.rmSync(gcFile, { force: true }); } catch (_) { /* ignore */ }
+      }
+    })();
+  });
+
+  // The breakaway GATE: a child spawned by a shell running inside a REAL node-pty ConPTY
+  // must stay in an ancestor job. If this passes, node-pty/ConPTY sets no
+  // CREATE_BREAKAWAY_FROM_JOB and the whole approach holds. Treat a failure here after a
+  // node-pty upgrade as "node-pty reintroduced breakaway." (See docs/specs/process-shutdown.md.)
+  it('node-pty ConPTY: a grandchild of the PTY shell is reaped when the per-PTY job closes', function (done) {
+    const pty = require('@lydell/node-pty');
+    const jg = require('../../../src/job-guard');
+    const gcFile = path.join(os.tmpdir(), `aod-pty-gc-${process.pid}-${Date.now()}.pid`);
+    try { fs.rmSync(gcFile, { force: true }); } catch (_) { /* ignore */ }
+
+    const shell = process.env.ComSpec || 'cmd.exe';
+    const term = pty.spawn(shell, [], { name: 'xterm-256color', cols: 80, rows: 30, cwd: process.cwd(), env: process.env });
+
+    // Put the PTY shell in its own kill-on-close job (mirrors base-bridge._attachPtyJob),
+    // BEFORE it spawns the grandchild, so the grandchild auto-joins.
+    const job = jg.createKillOnCloseJob();
+    assert.ok(job, 'job creation failed');
+    assert.ok(jg.assignPid(job, term.pid), 'assignPid(node-pty shell) failed');
+
+    // Have the shell spawn a detached long-lived node grandchild that records its pid.
+    const gcInline = "require('fs').writeFileSync(process.argv[1],String(process.pid));setInterval(()=>{},1e9);";
+    const gcOutForCmd = gcFile.replace(/\//g, '\\');
+    term.write(`node -e "${gcInline}" "${gcOutForCmd}"\r`);
+
+    (async () => {
+      let gcPid = 0;
+      try {
+        const gotPid = await waitFor(() => {
+          try { return fs.existsSync(gcFile) && parseInt(fs.readFileSync(gcFile, 'utf8').trim(), 10) > 0; }
+          catch (_) { return false; }
+        }, 10000);
+        assert.ok(gotPid, 'node grandchild did not start inside the PTY');
+        gcPid = parseInt(fs.readFileSync(gcFile, 'utf8').trim(), 10);
+        assert.ok(pidAlive(gcPid), 'grandchild should be alive before job close');
+
+        jg.closeJob(job); // KILL_ON_JOB_CLOSE — must reap the ConPTY grandchild
+
+        const dead = await waitFor(() => !pidAlive(gcPid), 6000);
+        assert.ok(dead, 'ConPTY grandchild survived job close — node-pty may have reintroduced CREATE_BREAKAWAY_FROM_JOB');
+        done();
+      } catch (e) {
+        if (gcPid) { try { spawnSync('taskkill', ['/F', '/PID', String(gcPid)], { windowsHide: true }); } catch (_) { /* ignore */ } }
+        done(e);
+      } finally {
+        try { term.kill(); } catch (_) { /* ignore */ }
+        try { fs.rmSync(gcFile, { force: true }); } catch (_) { /* ignore */ }
+      }
+    })();
+  });
+});

--- a/test/longevity/process/server-shutdown-e2e.test.js
+++ b/test/longevity/process/server-shutdown-e2e.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+// TRUE end-to-end regression for deterministic process shutdown.
+//
+// Unlike the unit/mechanism tests (job-guard in isolation; supervisor + a fake child;
+// node-pty with a manually-attached job), this drives the WHOLE real stack:
+//   real `bin/supervisor.js` -> forked server -> a real terminal PTY (the user's shell)
+//   -> a real `node` grandchild launched by typing a command over the live WebSocket.
+// Then it tears the system down two ways and asserts no orphaned process survives:
+//   A. Hard/uncatchable kill of the supervisor (taskkill /F on Windows, SIGKILL on POSIX).
+//      Windows: the kernel Job Object reaps the tree. POSIX: the server's IPC-disconnect
+//      watchdog reaps its PTY group and exits. Either way the grandchild must die.
+//   B. Graceful shutdown (IPC {type:'shutdown'}): clean exit 0 (no SIGABRT/134), and the
+//      PTY grandchild is reaped by the per-PTY job close / process-group teardown.
+//
+// Cross-platform; runs on the longevity-smoke matrix (Ubuntu + Windows + macOS).
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const net = require('net');
+const { spawn, spawnSync } = require('child_process');
+const WebSocket = require('ws');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SUPERVISOR = path.join(REPO_ROOT, 'bin', 'supervisor.js');
+const GC_FIXTURE = path.join(__dirname, 'fixtures', 'e2e-grandchild.js');
+const IS_WIN = process.platform === 'win32';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function pidAlive(pid) {
+  // process.kill(pid, 0) is a cross-platform existence probe (throws ESRCH when dead).
+  if (!pid) return false;
+  try { process.kill(pid, 0); return true; } catch (e) { return e.code === 'EPERM'; }
+}
+
+function killHard(pid) {
+  if (IS_WIN) spawnSync('taskkill', ['/F', '/PID', String(pid)], { windowsHide: true });
+  else { try { process.kill(pid, 'SIGKILL'); } catch (_) { /* ignore */ } }
+}
+
+function portOpen(port) {
+  return new Promise((resolve) => {
+    const s = net.connect({ host: '127.0.0.1', port }, () => { s.destroy(); resolve(true); });
+    s.on('error', () => resolve(false));
+    s.setTimeout(800, () => { s.destroy(); resolve(false); });
+  });
+}
+
+async function waitFor(fn, timeoutMs, iv = 200) {
+  const start = Date.now();
+  for (;;) {
+    let ok = false; try { ok = await fn(); } catch (_) { ok = false; }
+    if (ok) return true;
+    if (Date.now() - start >= timeoutMs) return false;
+    await sleep(iv);
+  }
+}
+
+// Boot the real supervisor, open a WS, start a real terminal PTY, and type a command that
+// launches a real `node` grandchild. Resolves { sup, gcPid, port, out, exitInfo }.
+async function bootAndSpawnGrandchild(port, withIpc) {
+  const gcFile = path.join(os.tmpdir(), `aod-e2e-gc-${process.pid}-${port}-${Date.now()}.pid`);
+  try { fs.rmSync(gcFile, { force: true }); } catch (_) { /* ignore */ }
+
+  const state = { out: '', exitInfo: null, gcFile };
+  const stdio = withIpc ? ['ignore', 'pipe', 'pipe', 'ipc'] : ['ignore', 'pipe', 'pipe'];
+  const sup = spawn(process.execPath, [
+    SUPERVISOR, '--port', String(port), '--disable-auth',
+    '--no-sticky-notes', '--no-stt', '--no-keepalive',
+  ], { cwd: REPO_ROOT, stdio, env: { ...process.env, AOD_SUPERVISOR_RESTART: '1' } });
+  state.sup = sup;
+  sup.stdout.on('data', (d) => { state.out += d.toString(); });
+  sup.stderr.on('data', (d) => { state.out += d.toString(); });
+  sup.on('exit', (code, signal) => { state.exitInfo = { code, signal }; });
+
+  const ready = await waitFor(() => /is running at|Press Ctrl\+C to stop/.test(state.out), 40000);
+  if (!ready) throw new Error('server did not start in 40s:\n' + state.out.slice(-500));
+
+  const ws = new WebSocket(`ws://localhost:${port}`);
+  await new Promise((res, rej) => {
+    ws.on('open', res); ws.on('error', rej);
+    setTimeout(() => rej(new Error('ws open timeout')), 10000);
+  });
+  ws.send(JSON.stringify({ type: 'create_session', name: 'e2e' }));
+  await sleep(1000);
+  ws.send(JSON.stringify({ type: 'start_terminal', cols: 100, rows: 30, options: {} }));
+  await sleep(3500); // let the shell boot
+
+  // Type a command in the real shell that launches the real node grandchild.
+  ws.send(JSON.stringify({ type: 'input', data: `node "${GC_FIXTURE}" "${gcFile}"\r` }));
+
+  const gotPid = await waitFor(() => {
+    try { return fs.existsSync(gcFile) && parseInt(fs.readFileSync(gcFile, 'utf8').trim() || '0', 10) > 0; }
+    catch (_) { return false; }
+  }, 20000);
+  try { ws.close(); } catch (_) { /* ignore */ }
+  if (!gotPid) throw new Error('node grandchild never started inside the PTY:\n' + state.out.slice(-500));
+
+  state.gcPid = parseInt(fs.readFileSync(gcFile, 'utf8').trim(), 10);
+  return state;
+}
+
+function cleanup(state) {
+  if (state && state.sup && state.sup.pid) { try { killHard(state.sup.pid); } catch (_) { /* ignore */ } }
+  if (state && state.gcPid && pidAlive(state.gcPid)) { try { killHard(state.gcPid); } catch (_) { /* ignore */ } }
+  if (state && state.gcFile) { try { fs.rmSync(state.gcFile, { force: true }); } catch (_) { /* ignore */ } }
+}
+
+describe('deterministic shutdown: real-server end-to-end (PTY + node grandchild)', function () {
+  this.timeout(90000);
+
+  it('uncatchable supervisor kill reaps the server + PTY + node grandchild (no orphan)', async function () {
+    const port = 11973;
+    let state;
+    try {
+      state = await bootAndSpawnGrandchild(port, false);
+      assert.ok(pidAlive(state.gcPid), 'grandchild should be alive before the kill');
+      assert.ok(await portOpen(port), 'server port should be open before the kill');
+
+      killHard(state.sup.pid); // taskkill /F (win) / SIGKILL (posix) — no cleanup code runs
+
+      const gcDead = await waitFor(() => !pidAlive(state.gcPid), 12000);
+      const portClosed = await waitFor(async () => !(await portOpen(port)), 12000);
+      assert.ok(gcDead, 'node grandchild SURVIVED the supervisor kill — orphan leaked');
+      assert.ok(portClosed, 'server still listening after the supervisor was killed');
+    } finally {
+      cleanup(state);
+    }
+  });
+
+  it('graceful shutdown exits cleanly (code 0) and reaps the PTY grandchild', async function () {
+    const port = 11974;
+    let state;
+    try {
+      state = await bootAndSpawnGrandchild(port, true); // ipc channel for the shutdown message
+      assert.ok(pidAlive(state.gcPid), 'grandchild should be alive before shutdown');
+
+      state.sup.send({ type: 'shutdown' }); // graceful path (works on Windows too, unlike SIGINT)
+
+      const exited = await waitFor(() => state.exitInfo !== null, 30000);
+      assert.ok(exited, 'supervisor did not exit within 30s of graceful shutdown');
+      assert.strictEqual(state.exitInfo.code, 0,
+        `graceful shutdown must exit 0 (got ${JSON.stringify(state.exitInfo)}; SIGABRT/134 = native-teardown regression)`);
+
+      const gcDead = await waitFor(() => !pidAlive(state.gcPid), 12000);
+      assert.ok(gcDead, 'node grandchild SURVIVED graceful shutdown — orphan leaked');
+    } finally {
+      cleanup(state);
+    }
+  });
+});

--- a/test/longevity/process/server-shutdown-e2e.test.js
+++ b/test/longevity/process/server-shutdown-e2e.test.js
@@ -61,7 +61,7 @@ async function waitFor(fn, timeoutMs, iv = 200) {
 
 // Boot the real supervisor, open a WS, start a real terminal PTY, and type a command that
 // launches a real `node` grandchild. Resolves { sup, gcPid, port, out, exitInfo }.
-async function bootAndSpawnGrandchild(port, withIpc) {
+async function bootAndSpawnGrandchild(port, withIpc, extraEnv) {
   const gcFile = path.join(os.tmpdir(), `aod-e2e-gc-${process.pid}-${port}-${Date.now()}.pid`);
   try { fs.rmSync(gcFile, { force: true }); } catch (_) { /* ignore */ }
 
@@ -70,7 +70,7 @@ async function bootAndSpawnGrandchild(port, withIpc) {
   const sup = spawn(process.execPath, [
     SUPERVISOR, '--port', String(port), '--disable-auth',
     '--no-sticky-notes', '--no-stt', '--no-keepalive',
-  ], { cwd: REPO_ROOT, stdio, env: { ...process.env, AOD_SUPERVISOR_RESTART: '1' } });
+  ], { cwd: REPO_ROOT, stdio, env: { ...process.env, AOD_SUPERVISOR_RESTART: '1', ...(extraEnv || {}) } });
   state.sup = sup;
   sup.stdout.on('data', (d) => { state.out += d.toString(); });
   sup.stderr.on('data', (d) => { state.out += d.toString(); });
@@ -147,6 +147,33 @@ describe('deterministic shutdown: real-server end-to-end (PTY + node grandchild)
 
       const gcDead = await waitFor(() => !pidAlive(state.gcPid), 12000);
       assert.ok(gcDead, 'node grandchild SURVIVED graceful shutdown — orphan leaked');
+    } finally {
+      cleanup(state);
+    }
+  });
+
+  // Degraded mode: force the Job Object guard off (AOD_DISABLE_JOB_GUARD=1) so teardown
+  // must use the best-effort fallback (taskkill /T /F on Windows, process-group kill on
+  // POSIX) instead of the kernel job. This is the path the SEA binary takes (no koffi) and
+  // any koffi/EDR-blocked host. It must STILL reap the grandchild on graceful shutdown.
+  it('graceful shutdown reaps the grandchild even with the job guard disabled (degraded fallback)', async function () {
+    const port = 11975;
+    let state;
+    try {
+      state = await bootAndSpawnGrandchild(port, true, { AOD_DISABLE_JOB_GUARD: '1' });
+      // Sanity: in degraded mode the supervisor must NOT report the job active.
+      assert.ok(!/kill-on-close job active/.test(state.out),
+        'job guard should be OFF under AOD_DISABLE_JOB_GUARD=1');
+      assert.ok(pidAlive(state.gcPid), 'grandchild should be alive before shutdown');
+
+      state.sup.send({ type: 'shutdown' });
+
+      const exited = await waitFor(() => state.exitInfo !== null, 30000);
+      assert.ok(exited, 'supervisor did not exit within 30s (degraded)');
+      assert.strictEqual(state.exitInfo.code, 0, `degraded graceful shutdown must exit 0 (got ${JSON.stringify(state.exitInfo)})`);
+
+      const gcDead = await waitFor(() => !pidAlive(state.gcPid), 12000);
+      assert.ok(gcDead, 'grandchild SURVIVED degraded graceful shutdown — best-effort taskkill/group-kill fallback did not reap it');
     } finally {
       cleanup(state);
     }

--- a/test/longevity/process/supervisor-tree-kill.test.js
+++ b/test/longevity/process/supervisor-tree-kill.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+// Integration regression: the REAL bin/supervisor.js establishes the kill-on-close Job
+// Object and self-assigns before forking, so an UNCATCHABLE kill of the supervisor
+// (`taskkill /F`, no cleanup runs) reaps its forked child via the OS closing the in-process
+// job handle on supervisor death.
+//
+// The child fixture installs no parent-death handling of its own — if it survives, only the
+// job could have reaped it, so this is a tight proof of the supervisor wiring (not just the
+// job-guard module in isolation). Windows-only; auto-skips elsewhere (POSIX is best-effort
+// and the real server's IPC-disconnect watchdog covers it, exercised by other suites).
+
+const assert = require('assert');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SUPERVISOR = path.join(REPO_ROOT, 'bin', 'supervisor.js');
+const CHILD_FIXTURE = path.join(__dirname, 'fixtures', 'supervised-child.js');
+
+function pidAlive(pid) {
+  const r = spawnSync('tasklist', ['/FI', `PID eq ${pid}`, '/NH'], { encoding: 'utf8', windowsHide: true });
+  return !!r.stdout && new RegExp(`\\b${pid}\\b`).test(r.stdout);
+}
+
+function waitFor(fn, timeoutMs, intervalMs = 100) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const tick = () => {
+      let ok = false; try { ok = fn(); } catch (_) { ok = false; }
+      if (ok) return resolve(true);
+      if (Date.now() - start >= timeoutMs) return resolve(false);
+      setTimeout(tick, intervalMs);
+    };
+    tick();
+  });
+}
+
+describe('deterministic shutdown: supervisor job reaps forked child on uncatchable kill (Windows)', function () {
+  this.timeout(25000);
+
+  before(function () {
+    if (process.platform !== 'win32') this.skip();
+    const jg = require('../../../src/job-guard');
+    if (!jg.isAvailable()) this.skip();
+  });
+
+  it('taskkill /F of the supervisor kills its forked child via KILL_ON_JOB_CLOSE', async function () {
+    let out = '';
+    const sup = spawn(process.execPath, [SUPERVISOR], {
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, SUPERVISOR_CHILD_SCRIPT: CHILD_FIXTURE },
+    });
+    sup.stdout.on('data', (d) => { out += d.toString(); });
+    sup.stderr.on('data', (d) => { out += d.toString(); });
+
+    let childPid = 0;
+    try {
+      const gotChild = await waitFor(() => /CHILD_PID (\d+)/.test(out), 12000);
+      assert.ok(gotChild, `child never started. supervisor output:\n${out.slice(-400)}`);
+      childPid = parseInt(out.match(/CHILD_PID (\d+)/)[1], 10);
+      assert.ok(childPid > 0, 'no child pid');
+
+      // Sanity: confirm the supervisor reported the guard active. If it did NOT (e.g. a
+      // locked-down runner), this test's guarantee does not apply — skip rather than fail.
+      if (!/process-guard: kill-on-close job active/.test(out)) {
+        this.skip();
+        return;
+      }
+
+      assert.ok(pidAlive(childPid), 'child should be alive before the kill');
+
+      // Uncatchable kill of the SUPERVISOR only. No cleanup code in the supervisor runs.
+      spawnSync('taskkill', ['/F', '/PID', String(sup.pid)], { windowsHide: true });
+
+      const dead = await waitFor(() => !pidAlive(childPid), 8000);
+      assert.ok(dead, 'forked child survived an uncatchable supervisor kill (FAIL: job did not reap it)');
+    } finally {
+      if (childPid && pidAlive(childPid)) { try { spawnSync('taskkill', ['/F', '/PID', String(childPid)], { windowsHide: true }); } catch (_) { /* ignore */ } }
+      try { spawnSync('taskkill', ['/F', '/T', '/PID', String(sup.pid)], { windowsHide: true }); } catch (_) { /* ignore */ }
+    }
+  });
+});

--- a/test/process-tree.test.js
+++ b/test/process-tree.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+// Unit tests for src/utils/process-tree.js — the best-effort cross-platform tree-kill
+// fallback. The internal helpers (_killGroup, _taskkillTree) are platform-independent
+// (they take injected spawn/kill), so these assert the kill shapes on every CI OS.
+
+const assert = require('assert');
+const { killProcessTree, killProcessTreeSync, _killGroup, _taskkillTree } = require('../src/utils/process-tree');
+const { EventEmitter } = require('events');
+
+describe('process-tree', function () {
+  describe('_killGroup (POSIX group kill)', function () {
+    it('kills the negative pid (group) then the pid itself', function () {
+      const calls = [];
+      const fakeKill = (target, sig) => { calls.push([target, sig]); };
+      const ok = _killGroup(1234, 'SIGKILL', fakeKill);
+      assert.strictEqual(ok, true);
+      assert.deepStrictEqual(calls, [[-1234, 'SIGKILL'], [1234, 'SIGKILL']]);
+    });
+
+    it('still reports success if the group kill throws (ESRCH) but the pid kill works', function () {
+      const calls = [];
+      const fakeKill = (target, sig) => {
+        if (target < 0) throw new Error('ESRCH');
+        calls.push([target, sig]);
+      };
+      const ok = _killGroup(50, 'SIGTERM', fakeKill);
+      assert.strictEqual(ok, true);
+      assert.deepStrictEqual(calls, [[50, 'SIGTERM']]);
+    });
+
+    it('returns false when both kills throw', function () {
+      const fakeKill = () => { throw new Error('EPERM'); };
+      assert.strictEqual(_killGroup(7, 'SIGKILL', fakeKill), false);
+    });
+  });
+
+  describe('_taskkillTree (Windows tree kill)', function () {
+    it('spawns taskkill /T /F /PID <pid> and resolves true on exit 0', async function () {
+      let seen = null;
+      const fakeSpawn = (cmd, args, opts) => {
+        seen = { cmd, args, opts };
+        const ee = new EventEmitter();
+        setImmediate(() => ee.emit('exit', 0));
+        return ee;
+      };
+      const ok = await _taskkillTree(99, fakeSpawn);
+      assert.strictEqual(ok, true);
+      assert.strictEqual(seen.cmd, 'taskkill');
+      assert.deepStrictEqual(seen.args, ['/T', '/F', '/PID', '99']);
+      assert.strictEqual(seen.opts.shell, false);
+      assert.strictEqual(seen.opts.windowsHide, true);
+    });
+
+    it('resolves false on non-zero exit', async function () {
+      const fakeSpawn = () => { const ee = new EventEmitter(); setImmediate(() => ee.emit('exit', 128)); return ee; };
+      assert.strictEqual(await _taskkillTree(1, fakeSpawn), false);
+    });
+
+    it('resolves false on spawn error', async function () {
+      const fakeSpawn = () => { const ee = new EventEmitter(); setImmediate(() => ee.emit('error', new Error('ENOENT'))); return ee; };
+      assert.strictEqual(await _taskkillTree(1, fakeSpawn), false);
+    });
+  });
+
+  describe('killProcessTree dispatch', function () {
+    it('rejects invalid pids', async function () {
+      assert.strictEqual(await killProcessTree(0), false);
+      assert.strictEqual(await killProcessTree(-5), false);
+      assert.strictEqual(killProcessTreeSync(0), false);
+    });
+
+    it('uses the platform-appropriate mechanism', async function () {
+      if (process.platform === 'win32') {
+        let spawned = false;
+        const fakeSpawn = () => { spawned = true; const ee = new EventEmitter(); setImmediate(() => ee.emit('exit', 0)); return ee; };
+        await killProcessTree(123, { spawn: fakeSpawn });
+        assert.strictEqual(spawned, true, 'win32 should taskkill');
+      } else {
+        const calls = [];
+        await killProcessTree(123, { kill: (t, s) => calls.push([t, s]) });
+        assert.deepStrictEqual(calls, [[-123, 'SIGKILL'], [123, 'SIGKILL']]);
+      }
+    });
+  });
+});

--- a/test/search-utils.test.js
+++ b/test/search-utils.test.js
@@ -257,6 +257,26 @@ describe('utils/search — backend detection (bde844f MEDIUM-2)', function () {
       return realAccessSync.apply(fs, arguments);
     };
 
+    // Stub the `require('@vscode/ripgrep')` resolution (search.js step 3) instead of
+    // hitting the real package. Required because @vscode/ripgrep is an ESM module that
+    // resolves a PER-PLATFORM binary package (`@vscode/ripgrep-<platform>-<arch>`) at
+    // load time and THROWS for any platform whose package isn't installed — and a CI
+    // runner only has its own platform's binary, never all three. Worse, that ESM
+    // evaluation rejection is cached by the ESM loader and is NOT cleared by
+    // `delete require.cache[...]`, so the first probe under a stubbed foreign platform
+    // would poison every later probe. Intercepting at Module._load decouples the test
+    // from the real package, mirrors search.js's "bundled present/absent" branches via
+    // `bundledAvailable`, and is restored in restore().
+    const fakeRgPath = '/fake/node_modules/@vscode/ripgrep/bin/' + (platform === 'win32' ? 'rg.exe' : 'rg');
+    const realModuleLoad = Module._load;
+    Module._load = function (request) {
+      if (request === '@vscode/ripgrep') {
+        if (bundledAvailable) return { rgPath: fakeRgPath };
+        const e = new Error("Cannot find module '@vscode/ripgrep'"); e.code = 'MODULE_NOT_FOUND'; throw e;
+      }
+      return realModuleLoad.apply(this, arguments);
+    };
+
     const searchPath = require.resolve('../src/utils/search');
     delete require.cache[searchPath];
     const search = require(searchPath);
@@ -265,6 +285,7 @@ describe('utils/search — backend detection (bde844f MEDIUM-2)', function () {
       restore: function () {
         realCp.execFileSync = realExec;
         fs.accessSync = realAccessSync;
+        Module._load = realModuleLoad;
         Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
         delete require.cache[searchPath];
       },


### PR DESCRIPTION
## Problem

The app spawns a deep tree: `supervisor.js` → `server.js` → node-pty PTYs → the CLI's own children (MCP servers that are `node`/`bun` processes, ripgrep). When the tree was torn down non-gracefully, those grandchildren survived as orphans. node-pty's Windows `kill()` (ConPTY) never walks the console process list, there was no force-kill escalation, the supervisor force-killed the server before it could tear down its tree (10s < 15s), the server "continued standalone" on supervisor death, and `uncaughtException` exited without reaping PTYs.

## Goal

When the **main (supervisor) process** dies for ANY reason — Ctrl+C, crash, `taskkill /F`, SIGKILL, console close — the entire descendant tree dies with it (server, PTYs, node/bun grandchildren). While the system is alive, subprocesses still restart independently; only top-process death brings everything down.

## Approach

**Windows (primary) — kernel-enforced via Job Objects, held in-process with koffi FFI**
- Supervisor creates a `KILL_ON_JOB_CLOSE` job and **self-assigns before forking** → the whole future tree auto-joins; the OS closes the in-process handle on supervisor death → the kernel reaps the tree atomically. Persists across the exit-75 memory restart.
- Each PTY gets its own **nested** kill-on-close job; closing it on teardown atomically kills the PTY **and its grandchildren** — what node-pty's `kill()` cannot do.
- Held in-process (no separate helper → no single point of failure) via koffi, not PowerShell (whose `Add-Type` is blocked by CLM/WDAC/AMSI on hardened corporate boxes).
- **Degraded mode** (koffi/job unavailable: EDR/CLM/silo): start + warn, surface `process_guard.job_guard_active=false` in `/api/diagnostics`, best-effort `taskkill /T /F` fallback.

**POSIX (best-effort)** — PTYs are session leaders; teardown escalates with `kill(-pgid, SIGKILL)`. The `setsid`/daemonized crash-path gap is documented honestly (cgroup v2 via `systemd-run --scope -p Delegate=yes` is the opt-in hard path).

**Cross-cutting** — the IPC `disconnect` handler reaps PTYs + shuts down on supervisor death (gated on `isShuttingDown` so it never races the exit-75 restart); `uncaughtException` reaps subtrees; supervisor hard-kill window raised to 20s (above the server's 15s force-exit).

## Verification (on a real Windows host)
- A node grandchild spawned by a shell inside a **real node-pty ConPTY** session dies when the per-PTY job closes — the live proof that node-pty sets no `CREATE_BREAKAWAY_FROM_JOB`.
- An uncatchable `taskkill /F` of the real `bin/supervisor.js` reaps its forked child via the kernel.
- Full suite: **1379 passing, 0 failing**.

New tests: `test/job-guard.test.js`, `test/process-tree.test.js`, `test/longevity/process/{job-tree-kill,supervisor-tree-kill}.test.js`.

## Also in this PR
Fixes 3 pre-existing `search-utils` test failures unrelated to shutdown: `@vscode/ripgrep` moved to ESM per-platform packages that throw (and cache the rejection) for absent platforms, poisoning the harness across `process.platform` overrides. The harness now stubs the `require()` resolution. Production `search.js` is untouched.

## Notes
- Adds the `koffi` dependency (prebuilt FFI; MIT; ~1.8M weekly downloads).
- Follow-up: verify the SEA single-binary build bundles koffi's prebuilt `.node` like the other natives.

See `docs/adrs/0031-deterministic-process-shutdown.md` and `docs/specs/process-shutdown.md`.