### PR TITLE
fix: sticky notes never summarize on Windows CPU (inference outran the timeout)

### DIFF
--- a/bin/ai-or-die.js
+++ b/bin/ai-or-die.js
@@ -43,7 +43,7 @@ program
   .option('--no-sticky-notes', 'disable per-tab AI session summaries + auto tab titles (on by default)')
   .option('--sticky-notes-model-dir <path>', 'custom directory for the sticky-note model file')
   .option('--sticky-notes-model <url>', 'override the sticky-note model GGUF download URL')
-  .option('--sticky-notes-threads <number>', 'CPU threads for sticky-note inference (default: auto, max 4)')
+  .option('--sticky-notes-threads <number>', 'CPU threads for sticky-note inference (default: auto — three-quarters of the cores on CPU, gentle on GPU)')
   .option('--no-keepalive', 'disable keeping the machine awake while the server runs (Windows only; on by default)')
   .option('--keepalive-display', 'also keep the display on (default keeps the system awake but lets the monitor sleep)');
 

--- a/docs/adrs/0023-sticky-note-model-bakeoff.md
+++ b/docs/adrs/0023-sticky-note-model-bakeoff.md
@@ -82,6 +82,13 @@ for a silent on-by-default download.
 - Latencies are Mac/Metal; a Windows CPU/Vulkan regression check belongs in the
   perf budget. If LFM2-2.6B proves too heavy on low-end Windows boxes, LFM2-1.2B
   is a one-line default downgrade with most of the quality.
+- **Windows-CPU latency budget (2026-06 follow-up).** On Windows 11 the Vulkan
+  prebuilt is frequently incompatible → pure-CPU inference at ~90–160s/turn, which
+  blew the original 60s engine timeout and left the card stuck on "No status yet."
+  Resolved by GPU-aware threading (CPU uses three-quarters of the cores, not 2;
+  GPU does full layer offload) + an unconditional 300s watchdog timeout
+  (summariser backstop 330s). See
+  `docs/history/sticky-notes-2026.md` and `src/sticky-note-threads.js`.
 - Gemma 4 E2B remains the eventual candidate once a `gemma4`-capable
   node-llama-cpp ships; re-run this bake-off against it before switching.
 

--- a/docs/history/sticky-notes-2026.md
+++ b/docs/history/sticky-notes-2026.md
@@ -3,6 +3,51 @@
 Implementation of the per-tab local-LLM "sticky note" + auto tab title feature
 (ADR-0022, spec `docs/specs/sticky-notes.md`). Gotchas worth remembering:
 
+## Windows 11: card stuck on "No status yet" forever — CPU inference outran every timeout
+
+Symptom: on Windows 11 the sticky-note card stays on *"No status yet — a summary
+appears as the session works."* indefinitely, even with the card expanded.
+
+Not a wiring bug. Ground-truth on the machine ruled out the usual suspects:
+`node-llama-cpp@3.18.1` + win-x64 native bins present, GGUF model present, JSONL
+binding + sidecar present, the `slugForCwd` drive-letter-colon fix already in.
+Running the **real `StickyNoteEngine` in-process** is what found it:
+
+- The Vulkan GPU prebuilt binary is *"not compatible with the current system"* →
+  node-llama-cpp falls back to **pure CPU** (`llama.gpu === false`).
+- The engine capped inference at **2 threads** (`min(2, cpus-2)`) even on a
+  16-core box — a "keep it gentle" cap that assumed the GPU did the work.
+- A real grammar-constrained summary (maxTokens 320, full NOTE_SCHEMA) measured
+  **159.5s at 2 threads / 88.8s at 8 threads** on CPU.
+- Every timeout was below that: engine 60s, summariser 75s, even the real-
+  inference smoke 90s — all tuned for Metal (~7s/turn, ADR-0023). So **every**
+  inference timed out, three consecutive failures opened the circuit breaker,
+  and the note was never produced. Waiting longer could not help.
+
+Fix (`sticky-note-worker.js`, `sticky-note-engine.js`, `sticky-note-summarizer.js`):
+1. **Thread count is auto-selected by the worker** after `getLlama()` reports the
+   backend — extracted as the pure `sticky-note-threads.js` `pickThreads`:
+   GPU → full layer offload (`gpuLayers:'max'`, fallback `auto`) + gentle
+   `min(2, cores-2)` CPU threads; **CPU → three-quarters of the cores**
+   (`max(1, floor(cores*3/4))`, via `availableParallelism()` for hybrid P/E cores).
+   `--sticky-notes-threads` still pins it; the engine omits `numThreads` from
+   workerData when auto.
+2. **Unconditional 300s watchdog timeout** (engine), summariser backstop 330s
+   (stays above so the engine is the sole timeout owner). Generous on purpose:
+   correctness over speed — a slow note must *complete*, not be killed. Harmless
+   to GPU (returns in ~7s). A cross-lab review rejected a GPU-conditional timeout
+   (a `gpu=true→90s` budget falsely assumes GPU == fast; iGPU/bad-driver/partial-
+   offload can exceed it, and learning gpu from the worker's first `ready` adds a
+   bootstrap + restart race). Unconditional removes all three.
+3. Worker reports `{gpu, threads}` on `ready`; a dev log surfaces CPU mode.
+
+Why it self-heals now: the breaker only stayed open before because *every* infer
+timed out at 60s. With a 300s watchdog, inferences succeed (~90s on half cores),
+and a success resets the failure count (`summarizer.js` `s.failures = 0`), so any
+transient trip recovers after the 60s cooldown. Regression coverage:
+`test/sticky-note-threads.test.js`, new assertions in the engine/summariser tests,
+and `test/sticky-real-inference.js` (now omits numThreads + 310s budget).
+
 ## v2: summarize from the claude JSONL transcript, not the terminal
 
 The v1 input (scrape the rendered terminal) produced garbage for `github-router claude`:

--- a/docs/specs/sticky-notes.md
+++ b/docs/specs/sticky-notes.md
@@ -53,8 +53,17 @@ minInterval), **initial**, **focus** (foreground transition, gated). Tab switch
 
 Guards: `minInterval = max(20s, 3 × lastInferenceMs)`; single-flight + dirty-bit
 (timeout clears the bit + backs off — no retry-storm); circuit breaker after N
-failures; foreground-first fair dispatch over one shared worker; thread cap
-`min(4, cores-2)`.
+failures; foreground-first fair dispatch over one shared worker. **Threads are
+auto-selected by the worker once it knows the backend** (`sticky-note-threads.js`
+`pickThreads`): GPU present → the worker requests **full layer offload**
+(`gpuLayers:'max'`, falling back to `auto` if VRAM is short) and keeps CPU threads
+gentle (`min(2, cores-2)`); **no GPU (CPU) → three-quarters of the cores**
+(`max(1, floor(cores*3/4))`, via `availableParallelism()`), since CPU inference is
+far slower and 2 threads blow the timeout. `--sticky-notes-threads` pins it
+explicitly. The
+per-request timeout is an unconditional **watchdog of 300s** (summariser backstop
+330s) — set well above real CPU latency so a slow note completes rather than
+being killed; GPU runs return in ~7s and are unaffected.
 
 ## Data shapes (v2)
 
@@ -174,6 +183,16 @@ unsupported, the engine reports `unavailable`, no card appears, and the terminal
 path is unaffected. Inference errors/timeouts never propagate into the PTY path;
 a failed summary is retried after backoff (never stranded) and repeated failures
 open a per-session circuit breaker.
+
+**Windows / CPU backend (primary target).** When the Vulkan/CUDA prebuilt binary
+is incompatible (common on Windows 11), node-llama-cpp falls back to pure CPU
+(`llama.gpu === false`). CPU inference is materially slower — a grammar-constrained
+summary measures ~90s on half-core threading and up to ~160s at 2 threads on a
+16-core box. The fix is twofold: the worker uses **half the cores** on CPU (not
+the gentle 2), and the per-request timeout is a generous **300s watchdog** (was
+60s, tuned for Metal). The first CPU note therefore renders ~90s after the card
+is expanded; the breaker self-heals (a success resets the failure count). A dev
+log on `ready` reports the backend + thread count. See ADR-0023.
 
 **Runtime: Node.js only.** The feature is force-disabled under Bun
 (`server.js` `!isBun()` + `StickyNoteEngine._doInitialize` self-gate →

--- a/src/server.js
+++ b/src/server.js
@@ -4276,7 +4276,24 @@ class ClaudeCodeWebServer {
           percent: progress.percent,
         });
       })
-      .then(() => this._broadcastStickyStatus())
+      .then(() => {
+        // One-time visibility into the inference backend. On CPU (no GPU — common
+        // on Windows when the Vulkan/CUDA prebuilt is incompatible) summaries are
+        // materially slower; the worker compensates with more threads + a generous
+        // watchdog timeout, but a note can still take a couple of minutes.
+        const rt = this.stickyNoteEngine.getRuntimeInfo && this.stickyNoteEngine.getRuntimeInfo();
+        if (this.dev && rt) {
+          if (rt.gpu) {
+            console.log(`[sticky-notes] engine ready (GPU backend, ${rt.threads} threads)`);
+          } else {
+            console.log(
+              `[sticky-notes] engine ready (CPU backend, ${rt.threads} threads) — ` +
+                'summaries run on CPU and may take a couple of minutes; a Vulkan/CUDA driver would accelerate them'
+            );
+          }
+        }
+        this._broadcastStickyStatus();
+      })
       .catch((err) => {
         // Allow a later AI-session start to retry after a transient failure
         // (download blip). A permanent failure (no binding) just fails fast.

--- a/src/sticky-note-engine.js
+++ b/src/sticky-note-engine.js
@@ -9,21 +9,31 @@
 
 const { Worker } = require('worker_threads');
 const path = require('path');
-const os = require('os');
 const GgufModelManager = require('./utils/gguf-model-manager');
 const { isBun } = require('./utils/runtime');
 
 const MAX_QUEUE_SIZE = 3;
-const DEFAULT_INFER_TIMEOUT_MS = 60000;
+// Watchdog-grade, unconditional per-request timeout. Real grammar-constrained
+// summaries on a CPU backend (no GPU — common on Windows when the Vulkan/CUDA
+// prebuilt is incompatible) take ~90s on half-core threading and up to ~160s on
+// 2 threads. This is a true catastrophic watchdog set well above that, NOT an
+// expected boundary: correctness over speed (a slow note must still complete).
+// GPU runs finish in ~7s and return immediately, so the high cap costs them
+// nothing. The summarizer's backstop sits strictly above this (one timeout
+// owner). An explicit inferTimeoutMs still overrides.
+const DEFAULT_INFER_TIMEOUT_MS = 300000;
 const MAX_RESTART_DELAY_MS = 15000;
 const MAX_RESTART_ATTEMPTS = 5;
 
 class StickyNoteEngine {
   constructor(options = {}) {
     this._enabled = !!options.enabled;
-    // Low thread cap keeps inference gentle so the model can't saturate CPU and
-    // starve the terminal / AI agent. Summaries are infrequent + throttled.
-    this._numThreads = options.numThreads || Math.max(1, Math.min(2, os.cpus().length - 2));
+    // Thread count is auto-selected by the worker once it knows whether a GPU
+    // backend loaded (see sticky-note-threads.pickThreads), UNLESS the caller
+    // pins it explicitly (--sticky-notes-threads). Auto is signalled by leaving
+    // numThreads out of the worker data entirely.
+    this._numThreadsExplicit = Number.isFinite(Number(options.numThreads)) && Number(options.numThreads) > 0;
+    this._numThreads = this._numThreadsExplicit ? Math.floor(Number(options.numThreads)) : null;
     this._contextSize = options.contextSize || 8192;
     this._inferTimeoutMs = options.inferTimeoutMs || DEFAULT_INFER_TIMEOUT_MS;
     this._maxQueue = options.maxQueue || MAX_QUEUE_SIZE;
@@ -39,22 +49,30 @@ class StickyNoteEngine {
     this._stopping = false;
     this._initPromise = null;
     this._downloadProgress = null;
+    this._runtimeInfo = null; // { gpu, threads } reported by the worker on ready
 
     this._modelManager =
       options.modelManager ||
       new GgufModelManager({ model: options.model, modelsDir: options.modelsDir });
 
-    // Injectable for tests; default spawns the real worker thread.
+    // Injectable for tests; default spawns the real worker thread. numThreads is
+    // included ONLY when explicitly pinned — otherwise the worker auto-picks.
     this._createWorker =
       options.createWorker ||
-      (() =>
-        new Worker(path.join(__dirname, 'sticky-note-worker.js'), {
-          workerData: {
-            modelPath: this._modelManager.getModelFile(),
-            numThreads: this._numThreads,
-            contextSize: this._contextSize,
-          },
-        }));
+      (() => new Worker(path.join(__dirname, 'sticky-note-worker.js'), { workerData: this._workerData() }));
+  }
+
+  /**
+   * Build the worker's workerData. numThreads is OMITTED when auto (not pinned)
+   * so the worker auto-selects based on the GPU backend it detects; pinning it
+   * here would defeat that. Kept as a method so it is unit-testable.
+   */
+  _workerData() {
+    return {
+      modelPath: this._modelManager.getModelFile(),
+      ...(this._numThreadsExplicit ? { numThreads: this._numThreads } : {}),
+      contextSize: this._contextSize,
+    };
   }
 
   async initialize(onProgress) {
@@ -107,6 +125,11 @@ class StickyNoteEngine {
 
   getDownloadProgress() {
     return this._downloadProgress;
+  }
+
+  /** { gpu, threads } reported by the worker on ready, or null before ready. */
+  getRuntimeInfo() {
+    return this._runtimeInfo;
   }
 
   /**
@@ -173,6 +196,7 @@ class StickyNoteEngine {
     this._queue = [];
     this._currentRequest = null;
     this._worker = null;
+    this._runtimeInfo = null; // dead worker — drop its reported backend/threads
 
     if (this._stopping) {
       this._status = 'unavailable';
@@ -230,6 +254,7 @@ class StickyNoteEngine {
           this._status = 'ready';
           this._restartAttempts = 0;
           this._lastSpawnError = null;
+          this._runtimeInfo = { gpu: !!msg.gpu, threads: msg.threads || null };
           worker.on('message', (m) => this._onWorkerMessage(m));
           worker.on('exit', (c) => this._onWorkerExit(c));
           this._processQueue();

--- a/src/sticky-note-summarizer.js
+++ b/src/sticky-note-summarizer.js
@@ -18,7 +18,7 @@ const DEFAULTS = {
   minIntervalMs: 20000, // floor between inferences for one session
   intervalFactor: 3, // adaptive: minInterval = max(floor, factor * lastDurationMs)
   turnDebounceMs: 1500, // (JSONL mode) coalesce a burst of appended turn lines
-  inferTimeoutMs: 75000, // backstop ABOVE the engine's own 60s timeout, so the
+  inferTimeoutMs: 330000, // backstop ABOVE the engine's own 300s timeout, so the
   // engine times out first (one timeout owner); this only fires if the engine
   // promise hangs entirely. Worker-side serialisation prevents concurrent runs.
   failureThreshold: 3, // consecutive failures -> open circuit breaker

--- a/src/sticky-note-threads.js
+++ b/src/sticky-note-threads.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Thread-count policy for the sticky-note inference worker. Pure + dependency-
+// free so it can be unit-tested without spawning a worker or loading a model.
+//
+// The worker decides its own thread count AFTER getLlama() reports whether a GPU
+// backend actually loaded:
+//   - GPU present  -> the GPU carries the inference (the worker also requests full
+//     layer offload); keep a low, gentle CPU thread count so it can't saturate CPU
+//     and starve the terminal / AI agent.
+//   - No GPU (CPU) -> common on Windows when the Vulkan/CUDA prebuilt binary is
+//     incompatible. At 2 threads one grammar-constrained summary takes ~160s on a
+//     16-core box and blows every timeout; use THREE-QUARTERS of the cores (leaving
+//     a quarter for the terminal/agent) so it completes well inside the watchdog.
+// An explicit override (--sticky-notes-threads) always wins, after validation.
+// `explicit` is coerced with Number() so a numeric string (e.g. from a CLI/env
+// arg) still counts as a valid pin rather than silently falling back to auto.
+function pickThreads({ explicit, gpu, cpus } = {}) {
+  const pinned = Number(explicit);
+  if (Number.isFinite(pinned) && pinned > 0) return Math.floor(pinned);
+  const cores = Number.isFinite(cpus) && cpus > 0 ? Math.floor(cpus) : 1;
+  return gpu ? Math.max(1, Math.min(2, cores - 2)) : Math.max(1, Math.floor((cores * 3) / 4));
+}
+
+module.exports = { pickThreads };

--- a/src/sticky-note-worker.js
+++ b/src/sticky-note-worker.js
@@ -9,10 +9,10 @@
 const { parentPort, workerData } = require('worker_threads');
 const os = require('os');
 const { SYSTEM_PROMPT, NOTE_SCHEMA } = require('./sticky-note-prompt');
+const { pickThreads } = require('./sticky-note-threads');
 
 const modelPath = workerData.modelPath;
 const contextSize = workerData.contextSize || 8192;
-const numThreads = workerData.numThreads || Math.max(1, Math.min(2, os.cpus().length - 2));
 const maxTokens = workerData.maxTokens || 320;
 
 let llama;
@@ -42,12 +42,29 @@ async function init() {
   LlamaChatSessionCtor = LlamaChatSession;
 
   llama = await getLlama();
-  model = await llama.loadModel({ modelPath });
+  // availableParallelism() reflects usable parallelism better than cpus().length
+  // on Windows hybrid P/E-core machines; fall back where it's unavailable.
+  const cpus = (typeof os.availableParallelism === 'function' ? os.availableParallelism() : 0) || os.cpus().length;
+  // llama.gpu is false | 'cuda' | 'vulkan' | 'metal'; any non-empty string = GPU.
+  const gpu = !!llama.gpu;
+  const numThreads = pickThreads({ explicit: workerData.numThreads, gpu, cpus });
+  // Use the GPU fully when present: request all layers in VRAM ('max'). If the
+  // GPU can't fit them, 'max' throws — fall back to the default 'auto', which
+  // still offloads as many layers as fit (never worse than CPU-only).
+  if (gpu) {
+    try {
+      model = await llama.loadModel({ modelPath, gpuLayers: 'max' });
+    } catch {
+      model = await llama.loadModel({ modelPath });
+    }
+  } else {
+    model = await llama.loadModel({ modelPath });
+  }
   context = await model.createContext({ contextSize, threads: numThreads });
   sequence = context.getSequence();
   grammar = await llama.createGrammarForJsonSchema(NOTE_SCHEMA);
 
-  parentPort.postMessage({ type: 'ready' });
+  parentPort.postMessage({ type: 'ready', gpu, threads: numThreads });
 }
 
 async function handleInfer(msg) {

--- a/test/sticky-note-engine.test.js
+++ b/test/sticky-note-engine.test.js
@@ -80,6 +80,62 @@ describe('sticky-note engine', function () {
     await engine.shutdown();
   });
 
+  it('defaults to a watchdog-grade 300s inference timeout (fits slow CPU inference)', function () {
+    const engine = new StickyNoteEngine({ enabled: true, modelManager: readyMM });
+    assert.strictEqual(engine._inferTimeoutMs, 300000);
+  });
+
+  it('treats numThreads as auto unless explicitly pinned (omits it from workerData)', function () {
+    // Auto: no numThreads given -> worker decides based on the GPU backend.
+    const auto = new StickyNoteEngine({ enabled: true, modelManager: readyMM });
+    assert.strictEqual(auto._numThreadsExplicit, false);
+    assert.strictEqual(auto._numThreads, null);
+    assert.ok(!('numThreads' in auto._workerData()), 'auto must omit numThreads so the worker auto-picks');
+
+    // Explicit pin (--sticky-notes-threads): forwarded verbatim.
+    const pinned = new StickyNoteEngine({ enabled: true, modelManager: readyMM, numThreads: 6 });
+    assert.strictEqual(pinned._numThreadsExplicit, true);
+    assert.strictEqual(pinned._numThreads, 6);
+    assert.strictEqual(pinned._workerData().numThreads, 6);
+
+    // Bogus pins (0 / negative / NaN) fall back to auto.
+    for (const bad of [0, -1, NaN]) {
+      const e = new StickyNoteEngine({ enabled: true, modelManager: readyMM, numThreads: bad });
+      assert.strictEqual(e._numThreadsExplicit, false, `numThreads=${bad} must be treated as auto`);
+      assert.ok(!('numThreads' in e._workerData()));
+    }
+  });
+
+  it('records the worker-reported runtime info ({gpu, threads}) on ready', async function () {
+    const { engine, fake } = makeEngine();
+    const initP = engine.initialize();
+    await tick();
+    fake.emit('message', { type: 'ready', gpu: false, threads: 8 });
+    await initP;
+    assert.deepStrictEqual(engine.getRuntimeInfo(), { gpu: false, threads: 8 });
+    await engine.shutdown();
+  });
+
+  it('clears stale runtime info when the worker dies', async function () {
+    const { engine, fake } = makeEngine();
+    const initP = engine.initialize();
+    await tick();
+    fake.emit('message', { type: 'ready', gpu: false, threads: 8 });
+    await initP;
+    assert.ok(engine.getRuntimeInfo(), 'runtime info present while ready');
+    engine._stopping = true; // prevent the scheduled respawn from lingering
+    fake.crash(1);
+    await tick();
+    assert.strictEqual(engine.getRuntimeInfo(), null, 'must not report dead-worker backend/threads');
+  });
+
+  it('forwards a numeric-string thread pin as an explicit override', function () {
+    const e = new StickyNoteEngine({ enabled: true, modelManager: readyMM, numThreads: '8' });
+    assert.strictEqual(e._numThreadsExplicit, true);
+    assert.strictEqual(e._numThreads, 8);
+    assert.strictEqual(e._workerData().numThreads, 8);
+  });
+
   it('degrades to unavailable when node-llama-cpp is missing', async function () {
     const { engine, fake } = makeEngine();
     const initP = engine.initialize();

--- a/test/sticky-note-summarizer.test.js
+++ b/test/sticky-note-summarizer.test.js
@@ -141,6 +141,21 @@ const FAST = {
 };
 
 describe('sticky-note summarizer scheduler', function () {
+  it('default backstop timeout stays strictly above the engine timeout (one timeout owner)', function () {
+    const StickyNoteEngine = require('../src/sticky-note-engine');
+    const { sum } = makeSummarizer(); // no config override -> DEFAULTS
+    const engine = new StickyNoteEngine({
+      enabled: true,
+      modelManager: { isModelReady: async () => true, ensureModel: async () => {}, getModelFile: () => '/tmp/m.gguf' },
+    });
+    assert.strictEqual(sum._cfg.inferTimeoutMs, 330000, 'summarizer backstop is 330s');
+    assert.strictEqual(engine._inferTimeoutMs, 300000, 'engine watchdog is 300s');
+    assert.ok(
+      sum._cfg.inferTimeoutMs > engine._inferTimeoutMs,
+      'summarizer backstop must exceed the engine timeout so the engine times out first'
+    );
+  });
+
   it('quiet trigger produces a summary after the debounce', async function () {
     const { sum, engine, clock, results } = makeSummarizer(FAST);
     sum.enable('s1');

--- a/test/sticky-note-threads.test.js
+++ b/test/sticky-note-threads.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const assert = require('assert');
+const { pickThreads } = require('../src/sticky-note-threads');
+
+describe('sticky-note pickThreads', function () {
+  it('uses three-quarters of the cores on a CPU backend (no GPU)', function () {
+    assert.strictEqual(pickThreads({ explicit: undefined, gpu: false, cpus: 16 }), 12);
+    assert.strictEqual(pickThreads({ explicit: undefined, gpu: false, cpus: 12 }), 9);
+    assert.strictEqual(pickThreads({ explicit: undefined, gpu: false, cpus: 8 }), 6);
+  });
+
+  it('is three-quarters of the cores down to a floor of 1 on small CPU boxes', function () {
+    assert.strictEqual(pickThreads({ gpu: false, cpus: 4 }), 3);
+    assert.strictEqual(pickThreads({ gpu: false, cpus: 2 }), 1);
+    assert.strictEqual(pickThreads({ gpu: false, cpus: 1 }), 1);
+  });
+
+  it('stays gentle (<=2) on a GPU backend — the GPU carries the load', function () {
+    assert.strictEqual(pickThreads({ gpu: true, cpus: 16 }), 2);
+    assert.strictEqual(pickThreads({ gpu: true, cpus: 3 }), 1);
+  });
+
+  it('honors a valid explicit override regardless of backend', function () {
+    assert.strictEqual(pickThreads({ explicit: 6, gpu: false, cpus: 16 }), 6);
+    assert.strictEqual(pickThreads({ explicit: 6, gpu: true, cpus: 16 }), 6);
+    assert.strictEqual(pickThreads({ explicit: 3.9, gpu: false, cpus: 16 }), 3); // floored
+    assert.strictEqual(pickThreads({ explicit: '8', gpu: false, cpus: 16 }), 8); // numeric string from CLI/env
+  });
+
+  it('ignores a bogus explicit override and falls back to auto', function () {
+    assert.strictEqual(pickThreads({ explicit: 0, gpu: false, cpus: 16 }), 12);
+    assert.strictEqual(pickThreads({ explicit: -2, gpu: false, cpus: 16 }), 12);
+    assert.strictEqual(pickThreads({ explicit: NaN, gpu: false, cpus: 16 }), 12);
+    assert.strictEqual(pickThreads({ explicit: 'x', gpu: false, cpus: 16 }), 12);
+  });
+});

--- a/test/sticky-real-inference.js
+++ b/test/sticky-real-inference.js
@@ -19,8 +19,10 @@ const WORKER_PATH = path.join(__dirname, '..', 'src', 'sticky-note-worker.js');
 
 function spawnWorker(modelPath) {
   return new Promise((resolve, reject) => {
+    // Omit numThreads so the worker auto-picks based on the GPU backend it
+    // detects (GPU -> gentle 2; CPU -> half the cores) — the real production path.
     const worker = new Worker(WORKER_PATH, {
-      workerData: { modelPath, numThreads: 2, contextSize: 4096 },
+      workerData: { modelPath, contextSize: 4096 },
     });
     const timeout = setTimeout(() => {
       reject(new Error('Worker did not become ready within 120s'));
@@ -42,7 +44,11 @@ function spawnWorker(modelPath) {
 function infer(worker, prompt) {
   return new Promise((resolve, reject) => {
     const id = 1;
-    const timeout = setTimeout(() => reject(new Error('Inference timed out after 90s')), 90000);
+    // Generous budget: on a CPU backend (no GPU — common on Windows when the
+    // Vulkan/CUDA prebuilt is incompatible) a real grammar-constrained summary
+    // takes ~90s on half-core threading and up to ~160s on small boxes. Matches
+    // the production watchdog (engine 300s).
+    const timeout = setTimeout(() => reject(new Error('Inference timed out after 310s')), 310000);
     const handler = (msg) => {
       if (msg.type !== 'result' || msg.id !== id) return;
       clearTimeout(timeout);


### PR DESCRIPTION
## Problem

On Windows 11 the sticky-note card stays stuck on **"No status yet — a summary appears as the session works."** forever, even with the card expanded.

**Root cause (measured in-process, not guessed):** the Vulkan GPU prebuilt binary is frequently *"not compatible with the current system"*, so `node-llama-cpp` falls back to **pure CPU** (`llama.gpu === false`). The engine hard-capped inference at **2 threads** (even on a 16-core box), so a real grammar-constrained summary takes **~160s**. Every timeout in the stack was tuned for GPU/Metal (~7s/turn): engine **60s**, summarizer **75s**, even the real-inference smoke **90s**. So every inference timed out → after 3 consecutive failures the circuit breaker opened → the note was **never** produced. Waiting longer could not help.

This is exactly the hazard ADR-0023 flagged: *"Metal latencies are a floor — Windows runs CPU/Vulkan and is materially slower."*

## Fix

- **Worker auto-selects threads from the detected backend** (new `src/sticky-note-threads.js` `pickThreads`):
  - GPU present → request **full layer offload** (`gpuLayers: 'max'`, graceful fallback to `'auto'` if VRAM is short) and keep CPU threads gentle.
  - No GPU → **three-quarters of the cores** (via `availableParallelism()` for hybrid P/E machines), leaving a quarter for the terminal/agent.
- **Unconditional 300s watchdog** inference timeout (was 60s); summarizer backstop raised to **330s** so the engine stays the sole timeout owner. Generous on purpose — correctness over speed: a slow CPU note completes instead of being killed. Harmless to GPU (returns in ~7s).
- `--sticky-notes-threads` still pins threads explicitly (numeric strings honored); the engine omits the value from `workerData` when auto so the worker decides.

A GPU-conditional timeout was considered and **rejected** after cross-lab review: `gpu == fast` is false for iGPU/partial-offload/bad-driver machines, and learning `gpu` before the first dispatch adds a bootstrap + worker-restart race. An unconditional watchdog removes all three.

## Verification

- **Unit:** new `pickThreads` coverage (auto / explicit / bogus / numeric-string, GPU vs CPU), engine 300s-timeout + auto-vs-explicit-threads + stale-runtime-info-on-crash regressions, summarizer one-timeout-owner check. **Full suite: 1390 passing**, exit 0.
- **Real-model smoke** (`test/sticky-real-inference.js`, budget raised to 310s): produces a valid grammar-constrained note in **~95s** (previously timed out at 90s).
- **Edge cases** driven through the real worker: auto → 12 threads, explicit pin `4` → 4, bogus `0` → auto, numeric-string `"6"` → 6 — all pass.
- **Live server** on an isolated port: dev log confirms `engine ready (CPU backend, 12 threads)` and a session's Status card replaced "No status yet" with a real summary — no timeout, no breaker.

Docs updated in the same change: `docs/specs/sticky-notes.md`, `docs/history/sticky-notes-2026.md`, ADR-0023, and the `--sticky-notes-threads` help text.

> Note: the GPU full-offload branch is guarded by `if (gpu)` and could not be exercised on the GPU-less test machine; the CPU path is fully validated.