### PR TITLE
feat: fleet control-plane scale hardening (F15/F16/F19/F21/F22 + contract audit)

### DIFF
--- a/docs/adrs/0032-fleet-session-control-plane.md
+++ b/docs/adrs/0032-fleet-session-control-plane.md
@@ -28,21 +28,101 @@ middleware in `src/server.js` (so every route is token-gated), built from inject
   `{ lifecycle, interactionState, canAcceptInput, confidence, blockReason?, awaiting?, lastTurnEndedAt }`.
   Reliability is agent-dependent and surfaced via `confidence`: **high** when read from the claude JSONL
   transcript (ADR-0026 binding), **medium** from a busy-footer regex over the rendered terminal, **low**
-  otherwise. We never fake certainty.
+  otherwise. We never fake certainty. Two cross-checks tighten the busy/idle call:
+  - **F8 (bound footer cross-check):** the polled JSONL transcript LAGS the rendered screen, so a
+    just-submitted message can momentarily look settled (`endsOnAssistant`, not `growing`) while claude is
+    already mid-turn. Before returning idle on a bound session, the live busy footer (`esc to interrupt` /
+    spinner gerund) is cross-checked; if it shows a running turn the state is **busy** at **medium**
+    confidence (screen disagrees with JSONL). The footer may only RAISE busy — it is never an authoritative
+    idle gate and never the sole signal that blocks a send (deadlock risk); JSONL turn state stays
+    authoritative.
+  - **F12 (coarse unbound recency):** for an active session with NO JSONL binding (e.g. claude launched
+    inside a `terminal` PTY), busy/idle is derived from PTY-output recency (`lastOutputAt` within a LARGE
+    quiet window → busy, else idle) at **low** confidence, and the server emits coarse `became_busy` /
+    `became_idle` edges (debounced on the session) so `await_turn` returns SOMETHING. This is a courtesy,
+    not a turn oracle: it NEVER emits `turn_ended` and is never presented as real turn completion — the
+    supported path for real turn detection is `agent:"claude"` (bound), and an unbound driver should be
+    surfaced as `NO_TURN_BINDING`.
 - `src/control/event-bus.js` — an in-process bounded monotonic event ring (the network-safe generalization of
   firstmate's durable wake-queue). It is **epoch-aware** (an instance restart mints a new epoch so a stale
-  cursor gets a `restart` gap, not a silent reset) and reports an explicit `overflow` gap when the ring rolls
-  past a consumer's cursor. Cursor = `{ epoch, seq }`.
+  cursor gets a `restart` gap, not a silent reset) and reports an explicit `overflow` gap when retention rolls
+  past a consumer's cursor. Cursor = `{ epoch, seq }`. **Retention is PER SESSION (F15):** each session keeps
+  its own bounded ring (default 256 events), so one chatty session evicts only its own old events and can
+  never roll another session's last `turn_ended` out of the buffer. A global monotonic `seq` still orders
+  events across sessions, and `_maxEvictedSeq` (the highest seq dropped from any ring, incl. whole-bucket LRU
+  eviction past the session cap) drives overflow detection — a drop is never silent. Cursors are **per-watcher
+  (F22):** `since()`/`waitFor()` are pure reads parameterised by the caller's cursor with no shared global
+  position, so many concurrent watchers each resume from their own `{epoch,seq}` independently.
 - `src/control/jsonl-awaiting.js` — detects a pending user-facing tool_use (`ExitPlanMode` → plan_approval,
   `AskUserQuestion` → choice_question, a permission prompt → tool_approval) so the client knows it must
   `respond` rather than `send_message`.
 - `src/control/routes.js` — `GET /sessions`, `/sessions/:id/{status,read}`, `POST /sessions/{create,:id/stop,
-  :id/message,:id/keys,:id/respond}`, `GET /events` (long-poll). Steering: `send_message` (multiline via
+  :id/message,:id/keys,:id/respond}`, `GET /events` (long-poll), **`GET /snapshot`** and **`GET /capabilities`**
+  (below). Steering: `send_message` (multiline via
   bracketed paste + Enter, idempotent, awaits a `turn_ended` for honest confirmation, LOUD failure on
-  unconfirmed delivery rather than a buried flag), `send_keys` (named-key table), `respond` (server-side
-  best-effort keystroke map for the agent + a `keys` override). All mutations take an `idempotencyKey`; the
+  unconfirmed delivery rather than a buried flag; the cold-boot dropped-Enter reaper re-sends only when no
+  NEW user entry (bound, F18) / no NEW activity edge after the pre-send cursor (unbound, F13) is observed,
+  so a lingering prior-turn busy never suppresses a genuinely dropped submit, and the per-session writeQueue
+  + idempotency make the retry duplicate-safe), `send_keys` (named-key table incl. Shift+Tab → CSI Z), `respond` (server-side
+  best-effort keystroke map for the agent + a `keys` override). All steering ops on one session also pass
+  through a **per-session steering mutex (F16)** — a logical-command queue distinct from the byte-level
+  writeQueue — so two concurrent DISTINCT ops can't interleave bytes (the mutex wraps delivery+submission and
+  releases before any long turn-await, so it never blocks a `respond` behind a slow `send_message`). All
+  mutations take an `idempotencyKey`; the
   instance caches last-N outcomes and returns the prior result with `duplicated:true` on a retry. The control
-  routes are rate-limited per token.
+  routes are rate-limited per token; a throttled call returns a **classifiable 429 (F21)** — stable
+  `error.code='RATE_LIMITED'` + `retryAfterMs`/`retryAfterSec` body + standard `Retry-After` header — so the
+  client backs off precisely instead of hammering.
+
+### Scale endpoints (Cluster 4)
+
+**`GET /api/control/snapshot` (F15)** — atomic O(1) reconnect after a cursor gap. Returns every session's
+derived status PLUS the event cursor, captured atomically (cursor FIRST, then statuses), so the controller
+resyncs in ONE call and resumes the long-poll from the returned cursor with **zero lost events** (a boundary
+event already reflected in a status may be redelivered on resume — harmless/idempotent — but is never
+dropped). Shape:
+
+```json
+{
+  "sessions": [
+    {
+      "sessionId": "…", "name": "…", "agent": "claude|terminal|…", "workingDir": "…",
+      "lifecycle": "created|starting|running|exited|crashed",
+      "interactionState": "busy|idle|waiting_input|exited|unknown",
+      "canAcceptInput": true,
+      "confidence": "high|medium|low",
+      "lastTurnEndedAt": 1719500000000,
+      "awaiting": { "kind": "next_message|plan_approval|tool_approval|choice_question|trust_prompt" },
+      "sessionStateSeq": 7,
+      "bound": true,
+      "lastActivity": "2026-06-27T…"
+    }
+  ],
+  "cursor": "<epoch>:<seq>",
+  "capturedAt": 1719500000000
+}
+```
+
+**Reconnect protocol:** on a `gap` (`overflow`/`restart`) marker from `GET /events`, call `GET /snapshot`,
+reconcile each session from `sessions[]`, then resume the long-poll from `snapshot.cursor`.
+
+**`GET /api/control/capabilities` (F19)** — cross-repo capability negotiation, read ONCE per instance; the
+client fails closed (or degrades explicitly) on a missing capability, so a newer client never silently
+assumes an older instance supports a field/event. Shape:
+
+```json
+{
+  "contractVersion": 1,
+  "capabilities": {
+    "permissionMode": true, "agentArgs": true, "turnBinding": true, "snapshot": true,
+    "perSessionRetention": true, "structuredConfirmation": true, "steeringMutex": true,
+    "coarseUnboundStatus": true, "rateLimitClassification": true
+  },
+  "permissionModes": ["plan", "acceptEdits", "default", "bypassPermissions"],
+  "events": ["turn_ended","became_idle","became_busy","waiting_input","exited","crashed","session_created","session_deleted"],
+  "limits": { "eventsPerSession": 256, "maxReadLines": 2000, "eventsLongPollMaxMs": 60000 }
+}
+```
 
 The primitives map 1:1 to firstmate (`fm-spawn`→create, `fm-send`→send_message/send_keys, `fm-peek`→read,
 `fm-watch`→events); the additions (idempotency, epoch/gap cursor, honest confidence) are exactly the cost of

--- a/docs/specs/bridges.md
+++ b/docs/specs/bridges.md
@@ -100,9 +100,18 @@ Fallback: `'claude'`
 
 ### CLI Arguments
 
+claude is always launched through the github-router prefix
+(`npx -y github-router@latest claude --browse`); `buildArgs` appends the flags
+below **after** that prefix.
+
 | Flag | Condition |
 |------|-----------|
-| `--dangerously-skip-permissions` | When `options.dangerouslySkipPermissions` is `true` |
+| `--permission-mode <mode>` | When `options.permissionMode` is one of `plan` / `acceptEdits` / `default` / `bypassPermissions` (F10). This is the canonical translation layer. The mode supersedes the legacy dangerous flag; github-router drops `--dangerously-skip-permissions` for non-bypass modes. An unknown mode throws `INVALID_ARGUMENT`. |
+| `<...options.agentArgs>` | Caller passthrough flags, appended last. If `agentArgs` carries `--permission-mode` or `--dangerously-skip-permissions`, `buildArgs` throws `INVALID_ARGUMENT` (no duplicate/conflicting flags). |
+| `--dangerously-skip-permissions` | When `options.dangerouslySkipPermissions` is `true` AND no `permissionMode` is set (back-compat) |
+
+Runtime permission-mode cycling is driven by **Shift+Tab** (CSI Z / `\x1b[Z`),
+exposed through the control-plane named-key map `_controlKeyBytes` (F3).
 
 ### Trust Prompt Auto-Accept
 

--- a/docs/specs/sticky-notes.md
+++ b/docs/specs/sticky-notes.md
@@ -127,8 +127,18 @@ The toolbar toggle (`#stickyNoteBtn`) is shown only once the engine reports
 ### Expand-gating & ai-title (ADR-0025)
 
 The card starts **collapsed** (expanding is a deliberate "activate"). Processing
-splits in two:
+splits in **three** tiers by cost:
 
+- **Turn-boundary detection (cheap; no model) runs EVERY poll regardless of
+  collapse or whether any client is connected (F14).** A separate always-advancing
+  `binding.turnOffset` reads new transcript turns and maintains
+  `lastGrowing`/`lastEndsOnAssistant`/`lastTurnEndedAt`, emitting `turn_ended` +
+  driving the `became_busy`/`became_idle` control-plane transitions. This is what
+  the fleet control plane's `await_turn` + `send_message` confirmation depend on, so
+  it must NOT be gated on a UI viewer — a headless fleet-spawned claude has no
+  WebSocket card to expand. `turnOffset` is independent of the note horizon
+  (`binding.offset`), so always-on turn detection never steals the summariser's
+  catch-up window.
 - **Note summarisation (the LLM inference) runs only while ≥1 connected client
   has the card EXPANDED.** Clients report this with `set_sticky_active
   {sessionId, active}`; the server reference-counts expanded viewers per session

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:browser": "npx playwright test --config e2e/playwright.config.js",
     "soak": "node test/longevity/harness/cli.js",
     "test:longevity-smoke": "mocha --exit --timeout 120000 test/longevity/smoke.test.js",
-    "test:longevity:server": "mocha --exit --timeout 120000 --recursive --extension .test.js test/longevity/event-loop test/longevity/disk test/longevity/process test/longevity/browser-sampler.test.js test/longevity/cli.test.js test/longevity/gate-evaluator-directional.test.js test/longevity/gate-evaluator-vacuous.test.js test/longevity/resume.test.js test/longevity/smoke.test.js",
+    "test:longevity:server": "mocha --exit --timeout 120000 --recursive --extension .test.js test/longevity/event-loop test/longevity/disk test/longevity/process test/longevity/browser-sampler.test.js test/longevity/cli.test.js test/longevity/gate-evaluator-directional.test.js test/longevity/gate-evaluator-vacuous.test.js test/longevity/event-loop-tolerance.test.js test/longevity/resume.test.js test/longevity/smoke.test.js",
     "test:longevity:browser": "playwright test --config test/longevity/playwright.config.js",
     "test:longevity": "npm run test:longevity:server && npm run test:longevity:browser",
     "build:bundle": "node scripts/build-sea.js bundle",

--- a/src/base-bridge.js
+++ b/src/base-bridge.js
@@ -275,6 +275,8 @@ class BaseBridge {
     const {
       workingDir = process.cwd(),
       dangerouslySkipPermissions = false,
+      permissionMode = undefined,
+      agentArgs = undefined,
       onOutput = () => {},
       onExit = () => {},
       onError = () => {},
@@ -292,7 +294,10 @@ class BaseBridge {
         console.log(`WARNING: Using ${this.dangerousFlag} flag`);
       }
 
-      const args = this.buildArgs({ dangerouslySkipPermissions });
+      // F10: forward permissionMode/agentArgs so tool-specific buildArgs (claude)
+      // can emit --permission-mode + caller passthrough flags. Subclasses that
+      // don't override buildArgs (terminal/codex) ignore these.
+      const args = this.buildArgs({ dangerouslySkipPermissions, permissionMode, agentArgs });
 
       const env = {
         ...process.env,

--- a/src/claude-bridge.js
+++ b/src/claude-bridge.js
@@ -1,4 +1,16 @@
 const BaseBridge = require('./base-bridge');
+const { TRUST_PROMPT_REGEX } = require('./control/session-status');
+
+// claude's --permission-mode allowlist (F10). The fleet/control plane forwards one
+// of these; an unknown value is rejected up front rather than passed to claude (a
+// flag silently ignored by a skewed claude is a dishonest "mode set").
+const VALID_PERMISSION_MODES = ['plan', 'acceptEdits', 'default', 'bypassPermissions'];
+
+function invalidArgument(message) {
+  const err = new Error(message);
+  err.code = 'INVALID_ARGUMENT';
+  return err;
+}
 
 // Claude is ALWAYS launched through github-router (never the raw `claude`
 // binary): `npx -y github-router@latest claude --browse [claude flags]`. This
@@ -53,22 +65,79 @@ class ClaudeBridge extends BaseBridge {
     this._trustPromptHandled = new Map();
   }
 
+  /**
+   * F10 — the ONE canonical translation layer from a high-level launch intent
+   * (permissionMode + caller agentArgs) to claude's argv, appended AFTER the
+   * github-router launcher prefix (`npx -y github-router@latest claude --browse`).
+   *
+   * claude is launched through github-router, whose `claude` subcommand emits
+   * `--dangerously-skip-permissions` by default and DROPS it when a non-bypass
+   * `--permission-mode` is present. So here we only need to forward the mode flag;
+   * github-router reconciles the dangerous flag on its side.
+   *
+   * Conflict policy: `agentArgs` may NOT itself carry
+   * `--permission-mode` or `--dangerously-skip-permissions` — that would emit
+   * duplicate/conflicting flags. We throw INVALID_ARGUMENT so the create fails
+   * cleanly instead of launching an ambiguous claude. An unknown `permissionMode`
+   * is likewise rejected.
+   */
+  buildArgs(options = {}) {
+    const prefix = this._prefixArgs || [];
+    const out = [...prefix];
+    const { permissionMode, agentArgs, dangerouslySkipPermissions } = options;
+
+    if (agentArgs != null && !Array.isArray(agentArgs)) {
+      throw invalidArgument('agentArgs must be an array of strings');
+    }
+    const extra = Array.isArray(agentArgs) ? agentArgs.map((a) => String(a)) : [];
+    for (const a of extra) {
+      if (/^--permission-mode(=|$)/.test(a) || a === '--dangerously-skip-permissions') {
+        throw invalidArgument(
+          `agentArgs may not contain '${a}'; use permissionMode for permission control`
+        );
+      }
+    }
+
+    if (permissionMode != null && permissionMode !== '') {
+      const mode = String(permissionMode);
+      if (!VALID_PERMISSION_MODES.includes(mode)) {
+        throw invalidArgument(
+          `Unknown permissionMode '${mode}' (expected one of: ${VALID_PERMISSION_MODES.join(', ')})`
+        );
+      }
+      // permissionMode is the source of truth: emit the canonical flag and let
+      // github-router drop --dangerously-skip-permissions for non-bypass modes.
+      out.push('--permission-mode', mode);
+    } else if (dangerouslySkipPermissions && this.dangerousFlag) {
+      // Back-compat: no explicit mode → honor the legacy skip-permissions toggle.
+      out.push(this.dangerousFlag);
+    }
+
+    out.push(...extra);
+    return out;
+  }
+
   processOutput(sessionId, ptyProcess, dataBuffer) {
     if (this._trustPromptHandled.get(sessionId)) return;
     // Strip ANSI first: claude's Ink TUI interleaves escape codes between words,
-    // so a clean-string `includes` misses the folder-trust modal (and the exact
-    // wording shifts between claude versions). Match a stable substring of the
-    // "Do you trust the files in this folder?" / "1. Yes, I trust this folder"
-    // modal on the de-ANSI'd buffer, then accept the default (Enter = Yes). The
+    // so a clean-string match misses the folder-trust modal (and the exact wording
+    // shifts between claude versions). Match the shared TRUST_PROMPT_REGEX on the
+    // de-ANSI'd buffer — but ONLY act when the modal's numbered "1. / 2." choice
+    // list is ALSO present. That structural guard (mirroring awaitingFromScreen)
+    // prevents a false positive from claude merely PRINTING a trust phrase in prose
+    // / a file / a commit message, which would otherwise inject a spurious keystroke
+    // into the live PTY. Then send the EXPLICIT "1" choice + Enter (not a bare Enter,
+    // which could land on a wrong default) — matching _controlMapResponseKeys. The
     // per-session guard makes this a one-shot. This is what lets HEADLESS /
     // fleet-spawned claude sessions (no human to click) get past trust.
     const plain = String(dataBuffer || '').replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '');
-    if (/Do you trust the files in this folder|trust this folder/i.test(plain)) {
+    const numbered = /\b1\.\s/.test(plain) && /\b2\.\s/.test(plain);
+    if (numbered && TRUST_PROMPT_REGEX.test(plain)) {
       this._trustPromptHandled.set(sessionId, true);
       console.log(`Auto-accepting trust prompt for session ${sessionId}`);
       setTimeout(() => {
-        try { ptyProcess.write('\r'); } catch (_) { /* pty may have exited */ }
-        console.log(`Sent Enter to accept trust prompt for session ${sessionId}`);
+        try { ptyProcess.write('1\r'); } catch (_) { /* pty may have exited */ }
+        console.log(`Sent "1" + Enter to accept trust prompt for session ${sessionId}`);
       }, 500);
     }
   }
@@ -81,3 +150,4 @@ class ClaudeBridge extends BaseBridge {
 
 module.exports = ClaudeBridge;
 module.exports.resolveClaudeLauncher = resolveClaudeLauncher;
+module.exports.VALID_PERMISSION_MODES = VALID_PERMISSION_MODES;

--- a/src/control/event-bus.js
+++ b/src/control/event-bus.js
@@ -11,16 +11,39 @@
 //   - EPOCH: a per-process id. An instance restart mints a new epoch, so a
 //     client holding a pre-restart cursor is told `gap: restart` instead of
 //     silently resuming a reset sequence (the ABA problem).
-//   - GAP REPORTING: when the ring overflows past a client's cursor, `since()`
-//     returns `gap: overflow` so the client resyncs (via list_sessions) instead
-//     of believing nothing happened.
-//   - The cursor is `{ epoch, seq }`; the model never threads it — the fleet
-//     layer manages it per-client (contract v1).
+//   - GAP REPORTING: when retention rolls past a client's cursor, `since()`
+//     returns `gap: overflow` so the client resyncs (via snapshot) instead of
+//     believing nothing happened.
+//   - The cursor is `{ epoch, seq }`; the model never threads it - the fleet
+//     layer manages it per-client (contract v1). Cursors are PER-WATCHER:
+//     `since()` / `waitFor()` are pure reads parameterised by the caller's
+//     cursor, with NO shared global watcher position, so many concurrent
+//     watchers each resume from their own `{epoch,seq}` without interfering
+//     (F22).
+//
+// RETENTION IS PER SESSION (F15). The naive single global ring let one chatty
+// session roll the buffer and evict another session's last `turn_ended`, forcing
+// an avoidable resync. Instead each session keeps its OWN bounded ring, so a busy
+// session only evicts its own old events - never another session's turn boundary.
+// A global monotonic `seq` still orders events across sessions for the cursor,
+// and `_maxEvictedSeq` (the highest seq ever dropped from ANY ring) drives
+// overflow detection: a cursor older than it has provably missed an event. Whole
+// idle-session rings are evicted (LRU) only past a large session cap, also
+// bumping `_maxEvictedSeq` so the drop is never silent.
 
 const { EventEmitter } = require('events');
 const crypto = require('crypto');
 
-const DEFAULT_MAX_EVENTS = 1000;
+// Per-SESSION ring depth. ~85 turns of busy/idle/turn_ended history per session,
+// so a session's last turn_ended survives any realistic fan-out burst by OTHER
+// sessions. (Back-compat: the old `maxEvents` option maps to this.)
+const DEFAULT_MAX_EVENTS_PER_SESSION = 256;
+// Whole-session bucket cap. Past this many distinct sessions, the least-recently
+// active session's ring is evicted wholesale (its events are old/dead). Sized for
+// the scale bar (100+ live sessions) with generous headroom for exited ones.
+const DEFAULT_MAX_SESSIONS = 1024;
+// Bucket key for session-less events (defensive; current emitters always pass an id).
+const GLOBAL_KEY = '__global__';
 
 // Event kinds the control plane emits (mirrors the contract's await_turn `kind`).
 const EVENT_KINDS = Object.freeze([
@@ -38,16 +61,26 @@ class ControlEventBus extends EventEmitter {
   constructor(options = {}) {
     super();
     this.setMaxListeners(0); // many concurrent long-polls
-    this._maxEvents = options.maxEvents || DEFAULT_MAX_EVENTS;
+    // `maxEvents` is the legacy single-ring cap; it now sizes the PER-SESSION ring
+    // (a chatty session evicts only its own old events, never another's turn_ended).
+    this._maxPerSession = options.maxEventsPerSession || options.maxEvents || DEFAULT_MAX_EVENTS_PER_SESSION;
+    this._maxSessions = options.maxSessions || DEFAULT_MAX_SESSIONS;
     // A fresh, unguessable epoch per process. Math.random/Date are fine here
     // (normal server code), but a crypto id avoids cross-process collisions.
     this._epoch = options.epoch || crypto.randomBytes(8).toString('hex');
     this._seq = 0; // last assigned seq; first event is seq 1
-    this._ring = []; // [{ seq, sessionId, kind, at, detail? }], ascending seq
+    this._buckets = new Map(); // sessionKey -> [{ seq, sessionId, kind, at, detail? }] ascending; Map order = LRU
+    this._maxEvictedSeq = 0; // highest seq dropped from ANY ring (GLOBAL overflow floor, for unfiltered watchers)
+    this._evictedBySession = new Map(); // sessionKey -> highest seq evicted from THAT bucket (filter-aware overflow)
   }
 
   get epoch() {
     return this._epoch;
+  }
+
+  /** Per-session ring depth (the retention contract surfaced via /capabilities). */
+  get maxEventsPerSession() {
+    return this._maxPerSession;
   }
 
   /** Append an event, assign it the next seq, and notify long-poll waiters. */
@@ -57,12 +90,45 @@ class ControlEventBus extends EventEmitter {
     }
     const event = { seq: ++this._seq, sessionId: sessionId || null, kind, at: Date.now() };
     if (detail !== undefined) event.detail = detail;
-    this._ring.push(event);
-    if (this._ring.length > this._maxEvents) {
-      this._ring.splice(0, this._ring.length - this._maxEvents);
+
+    const key = event.sessionId || GLOBAL_KEY;
+    let bucket = this._buckets.get(key);
+    if (bucket) {
+      this._buckets.delete(key); // re-insert to mark this session most-recently-active (LRU order)
+    } else {
+      bucket = [];
     }
+    bucket.push(event);
+    if (bucket.length > this._maxPerSession) {
+      // Evict THIS session's oldest events only - never another session's.
+      const dropped = bucket.splice(0, bucket.length - this._maxPerSession);
+      this._bumpEvictedFor(key, dropped[dropped.length - 1].seq);
+    }
+    this._buckets.set(key, bucket);
+
+    // Whole-session eviction: past the session cap, drop the least-recently-active
+    // session's ring entirely (its events are stale). Bump the floor so a watcher
+    // holding a cursor into that range gets an overflow gap, not a silent loss.
+    while (this._buckets.size > this._maxSessions) {
+      const oldestKey = this._buckets.keys().next().value;
+      const oldest = this._buckets.get(oldestKey);
+      this._buckets.delete(oldestKey);
+      if (oldest && oldest.length) this._bumpEvictedFor(oldestKey, oldest[oldest.length - 1].seq);
+    }
+
     this.emit('event', event);
     return event;
+  }
+
+  _bumpEvicted(seq) {
+    if (seq > this._maxEvictedSeq) this._maxEvictedSeq = seq;
+  }
+
+  /** Bump BOTH the global overflow floor and the per-bucket evicted watermark. */
+  _bumpEvictedFor(key, seq) {
+    this._bumpEvicted(seq);
+    const cur = this._evictedBySession.get(key) || 0;
+    if (seq > cur) this._evictedBySession.set(key, seq);
   }
 
   /** The cursor a fresh consumer should start from (i.e. "only new events"). */
@@ -71,8 +137,32 @@ class ControlEventBus extends EventEmitter {
   }
 
   /**
-   * Events strictly after `cursor`, plus any gap markers. Pure read.
-   * @param {?{epoch:string, seq:number}} cursor  omitted/null → start at head (no replay)
+   * Retained events with seq strictly greater than `minSeq`, merged across all
+   * session rings and returned ascending by seq. Each ring is already ascending,
+   * so we walk it from the tail and stop once we pass `minSeq` - only the new tail
+   * of each session is collected, not the whole fleet history.
+   */
+  _collectAfter(minSeq) {
+    const out = [];
+    for (const bucket of this._buckets.values()) {
+      for (let i = bucket.length - 1; i >= 0; i--) {
+        if (bucket[i].seq <= minSeq) break;
+        out.push(bucket[i]);
+      }
+    }
+    out.sort((a, b) => a.seq - b.seq);
+    return out;
+  }
+
+  /** All retained events, ascending by seq (diagnostics / restart resync). */
+  listEvents() {
+    return this._collectAfter(0);
+  }
+
+  /**
+   * Events strictly after `cursor`, plus any gap markers. Pure read - no shared
+   * cursor state, so concurrent watchers are independent (F22).
+   * @param {?{epoch:string, seq:number}} cursor  omitted/null -> start at head (no replay)
    * @param {?{sessionIds?:string[], kinds?:string[]}} [filter]
    */
   since(cursor, filter) {
@@ -86,18 +176,34 @@ class ControlEventBus extends EventEmitter {
       // The instance restarted under this consumer. Surface a gap and hand back
       // everything we currently retain so the consumer can resync.
       gaps.push({ reason: 'restart' });
-      events = this._ring.slice();
+      events = this._collectAfter(0);
     } else {
-      const oldestSeq = this._ring.length ? this._ring[0].seq : this._seq + 1;
-      if (cursor.seq < oldestSeq - 1) {
-        // The ring rolled past the cursor: events were dropped.
-        gaps.push({ reason: 'overflow', fromSeq: cursor.seq, toSeq: oldestSeq - 1 });
+      // Overflow is FILTER-AWARE: a session-filtered watcher must only see overflow
+      // caused by eviction in a session IT watches, not by another chatty session's
+      // eviction. Unfiltered watchers use the global floor.
+      const overflowFloor = (filter && Array.isArray(filter.sessionIds) && filter.sessionIds.length)
+        ? Math.max(0, ...filter.sessionIds.map((id) => this._evictedBySession.get(id || GLOBAL_KEY) || 0))
+        : this._maxEvictedSeq;
+      if (cursor.seq < overflowFloor) {
+        // At least one event the watcher cares about was evicted: it must resync
+        // via the snapshot endpoint.
+        gaps.push({ reason: 'overflow', fromSeq: cursor.seq, toSeq: overflowFloor });
       }
-      events = this._ring.filter((e) => e.seq > cursor.seq);
+      // Collect AFTER the gap boundary so returned events never contradict the gap
+      // (an event with seq inside [cursor.seq, overflowFloor] would overlap the
+      // claimed-lost range). With no overflow this is just cursor.seq - unchanged.
+      events = this._collectAfter(Math.max(cursor.seq, overflowFloor));
     }
 
     const filtered = applyFilter(events, filter);
-    const maxSeq = events.length ? events[events.length - 1].seq : this._seq;
+    // Advance the cursor to the global head (`_seq`) past EVERY event seen, so a
+    // filtered watcher never re-scans and a stale cursor can't re-trigger overflow.
+    // The newest event is always retained (a ring evicts only its own oldest, and
+    // the just-active bucket is never the LRU whole-session victim), so in every
+    // reachable state `events[last].seq === _seq` whenever anything is newer than
+    // the cursor; setting it unconditionally removes that fragile invariant-reasoning
+    // with zero behaviour change.
+    const maxSeq = this._seq;
     return { events: filtered, gaps, cursor: { epoch: this._epoch, seq: maxSeq }, more: false };
   }
 
@@ -108,8 +214,17 @@ class ControlEventBus extends EventEmitter {
    * @returns {Promise<{events:Array, gaps:Array, cursor:object, more:boolean}>}
    */
   waitFor(cursor, timeoutMs, filter) {
-    const immediate = this.since(cursor, filter);
-    if (immediate.events.length || immediate.gaps.length) return Promise.resolve(immediate);
+    // A fresh watcher (no cursor) must still RECEIVE the event that wakes the
+    // long-poll. since(undefined) returns []; without anchoring to the current
+    // head, the woken poll would resolve since(undefined) again and drop the very
+    // event it woke for. Anchor to head: only events AFTER wait-start are returned
+    // (no history replay), and the waking event is delivered.
+    const baseCursor = cursor || this.headCursor();
+    const immediate = this.since(baseCursor, filter);
+    // Return immediately when there's already something to deliver, OR when this is
+    // a non-blocking poll (timeoutMs <= 0): a 0-timeout caller wants "what's there
+    // now", and entering the wait with no armed timer (FIX D) would otherwise hang.
+    if (immediate.events.length || immediate.gaps.length || timeoutMs <= 0) return Promise.resolve(immediate);
 
     return new Promise((resolve) => {
       let done = false;
@@ -117,14 +232,16 @@ class ControlEventBus extends EventEmitter {
         if (done) return;
         done = true;
         this.removeListener('event', onEvent);
-        clearTimeout(timer);
-        resolve(this.since(cursor, filter));
+        if (timer) clearTimeout(timer);
+        resolve(this.since(baseCursor, filter));
       };
       const onEvent = (event) => {
         if (matches(event, filter)) finish();
       };
-      const timer = setTimeout(finish, Math.max(0, timeoutMs || 0));
-      if (timer.unref) timer.unref();
+      // FIX D: only arm the timer when a positive timeout is given; setTimeout(0)
+      // would resolve on the next macrotask and turn the long-poll into a hot loop.
+      const timer = timeoutMs > 0 ? setTimeout(finish, timeoutMs) : null;
+      if (timer && timer.unref) timer.unref();
       this.on('event', onEvent);
     });
   }
@@ -146,4 +263,4 @@ function applyFilter(events, filter) {
   return events.filter((e) => matches(e, filter));
 }
 
-module.exports = { ControlEventBus, EVENT_KINDS, DEFAULT_MAX_EVENTS };
+module.exports = { ControlEventBus, EVENT_KINDS, DEFAULT_MAX_EVENTS_PER_SESSION, DEFAULT_MAX_SESSIONS };

--- a/src/control/routes.js
+++ b/src/control/routes.js
@@ -67,16 +67,18 @@ function summaryFromStatus(id, session, status) {
 
 function parseCursor(raw) {
   if (!raw) return undefined;
-  // Accept either "epoch:seq" or a base64url JSON blob.
+  // Accept either "epoch:seq" or a base64url JSON blob. A valid seq is a
+  // non-negative safe integer (FIX C: reject -5, 1.5, NaN so a present-but-invalid
+  // cursor is a client bug surfaced as 400, not a silent fresh tail-follow).
   if (typeof raw === 'string' && raw.includes(':')) {
     const idx = raw.lastIndexOf(':');
     const epoch = raw.slice(0, idx);
     const seq = Number(raw.slice(idx + 1));
-    if (epoch && Number.isFinite(seq)) return { epoch, seq };
+    if (epoch && Number.isSafeInteger(seq) && seq >= 0) return { epoch, seq };
   }
   try {
     const obj = JSON.parse(Buffer.from(String(raw), 'base64').toString('utf8'));
-    if (obj && typeof obj.epoch === 'string' && Number.isFinite(obj.seq)) return obj;
+    if (obj && typeof obj.epoch === 'string' && Number.isSafeInteger(obj.seq) && obj.seq >= 0) return obj;
   } catch {
     /* fall through */
   }
@@ -157,15 +159,50 @@ function createControlRouter(deps) {
     if (isRateLimitExempt(req) || !rateLimit.max || !rateLimit.windowMs) return next();
     const limited = checkRateLimit(rateLimitBuckets, rateLimit, rateLimitIdentity(req));
     if (limited) {
+      // F21: a CLASSIFIABLE 429 so the fleet client can back off precisely rather
+      // than hammer. Stable error.code='RATE_LIMITED' + retryAfterMs in the body,
+      // and the standard Retry-After header (whole seconds, min 1).
+      const retryAfterSec = Math.max(1, Math.ceil(limited.retryAfterMs / 1000));
+      res.set('Retry-After', String(retryAfterSec));
       return res.status(429).json({
         error: {
           code: 'RATE_LIMITED',
           message: 'Too many control requests; retry after the current rate-limit window',
           retryAfterMs: limited.retryAfterMs,
+          retryAfterSec,
         },
       });
     }
     next();
+  });
+
+  // GET /capabilities — F19 cross-repo capability negotiation. The fleet client
+  // reads this ONCE per instance and fails closed on a missing capability, so a
+  // newer client never silently assumes an older instance supports a field/event.
+  router.get('/capabilities', (req, res, next) => {
+    try {
+      res.json(deps.capabilities ? deps.capabilities() : { capabilities: [], controlVersion: '0' });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // GET /snapshot — F15 atomic batch resync. Returns every session's derived
+  // status PLUS the event cursor, captured atomically (cursor first, then
+  // statuses), so after a gap/overflow the controller resyncs in ONE call and
+  // resumes the long-poll from `cursor` with zero lost events (a boundary event
+  // may be redelivered — safe/idempotent — but never dropped).
+  router.get('/snapshot', async (req, res, next) => {
+    try {
+      const snap = deps.snapshot ? await deps.snapshot() : { sessions: [], cursor: null, capturedAt: Date.now() };
+      res.json({
+        sessions: snap.sessions || [],
+        cursor: snap.cursor ? encodeCursor(snap.cursor) : null,
+        capturedAt: snap.capturedAt,
+      });
+    } catch (err) {
+      next(err);
+    }
   });
 
   // GET /sessions — list with derived status (light).
@@ -214,6 +251,11 @@ function createControlRouter(deps) {
     } catch (err) {
       if (err && err.code === 'INVALID_WORKDIR') {
         return res.status(403).json({ error: { code: 'CAPABILITY_DENIED', message: err.message } });
+      }
+      if (err && err.code) {
+        return res.status(err.statusCode || statusForErrorCode(err.code)).json({
+          error: { code: err.code, message: err.message },
+        });
       }
       next(err);
     }
@@ -305,6 +347,10 @@ function createControlRouter(deps) {
   router.get('/events', async (req, res, next) => {
     try {
       const cursor = parseCursor(req.query.cursor);
+      // FIX C: ABSENT cursor → fresh watcher (ok); PRESENT-but-INVALID → client bug.
+      if (req.query.cursor && cursor === undefined) {
+        return res.status(400).json({ error: { code: 'INVALID_ARGUMENT', message: 'invalid cursor' } });
+      }
       const timeoutMs = clampInt(req.query.timeoutMs, DEFAULT_EVENTS_TIMEOUT_MS, 0, MAX_EVENTS_TIMEOUT_MS);
       const filter = {};
       if (req.query.sessionIds) filter.sessionIds = String(req.query.sessionIds).split(',').filter(Boolean);

--- a/src/control/session-status.js
+++ b/src/control/session-status.js
@@ -28,6 +28,12 @@
 // ellipsis. Override with AIORDIE_BUSY_REGEX.
 const DEFAULT_BUSY_REGEX = /esc (to )?interrupt|Working|Thinking|Compacting|Generating|\b\w*ing\s*(…|\.\.\.)/i;
 
+// F12: coarse busy/idle for UNBOUND active sessions is derived from PTY-output
+// recency. This is a LOW-confidence courtesy, not a turn oracle, so we require a
+// LARGE quiet window before declaring idle (accept the responsiveness hit) — a
+// brief inter-token gap must not flap a streaming turn to idle (review caveat).
+const DEFAULT_UNBOUND_QUIET_MS = 4000;
+
 function resolveBusyRegex(envValue) {
   if (!envValue || !String(envValue).trim()) return DEFAULT_BUSY_REGEX;
   try {
@@ -62,6 +68,8 @@ function awaitingKindForPendingTool(toolName) {
  * @param {string} [input.renderedTail]   last few rendered terminal lines (plain text)
  * @param {?{code:?number, signal:?string}} [input.exit]  present once the PTY has exited
  * @param {number} [input.now]
+ * @param {number} [input.lastOutputAt]  ms epoch of the last PTY output chunk (F12, unbound recency)
+ * @param {number} [input.quietWindowMs] busy↔idle recency window for unbound sessions (F12)
  * @param {RegExp} [input.busyRegex]
  * @returns {object} status
  */
@@ -71,6 +79,9 @@ function deriveStatus(input) {
   const renderedTail = (input && input.renderedTail) || '';
   const exit = (input && input.exit) || null;
   const busyRegex = (input && input.busyRegex) || resolveBusyRegex(process.env.AIORDIE_BUSY_REGEX);
+  const now = (input && typeof input.now === 'number') ? input.now : Date.now();
+  const lastOutputAt = (input && typeof input.lastOutputAt === 'number') ? input.lastOutputAt : undefined;
+  const quietWindowMs = (input && typeof input.quietWindowMs === 'number') ? input.quietWindowMs : DEFAULT_UNBOUND_QUIET_MS;
 
   const lastActivity = toMs(session.lastActivity);
   const lastTurnEndedAt = jsonl && typeof jsonl.lastTurnEndedAt === 'number' ? jsonl.lastTurnEndedAt : undefined;
@@ -136,28 +147,64 @@ function deriveStatus(input) {
     };
   }
 
-  // 2) JSONL-bound (claude): the transcript is the source of truth.
+  // 2) JSONL-bound (claude): the transcript is the source of truth for BUSY, but
+  //    the polled transcript LAGS the rendered screen. Between a just-submitted
+  //    message and the poller detecting the new user turn, the last transcript
+  //    line is still the prior settled assistant turn (endsOnAssistant:true,
+  //    growing:false) → a spurious idle/high while claude is already mid-turn.
   if (jsonl && jsonl.bound) {
     if (jsonl.growing) {
-      return base('busy', false);
+      return base('busy', false); // authoritative busy from JSONL turn state (high)
     }
-    if (jsonl.endsOnAssistant) {
-      return withAwaiting(base('idle', true), 'next_message');
+    // F8: the rendered footer LEADS the polled transcript, so cross-check it
+    // BEFORE returning idle. If it shows a running turn ("esc to interrupt" /
+    // spinner gerund) while the JSONL looks settled, the screen wins and we
+    // report busy — but at MEDIUM confidence, because the footer is a
+    // low-confidence annotation (wording drifts across claude versions; a small
+    // or alternate-screen PTY can hide it; a stale footer can linger). It may
+    // only RAISE busy; it is NEVER an authoritative idle gate and must never be
+    // the sole signal that blocks a send (deadlock risk). The
+    // authoritative busy signal remains the JSONL turn state.
+    if (footerBusy(renderedTail, busyRegex)) {
+      return { lifecycle, interactionState: 'busy', canAcceptInput: false, confidence: 'medium', lastTurnEndedAt };
     }
-    // Bound but the last turn isn't a settled assistant reply and nothing is
-    // growing: most likely awaiting the user's first/next message.
+    // JSONL settled AND the screen agrees (or no footer) → high-confidence idle.
+    // (endsOnAssistant, or bound-but-unsettled awaiting the first/next message.)
     return withAwaiting(base('idle', true), 'next_message');
   }
 
-  // 3) Fallback: busy-footer regex over the rendered terminal tail. The footer
-  //    (spinner / "esc to interrupt") is always at the very bottom, so match
-  //    only the last few rows — renderedTail may be a wide window (so the
-  //    screen-await check above can see a tall modal header), and matching the
-  //    busy regex across all of it risks a false-busy from stale scrollback.
+  // 3) Unbound fallback (no JSONL binding). Combine two coarse signals:
+  //    - the busy FOOTER over the rendered tail ("esc to interrupt" / spinner) is a
+  //      specific busy annotation (MEDIUM confidence when a renderedTail exists);
+  //    - PTY OUTPUT RECENCY (F12) is a LOW-confidence freshness signal.
+  //    Freshness ARBITRATES staleness: if output has been QUIET beyond the window a
+  //    lingering footer is treated as STALE and we report idle, so the coarse
+  //    became_idle edge still fires for await_turn (without this, a stale footer
+  //    could pin the state busy forever and also swallow the next became_busy).
+  //    A footer only RAISES busy while output is not stale-quiet. Neither is a turn
+  //    oracle (review caveat): the supported real-turn path is
+  //    agent:"claude" (bound), surfaced otherwise as NO_TURN_BINDING. None of these
+  //    gate sending — _controlInputBridge only checks session.active — so a stale
+  //    footer can never deadlock a send.
+  const recent = typeof lastOutputAt === 'number' ? (now - lastOutputAt) < quietWindowMs : null;
+  const footer = footerBusy(renderedTail, busyRegex);
+  if (footer && recent !== false) {
+    // Footer says busy and output is not stale-quiet (fresh, or recency unknown).
+    return base('busy', false); // renderedTail present → confidence var = medium
+  }
+  if (recent === true) {
+    // No (or stale) footer but output is genuinely recent → coarse busy (low).
+    return { lifecycle, interactionState: 'busy', canAcceptInput: false, confidence: 'low', lastTurnEndedAt };
+  }
+  if (recent === false) {
+    // Quiet beyond the window → coarse idle (low); any footer is treated as stale.
+    const status = { lifecycle, interactionState: 'idle', canAcceptInput: true, confidence: 'low', lastTurnEndedAt };
+    status.awaiting = { kind: 'next_message' };
+    return status;
+  }
+  // No recency signal at all (recent === null) and the footer didn't match.
   if (renderedTail) {
-    const footer = renderedTail.split('\n').slice(-6).join('\n');
-    if (busyRegex.test(footer)) return base('busy', false);
-    return withAwaiting(base('idle', true), 'next_message');
+    return withAwaiting(base('idle', true), 'next_message'); // medium idle
   }
 
   // 4) No usable signal yet.
@@ -176,6 +223,18 @@ function isCrashExit(exit) {
   if (!exit) return false;
   if (exit.signal) return exit.signal !== 'SIGTERM' && exit.signal !== 'SIGINT';
   return typeof exit.code === 'number' && exit.code !== 0;
+}
+
+// The busy footer (spinner / "esc to interrupt") is always at the very bottom of
+// the screen, so match only the last few rows — renderedTail may be a wide window
+// (so the screen-await check can see a tall modal header), and matching the busy
+// regex across all of it risks a false-busy from stale scrollback.
+function footerTail(renderedTail) {
+  return String(renderedTail || '').split('\n').slice(-6).join('\n');
+}
+function footerBusy(renderedTail, busyRegex) {
+  if (!renderedTail) return false;
+  return busyRegex.test(footerTail(renderedTail));
 }
 
 function trimAwaiting(awaiting) {
@@ -210,6 +269,18 @@ function toMs(v) {
 //     numbered options), not independent global matches;
 //   - tolerate intra-phrase line wrapping (\s+) so a wrapped header still matches.
 const SCREEN_AWAIT_ROWS = 12;
+
+// Single source of truth for the folder-trust modal wording (F7). Claude's exact
+// wording is undocumented and shifts between versions, so we match the observed
+// variants empirically. Used by awaitingFromScreen (gated on a numbered list) AND
+// by the ANSI-buffer auto-accept paths in claude-bridge.js / server.js — exporting
+// one constant keeps those sites from drifting apart (they were duplicated and
+// out of sync, missing the "Is this a project you trust?" variant).
+//   - "Do you trust the files in this folder?"  → `do you trust the files`
+//   - "Is this a project you trust?"            → `is this a project you trust`
+//   - "1. Yes, I trust this folder"             → `trust this folder`
+const TRUST_PROMPT_REGEX = /do you trust the files|trust this folder|is this a project you trust/i;
+
 function awaitingFromScreen(renderedTail) {
   const full = String(renderedTail || '');
   if (!full) return null;
@@ -226,11 +297,18 @@ function awaitingFromScreen(renderedTail) {
   if (richPlan || exitPlan) {
     return { kind: 'plan_approval', prompt: 'Claude is ready to leave plan mode and execute.' };
   }
+  // Folder-trust modal (F7). High precision: the numbered-list guard above already
+  // ensures a real "1. Yes / 2. No" choice list, so stray prose mentioning "trust"
+  // can't trip it. accept = the EXPLICIT "1" choice (see _controlMapResponseKeys),
+  // never a bare Enter that could land on a wrong default.
+  if (TRUST_PROMPT_REGEX.test(t)) {
+    return { kind: 'trust_prompt', prompt: 'Claude is asking whether to trust this folder before starting.' };
+  }
   if (/do\s+you\s+want\s+to\s+(proceed|allow|run|make|create|edit|continue)/i.test(t)) {
     return { kind: 'tool_approval' };
   }
   return null;
 }
 
-module.exports = { deriveStatus, awaitingKindForPendingTool, awaitingFromScreen, resolveBusyRegex, DEFAULT_BUSY_REGEX };
+module.exports = { deriveStatus, awaitingKindForPendingTool, awaitingFromScreen, resolveBusyRegex, DEFAULT_BUSY_REGEX, DEFAULT_UNBOUND_QUIET_MS, TRUST_PROMPT_REGEX };
 

--- a/src/server.js
+++ b/src/server.js
@@ -4974,9 +4974,11 @@ class ClaudeCodeWebServer {
       left: '\x1b[D',
       space: ' ',
       backspace: '\x7f',
-      // Shift+Tab (CSI Z, back-tab) — claude's permission-mode cycle.
+      // Shift+Tab (CSI Z, back-tab) — claude's permission-mode cycle. A driver
+      // reads the current mode from claude's status-line and cycles to plan mode.
       'shift-tab': '\x1b[Z',
       's-tab': '\x1b[Z',
+      backtab: '\x1b[Z',
       home: '\x1b[H',
       end: '\x1b[F',
       pageup: '\x1b[5~',
@@ -5418,20 +5420,26 @@ class ClaudeCodeWebServer {
   _maybeStartStickyNotes(sessionId, toolName, cols, rows) {
     const session = this.claudeSessions.get(sessionId);
     if (!session) return;
-    if (!this.stickyNoteEngine._enabled) return;
-    if (session.stickyNotesEnabled === false) return;
     if (!this._isStickyEligible(toolName)) return;
-    // Start buffering output now — this is cheap (a pure-JS headless terminal),
-    // never inference. The engine model is already being pulled at startup; this
-    // ensures it (idempotent) in case startup init failed transiently. The
-    // summariser buffers in the meantime and produces its first note once ready.
-    this.stickyNoteSummarizer.enable(sessionId, {
-      cols: cols || 80,
-      rows: rows || 24,
-      note: session.stickyNote || null,
-      rev: (session.stickyNote && session.stickyNote.rev) || 0,
-    });
-    this._ensureStickyNoteEngine();
+    // A control/fleet claude session with a bind sidecar ALWAYS needs the model-free
+    // JSONL turn-binding pump (fleet await_turn / readiness depend on it) — even if
+    // this tab opted out of sticky-note summarisation or the engine is unavailable.
+    const bindingNeeded = toolName === 'claude' && !!session.claudeBindSidecar;
+    if (session.stickyNotesEnabled === false && !bindingNeeded) return;
+    // The model-free binding/turn pump is a CONTROL-PLANE invariant and runs
+    // independently of the OPTIONAL summariser. Enable the LLM summariser only when
+    // it is wanted (not opted out) AND its engine is available; always start the poll.
+    if (session.stickyNotesEnabled !== false && this.stickyNoteEngine._enabled) {
+      // Start buffering output now — cheap (a pure-JS headless terminal), never
+      // inference. The summariser buffers and produces its first note once ready.
+      this.stickyNoteSummarizer.enable(sessionId, {
+        cols: cols || 80,
+        rows: rows || 24,
+        note: session.stickyNote || null,
+        rev: (session.stickyNote && session.stickyNote.rev) || 0,
+      });
+      this._ensureStickyNoteEngine();
+    }
     this._startStickyJsonlPoll();
   }
 
@@ -5449,16 +5457,26 @@ class ClaudeCodeWebServer {
   }
 
   async _pollStickyJsonl() {
-    if (!this._stickyNotesEnabledGlobally || !this.stickyNoteEngine._enabled) return;
+    // NOT gated on the sticky-note engine: the model-free binding + turn detection
+    // below must run for control/fleet claude sessions even when the summariser is
+    // disabled (--no-sticky-notes) or its model is unavailable. The LLM note
+    // inference inside _pumpStickyJsonl stays independently gated.
     // Lock so a slow sweep (many old session files) can't overlap the next tick
     // and double-feed the same turns into pendingText.
     if (this._pollingStickyJsonl) return;
     this._pollingStickyJsonl = true;
     try {
       for (const [sessionId, session] of this.claudeSessions) {
-        if (!session.active || session.stickyNotesEnabled === false) continue;
+        if (!session.active) continue;
         if (!this._isStickyEligible(session.agent)) continue;
-        if (!this.stickyNoteSummarizer.isEnabled(sessionId)) continue;
+        // Pump when summarising (UI note cards) OR when this is a claude session
+        // with a bind sidecar (control/fleet turn-binding) — the latter needs
+        // binding + turn events regardless of the summariser, and a per-tab
+        // summarisation opt-out must NOT defeat control-plane turn-binding.
+        const bindingNeeded = session.agent === 'claude' && !!session.claudeBindSidecar;
+        if (session.stickyNotesEnabled === false && !bindingNeeded) continue;
+        const summarising = this.stickyNoteSummarizer.isEnabled(sessionId);
+        if (!summarising && !bindingNeeded) continue;
         const cwd = session.liveCwd || session.workingDir;
         if (!cwd) continue;
         try {
@@ -5503,21 +5521,31 @@ class ClaudeCodeWebServer {
         sidecar.event !== 'end' &&
         sidecar.claudeSessionId &&
         sidecar.transcriptPath &&
-        (!binding || binding.claudeSessionId !== sidecar.claudeSessionId)
+        (!binding ||
+          binding.claudeSessionId !== sidecar.claudeSessionId ||
+          // While still pending, follow a transcriptPath that drifts under the same
+          // session id (e.g. a corrected path) so a wrong initial path can't strand
+          // the binding forever. A promoted binding's path is stable, so this never
+          // churns it.
+          (binding.transcriptPending && binding.pendingTranscriptPath !== sidecar.transcriptPath))
       ) {
         const stp = await this._statQuiet(sidecar.transcriptPath);
-        if (stp) {
-          this._bindStickyJsonl(sessionId, {
-            file: sidecar.transcriptPath,
-            sessionId: sidecar.claudeSessionId,
-            mtimeMs: stp.mtimeMs,
-            size: stp.size,
-          });
-          binding = this._stickyJsonl.get(sessionId);
-          session.claudePinnedSessionId = sidecar.claudeSessionId;
-          this.sessionStore.markDirty();
-        }
-        // transcript not created yet → wait for a later tick (never inference).
+        // Bind on the sidecar's IDENTITY immediately — even before the transcript
+        // file exists. Claude Code does not create the .jsonl until the session's
+        // FIRST turn, so a fresh idle fleet session has a sidecar (claudeSessionId
+        // known) but no transcript yet. Binding now makes the session report
+        // bound:true (the F17 readiness barrier and session_status key off presence
+        // in _stickyJsonl); the tail below promotes to the real file once it lands.
+        this._bindStickyJsonl(sessionId, {
+          file: stp ? sidecar.transcriptPath : null,
+          pendingTranscriptPath: sidecar.transcriptPath,
+          sessionId: sidecar.claudeSessionId,
+          mtimeMs: stp ? stp.mtimeMs : 0,
+          size: stp ? stp.size : 0,
+        });
+        binding = this._stickyJsonl.get(sessionId);
+        session.claudePinnedSessionId = sidecar.claudeSessionId;
+        this.sessionStore.markDirty();
       }
       // Pinned tabs never run the mtime inference / resume-follow below.
     } else if (session && session._sidecarSeen) {
@@ -5577,6 +5605,25 @@ class ClaudeCodeWebServer {
       }
     }
     if (!binding) return;
+
+    // Promote a pending (identity-only) sidecar binding to a full tail once the
+    // transcript file appears (claude writes the .jsonl on its first turn). Until
+    // then the session stays bound (bound:true for readiness/status) but has nothing
+    // to tail — do NOT unbind for the missing file.
+    if (binding.transcriptPending || !binding.file) {
+      const ptp = binding.pendingTranscriptPath;
+      const pst = ptp ? await this._statQuiet(ptp) : null;
+      if (!pst) { await emitTransition(); return; } // transcript still absent → stay identity-bound
+      // The transcript is brand-new (claude created it AFTER we bound), so ALL of it
+      // is post-bind content. Tail AND turn-detect from byte 0 so the very first turn
+      // is never skipped — there is no pre-bind history to skip here (unlike a normal
+      // bind to a pre-existing transcript, which deliberately starts "from now").
+      binding.file = ptp;
+      binding.transcriptPending = false;
+      binding.boundMtimeMs = pst.mtimeMs || 0;
+      binding.offset = 0;
+      binding.turnOffset = 0;
+    }
 
     const st = await this._statQuiet(binding.file);
     if (!st) { this._stickyJsonl.delete(sessionId); return; } // file gone → unbind (note kept)
@@ -5646,6 +5693,10 @@ class ClaudeCodeWebServer {
     // next poll resumes from there in a single bounded catch-up read. Turn
     // detection above already ran unconditionally, so collapsing a tab no longer
     // blinds the control plane to turn boundaries. ---
+    // NOTE INFERENCE — ONLY while a viewer has the card EXPANDED. A control/fleet
+    // session pumped purely for binding + turn detection has no expanded viewer and
+    // stops here; even if it didn't, feedTurns() no-ops for a session the summariser
+    // never enabled, so the model is never fed for a non-summarised session.
     if (!this._isStickyExpandedActive(sessionId)) {
       await emitTransition();
       return;
@@ -5796,15 +5847,22 @@ class ClaudeCodeWebServer {
   _bindStickyJsonl(sessionId, chosen) {
     const claudeSessionId = chosen.sessionId;
     const INITIAL_WINDOW = 24 * 1024;
+    // A pending (identity-only) bind has no transcript file yet — claude creates
+    // the .jsonl on its first turn. Stay bound; the pump promotes it (computing the
+    // real offset) once the file appears.
+    const transcriptPending = !chosen.file;
     // Resume from the last consumed offset if we've seen this session before
     // (avoids re-summarising the recent window); else start near the end.
     const cached = this._claudeOffsets.get(claudeSessionId);
-    const offset =
-      typeof cached === 'number' && cached <= (chosen.size || 0)
+    const offset = transcriptPending
+      ? 0
+      : (typeof cached === 'number' && cached <= (chosen.size || 0)
         ? cached
-        : Math.max(0, (chosen.size || 0) - INITIAL_WINDOW);
+        : Math.max(0, (chosen.size || 0) - INITIAL_WINDOW));
     this._stickyJsonl.set(sessionId, {
-      file: chosen.file,
+      file: chosen.file || null,
+      pendingTranscriptPath: chosen.pendingTranscriptPath || chosen.file || null,
+      transcriptPending,
       offset,
       titleOffset: 0, // ai-title tail walks the whole file from the start
       lastTitle: null,

--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,7 @@ const WebSocket = require('ws');
 const cors = require('cors');
 const { v4: uuidv4 } = require('uuid');
 const ClaudeBridge = require('./claude-bridge');
+const { VALID_PERMISSION_MODES } = require('./claude-bridge');
 const CodexBridge = require('./codex-bridge');
 const CopilotBridge = require('./copilot-bridge');
 const GeminiBridge = require('./gemini-bridge');
@@ -33,11 +34,11 @@ const CircularBuffer = require('./utils/circular-buffer');
 const MinHeap = require('./utils/eviction-heap');
 const RestartManager = require('./restart-manager');
 const KeepaliveManager = require('./keepalive-manager');
-const { ControlEventBus } = require('./control/event-bus');
+const { ControlEventBus, EVENT_KINDS: CONTROL_EVENT_KINDS } = require('./control/event-bus');
 const TranscriptBuffer = require('./sticky-note-transcript');
 const { createControlRouter } = require('./control/routes');
 const { ArtifactReviewStore, createArtifactReviewRouter, createAssetTokenSigner } = require('./artifact-review');
-const { deriveStatus, awaitingKindForPendingTool, awaitingFromScreen } = require('./control/session-status');
+const { deriveStatus, awaitingKindForPendingTool, awaitingFromScreen, TRUST_PROMPT_REGEX, DEFAULT_UNBOUND_QUIET_MS } = require('./control/session-status');
 const { detectAwaiting } = require('./control/jsonl-awaiting');
 
 // HOT-08: per-WebSocket-message size cap. Gates JSON.parse so a single
@@ -53,6 +54,13 @@ const { detectAwaiting } = require('./control/jsonl-awaiting');
 //
 // See docs/audits/hot-03-ws-frame-size.md.
 const MAX_WS_MESSAGE_BYTES = 1 * 1024 * 1024;
+
+// Fleet control-plane contract version (F19). Bumped when the cross-repo wire
+// shape (status fields, event kinds, snapshot/capabilities/permission-mode
+// contract) changes in a way the github-router client must negotiate. The client
+// reads GET /api/control/capabilities once per instance and fails closed when a
+// required capability is absent.
+const CONTROL_CONTRACT_VERSION = 1;
 
 // Inbound binary voice frames (client mic -> server STT) bypass the JSON guard
 // above. Framing + validation (incl. the Buffer[] fragmented-frame normalize)
@@ -4023,8 +4031,106 @@ class ClaudeCodeWebServer {
       sendMessage: async (opts) => this._controlSendMessage(opts),
       sendKeys: async (opts) => this._controlSendKeys(opts),
       respond: async (opts) => this._controlRespond(opts),
+      snapshot: async () => this._controlSnapshot(),
+      capabilities: () => this._controlCapabilities(),
     };
   }
+
+  /**
+   * F15: an ATOMIC batch snapshot for O(1) reconnect after a cursor gap. Returns
+   * every session's full derived status PLUS the event cursor, such that the
+   * controller can resume the long-poll from exactly that cursor with zero LOST
+   * events. Atomicity rule: capture the cursor FIRST, then build the statuses. Any
+   * event that fires while the statuses are being read has seq > cursor and is
+   * therefore redelivered on resume — so the worst case is a harmless duplicate
+   * (an edge already reflected in the snapshot AND replayed), never a loss.
+   *
+   * Reconnect protocol (documented in ADR-0032): on a `gap`/`overflow`/`restart`
+   * marker from /events, call GET /snapshot, reconcile each session from the
+   * returned statuses, then resume the long-poll from `snapshot.cursor`.
+   */
+  async _controlSnapshot() {
+    const cursor = this.controlEventBus ? this.controlEventBus.headCursor() : { epoch: null, seq: 0 };
+    const ids = Array.from(this.claudeSessions.keys());
+    const sessions = await Promise.all(ids.map(async (id) => {
+      const session = this.claudeSessions.get(id);
+      if (!session) return null;
+      const status = await this._controlDerivedStatus(id);
+      return {
+        sessionId: id,
+        name: session.name,
+        agent: session.agent || null,
+        workingDir: session.workingDir,
+        lifecycle: status ? status.lifecycle : 'unknown',
+        interactionState: status ? status.interactionState : 'unknown',
+        canAcceptInput: status ? !!status.canAcceptInput : false,
+        confidence: status ? status.confidence : 'low',
+        lastTurnEndedAt: status && typeof status.lastTurnEndedAt === 'number' ? status.lastTurnEndedAt : null,
+        awaiting: (status && status.awaiting) || null,
+        sessionStateSeq: this._controlSessionSeqFor(id),
+        bound: !!(this._stickyJsonl && this._stickyJsonl.has(id)),
+        lastActivity: session.lastActivity || null,
+      };
+    }));
+    return { sessions: sessions.filter(Boolean), cursor, capturedAt: Date.now() };
+  }
+
+  /**
+   * F19: the cross-repo capability contract. The github-router fleet client reads
+   * this ONCE per instance and fails closed (or degrades explicitly) when a needed
+   * capability is absent — so a newer client talking to an older ai-or-die never
+   * silently believes a permission mode was set or a confirmation is available.
+   */
+  _controlCapabilities() {
+    return {
+      capabilities: [
+        'permission_mode',     // F10 create_session(permissionMode), validated + conflict-rejecting
+        'agent_args',          // F10 create_session(agentArgs[])
+        'turn_binding',        // ADR-0026 JSONL turn detection (bound claude)
+        'events_cursor',       // F22 cursor-based /events long-poll (epoch:seq, strictly-after)
+        'events_retention',    // F15 per-session event ring + overflow gap
+        'session_state_seq',   // monotonic per-session state seq surfaced in status/message responses
+      ],
+      controlVersion: String(CONTROL_CONTRACT_VERSION),
+      // Additive extras (the fleet client ignores unknown keys; kept for human/debug + future clients):
+      permissionModes: VALID_PERMISSION_MODES,
+      events: CONTROL_EVENT_KINDS,
+      limits: {
+        eventsPerSession: this.controlEventBus ? this.controlEventBus.maxEventsPerSession : null,
+        maxReadLines: 2000,
+        eventsLongPollMaxMs: 60000,
+      },
+    };
+  }
+
+  /**
+   * F16: a per-session STEERING MUTEX — a logical-command queue distinct from the
+   * byte-level writeQueue. Two DISTINCT concurrent steering ops (e.g. two
+   * send_message, or a send_message + a respond) to the SAME session would each
+   * enqueue their bytes separately on the writeQueue and could interleave at the
+   * message boundary (text1, text2, \r, \r). This queue serialises the whole op so
+   * one completes before the next begins. (The retry-double-submit case is already
+   * covered by idempotency + writeQueue; this closes the concurrent-distinct-ops
+   * interleave.) Idempotency stays OUTSIDE this lock, so a same-key retry
+   * short-circuits to the cached result without ever entering the critical section.
+   */
+  // NON-REENTRANT: fn() must not call _controlSteeringLock for the same session (would deadlock). All current callers (sendMessage/sendKeys/respond) do a single bridge op - verified no nested acquire.
+  _controlSteeringLock(sessionId, fn) {
+    if (!this._steeringQueues) this._steeringQueues = new Map();
+    const prev = this._steeringQueues.get(sessionId) || Promise.resolve();
+    // Run after the previous op settles (success OR failure — a failed op must not
+    // wedge the queue). The returned promise carries the real result/rejection.
+    const run = prev.then(() => fn(), () => fn());
+    // The stored tail is failure-guarded so the chain never rejection-propagates.
+    const tail = run.then(() => {}, () => {});
+    this._steeringQueues.set(sessionId, tail);
+    // Drop the queue entry once drained, so it doesn't leak per dead session.
+    tail.then(() => {
+      if (this._steeringQueues.get(sessionId) === tail) this._steeringQueues.delete(sessionId);
+    });
+    return run;
+  }
+
 
   async _controlStatusSignal(id) {
     const session = this.claudeSessions.get(id);
@@ -4074,6 +4180,11 @@ class ClaudeCodeWebServer {
       jsonl: signal.jsonl,
       renderedTail: signal.renderedTail,
       exit: signal.exit,
+      // F12: coarse PTY-output recency feeds the UNBOUND busy/idle fallback. Only
+      // consulted when there is no JSONL binding; bound claude returns earlier on
+      // the authoritative transcript turn state.
+      lastOutputAt: typeof session._ctlLastOutputAt === 'number' ? session._ctlLastOutputAt : undefined,
+      now: Date.now(),
     });
   }
 
@@ -4101,12 +4212,19 @@ class ClaudeCodeWebServer {
     const status = await this._controlDerivedStatus(sessionId);
     if (!status || !status.interactionState) return status;
     const binding = this._stickyJsonl && this._stickyJsonl.get(sessionId);
-    const previous = binding ? binding._lastInteractionState : undefined;
+    // F12: bound sessions debounce the edge on their JSONL binding (authoritative
+    // turn state); UNBOUND sessions have no binding, so they debounce on the
+    // session object instead — otherwise every poll would re-emit the same coarse
+    // PTY-recency edge. We only ever emit became_busy / became_idle here; a real
+    // turn_ended is emitted exclusively by the JSONL turn detector (bound only),
+    // never faked from the coarse unbound signal (review caveat).
+    const stateHolder = binding || this.claudeSessions.get(sessionId);
+    const previous = stateHolder ? stateHolder._lastInteractionState : undefined;
     if (previous === status.interactionState) return status;
-    if (binding) binding._lastInteractionState = status.interactionState;
+    if (stateHolder) stateHolder._lastInteractionState = status.interactionState;
 
     const kind = this._controlEventKindForInteractionState(status.interactionState);
-    if (kind) this._controlAppendStateEvent(sessionId, kind, { interactionState: status.interactionState });
+    if (kind) this._controlAppendStateEvent(sessionId, kind, { interactionState: status.interactionState, confidence: status.confidence });
     return status;
   }
 
@@ -4115,6 +4233,78 @@ class ClaudeCodeWebServer {
     if (interactionState === 'idle') return 'became_idle';
     if (interactionState === 'waiting_input') return 'waiting_input';
     return null;
+  }
+
+  // F12: record PTY-output recency and drive the COARSE busy/idle edges for
+  // UNBOUND active sessions (claude launched inside a `terminal` PTY, or a
+  // bound claude whose JSONL sidecar hasn't attached yet). Bound claude returns
+  // early — its authoritative turn_ended/became_busy come from the JSONL turn
+  // detector, so this coarse path is a no-op there and never competes.
+  //
+  // Two edges:
+  //   - rising  → emit became_busy promptly on the first chunk after quiet
+  //               (debounced inside _controlEmitInteractionTransition);
+  //   - falling → a LARGE quiet debounce timer; when no further output arrives
+  //               within the window, re-derive (now quiet → idle) and emit
+  //               became_idle. Reset on every chunk so a streaming turn never
+  //               flaps to idle (review caveat).
+  // We NEVER emit turn_ended from here — callers key on became_idle for coarse
+  // completion; the honest fix for unbound is NO_TURN_BINDING, not a fake turn.
+  _controlRecordPtyOutput(sessionId) {
+    const session = this.claudeSessions.get(sessionId);
+    if (!session) return;
+    session._ctlLastOutputAt = Date.now();
+    // Bound sessions get authoritative turn detection — skip the coarse path.
+    // (Presence in _stickyJsonl == bound: _controlStatusSignal hardcodes bound:true
+    // for any entry, and _controlIsTurnAgent keys 'bound' on the same has() check.)
+    if (this._stickyJsonl && this._stickyJsonl.has(sessionId)) return;
+    // Rising edge: emit became_busy only when NOT already busy. On a fast-streaming
+    // PTY (thousands of chunks/sec) this avoids flooding the microtask queue with a
+    // _controlDerivedStatus (snapshot + regex) per chunk — event-loop starvation.
+    // While already busy, a chunk just refreshes recency above and re-arms the idle
+    // timer below; that timer drives the eventual flip back to idle.
+    if (session._lastInteractionState !== 'busy' && typeof this._controlEmitInteractionTransition === 'function') {
+      Promise.resolve(this._controlEmitInteractionTransition(sessionId)).catch(() => {});
+    }
+    // Falling edge: re-arm the quiet-debounce timer.
+    if (session._ctlIdleTimer) clearTimeout(session._ctlIdleTimer);
+    const debounceMs = DEFAULT_UNBOUND_QUIET_MS + 500; // > the recency window so the re-derive reads quiet
+    session._ctlIdleTimer = setTimeout(() => {
+      session._ctlIdleTimer = null;
+      if (typeof this._controlEmitInteractionTransition === 'function') {
+        Promise.resolve(this._controlEmitInteractionTransition(sessionId)).catch(() => {});
+      }
+    }, debounceMs);
+    if (session._ctlIdleTimer && session._ctlIdleTimer.unref) session._ctlIdleTimer.unref();
+  }
+
+  /**
+   * F13: did a NEW activity edge (became_busy / waiting_input) appear AFTER the
+   * pre-send cursor? Positive evidence that THIS send started something, as
+   * opposed to a lingering prior-turn busy whose edge predates the cursor. Used to
+   * gate the unbound dropped-Enter reaper so a retry is only sent when no new edge
+   * is observed. Falls back to a status-poll heuristic when no event bus / cursor
+   * is available (keeps the legacy behaviour for callers without a bus).
+   */
+  async _controlAwaitActivityEdge(sessionId, preCursor, timeoutMs) {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    if (this.controlEventBus && preCursor) {
+      const filter = { sessionIds: [sessionId], kinds: ['became_busy', 'waiting_input'] };
+      for (;;) {
+        const remaining = Math.max(0, deadline - Date.now());
+        const out = await this.controlEventBus.waitFor(preCursor, Math.min(remaining, 600), filter);
+        if (out && out.events && out.events.length) return true;
+        if (Date.now() >= deadline) return false;
+      }
+    }
+    // No bus / cursor: poll derived status for a visible busy/waiting edge. Clamp
+    // each sleep to the remaining budget so a short deadline isn't overshot.
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, Math.min(600, Math.max(0, deadline - Date.now()))));
+      const s = await this._controlDerivedStatus(sessionId);
+      if (s && (s.interactionState === 'busy' || s.interactionState === 'waiting_input')) return true;
+    }
+    return false;
   }
 
   async _controlReadTail(id, lines) {
@@ -4154,6 +4344,27 @@ class ClaudeCodeWebServer {
         validWorkingDir = validation.path;
       } else if (this.selectedWorkingDir) {
         validWorkingDir = this.selectedWorkingDir;
+      }
+
+      // F10: validate permissionMode/agentArgs UP FRONT (before allocating the
+      // session) through the bridge's canonical translation layer, so a bad mode
+      // or a conflicting agentArgs flag fails the create with INVALID_ARGUMENT
+      // rather than spawning an ambiguous agent. claude's ClaudeBridge.buildArgs
+      // validates + rejects; terminal/codex BaseBridge.buildArgs ignores both.
+      if (opts.start) {
+        const agentForValidation = opts.agent || 'claude';
+        const vbridge = this.getBridgeForAgent(agentForValidation);
+        if (vbridge && typeof vbridge.buildArgs === 'function') {
+          try {
+            vbridge.buildArgs({
+              dangerouslySkipPermissions: !!opts.dangerouslySkipPermissions,
+              permissionMode: opts.permissionMode,
+              agentArgs: opts.agentArgs,
+            });
+          } catch (e) {
+            throw this._controlError('INVALID_ARGUMENT', (e && e.message) || 'invalid launch arguments', 400);
+          }
+        }
       }
 
       // opts.start spawns the agent headlessly via _controlStartAgent (below).
@@ -4196,14 +4407,30 @@ class ClaudeCodeWebServer {
           await this._controlStartAgent(sessionId, agent, {
             cols: opts.cols, rows: opts.rows,
             dangerouslySkipPermissions: !!opts.dangerouslySkipPermissions,
+            permissionMode: opts.permissionMode,
+            agentArgs: opts.agentArgs,
           });
         } catch (e) {
           lifecycle = 'exited';
-          return { sessionId, lifecycle, name: session.name, agent: null, startError: e && e.message };
+          return { sessionId, lifecycle, name: session.name, agent: null, ready: false, bound: false, blocker: { kind: 'start_error', message: (e && e.message) || 'start failed' }, startError: e && e.message };
         }
-        lifecycle = session.active ? 'running' : 'starting';
+        // F17: readiness barrier — don't report success the moment the PTY spawns.
+        // Wait (bounded) until the agent is actually driveable (claude: JSONL-bound +
+        // prompt-ready), or surface a concrete blocker (trust modal / binding pending).
+        const readyTimeoutMs = this._controlClampInt(opts.readyTimeoutMs, 12000, 0, 30000);
+        const state = await this._controlAwaitReady(sessionId, readyTimeoutMs);
+        lifecycle = session.active ? (state.ready ? 'running' : 'starting') : 'exited';
+        return {
+          sessionId,
+          lifecycle,
+          name: session.name,
+          agent: session.agent || null,
+          ready: state.ready,
+          bound: state.bound,
+          ...(state.blocker ? { blocker: state.blocker } : {}),
+        };
       }
-      return { sessionId, lifecycle, name: session.name, agent: session.agent || null };
+      return { sessionId, lifecycle, name: session.name, agent: session.agent || null, ready: false, bound: false };
     });
   }
 
@@ -4222,7 +4449,7 @@ class ClaudeCodeWebServer {
       tries++;
       let screen = '';
       try { screen = await s._ctlTranscript.snapshot(40); } catch (_) { /* ignore */ }
-      const onModal = /trust this folder|Do you trust the files/i.test(screen);
+      const onModal = TRUST_PROMPT_REGEX.test(screen);
       if (onModal) {
         sawModal = true;
         try { await bridge0.sendInput(sessionId, '\r'); } catch (_) { /* pty may be gone */ }
@@ -4250,6 +4477,25 @@ class ClaudeCodeWebServer {
     const rows = opts.rows || 30;
 
     const extraEnv = {};
+    // F6: non-interactive env hardening for CONTROL-spawned PTYs only (interactive
+    // WebSocket terminals keep their pager UX). A headless fleet shell has no human
+    // to press 'q', so a paging git command (log/diff/branch → less) would hang the
+    // PTY until someone sends 'q'. Disable every common pager + interactive prompt:
+    //   - GIT_PAGER / PAGER / GH_PAGER / DELTA_PAGER / MANPAGER / AWS_PAGER / SYSTEMD_PAGER
+    //     route paged output straight to stdout (cat / empty = no pager).
+    //   - LESS=FRX makes any residual `less` exit immediately on a short page.
+    //   - GIT_TERMINAL_PROMPT=0 turns a credential prompt into an immediate git
+    //     FAILURE (fail-fast) instead of a silent hang — intended; the driver sees a
+    //     structural error rather than a stuck session.
+    extraEnv.GIT_PAGER = 'cat';
+    extraEnv.PAGER = 'cat';
+    extraEnv.GH_PAGER = 'cat';
+    extraEnv.DELTA_PAGER = 'cat';
+    extraEnv.MANPAGER = 'cat';
+    extraEnv.AWS_PAGER = '';
+    extraEnv.SYSTEMD_PAGER = '';
+    extraEnv.LESS = 'FRX';
+    extraEnv.GIT_TERMINAL_PROMPT = '0';
     try {
       const sidecar = this._prepareClaudeBindSidecar(sessionId, session);
       if (sidecar) extraEnv.AIORDIE_CLAUDE_BIND = sidecar; // deterministic JSONL turn detection (ADR-0026)
@@ -4270,11 +4516,19 @@ class ClaudeCodeWebServer {
         workingDir: session.workingDir,
         cols, rows,
         dangerouslySkipPermissions: !!opts.dangerouslySkipPermissions,
+        // F10: claude permission mode + caller passthrough flags (claude only;
+        // terminal/codex bridges ignore these in BaseBridge.buildArgs).
+        permissionMode: opts.permissionMode,
+        agentArgs: opts.agentArgs,
         onOutput: (data) => {
           const s = this.claudeSessions.get(sessionId);
           if (!s) return;
           s.outputBuffer.push(data);
           try { if (s._ctlTranscript) s._ctlTranscript.write(data); } catch (_) { /* isolate */ }
+          // F12: record PTY-output recency + drive coarse busy/idle edges for
+          // UNBOUND sessions (no-op for bound claude — the JSONL turn detector is
+          // authoritative there).
+          try { this._controlRecordPtyOutput(sessionId); } catch (_) { /* isolate */ }
           this.sessionStore.markDirty();
           try { if (this.stickyNoteSummarizer && this.stickyNoteSummarizer.isEnabled(sessionId)) this.stickyNoteSummarizer.feed(sessionId, data); } catch (_) { /* isolate */ }
         },
@@ -4287,6 +4541,8 @@ class ClaudeCodeWebServer {
             s._lastExit = { code, signal };
             this.sessionStore.markDirty();
             try { if (s._ctlTranscript) { s._ctlTranscript.dispose(); s._ctlTranscript = null; } } catch (_) { /* isolate */ }
+            // F12: stop the coarse idle-debounce timer for unbound sessions.
+            try { if (s._ctlIdleTimer) { clearTimeout(s._ctlIdleTimer); s._ctlIdleTimer = null; } } catch (_) { /* isolate */ }
           }
           try { this.stickyNoteSummarizer && this.stickyNoteSummarizer.flushExit(sessionId); } catch (_) { /* isolate */ }
           if (this.controlEventBus) this.controlEventBus.append(sessionId, 'exited', { code, signal });
@@ -4338,57 +4594,255 @@ class ClaudeCodeWebServer {
     return this._controlWithIdempotency(sessionId, idempotencyKey, async () => {
       const bridge = this._controlInputBridge(sessionId, session);
       const timeoutMs = this._controlClampInt(awaitMs, 120000, 0, 180000);
-      const cursor = this.controlEventBus && typeof this.controlEventBus.headCursor === 'function'
-        ? this.controlEventBus.headCursor()
-        : null;
       const text = message == null ? '' : String(message);
-      if (text.includes('\n')) {
-        await bridge.sendInput(sessionId, `\x1b[200~${text}\x1b[201~`);
-      } else {
-        await bridge.sendInput(sessionId, text);
-      }
-      await bridge.sendInput(sessionId, '\r');
+      // F1/F18: classify the agent's turn capability up front.
+      //   'terminal' — a shell / non-claude agent: NO turn model, so confirmation is
+      //                N/A (return honest delivery, never a false negative).
+      //   'unbound'  — claude expected but its JSONL turn-binding hasn't attached yet
+      //                (cold-boot race): we cannot prove submission/turn, so we run the
+      //                legacy dropped-Enter reaper but never claim a confirmed turn.
+      //   'bound'    — claude with a live JSONL binding: confirm the SPECIFIC message
+      //                submitted (a new matching user transcript entry) + its turn end.
+      const turnClass = this._controlIsTurnAgent(sessionId, session);
+      const binding = this._stickyJsonl && this._stickyJsonl.get(sessionId);
+      // One shared deadline so submission + turn detection together honour awaitMs.
+      const deadline = Date.now() + timeoutMs;
+      const remaining = () => Math.max(0, deadline - Date.now());
 
-      // Cold-boot submit reaper: a slow claude.exe Ink composer can drop the
-      // submit Enter, leaving the message sitting unsent (no turn starts, so the
-      // honest result is confirmed:false). If claude hasn't visibly started a turn
-      // shortly after, re-send Enter ONCE. Safe: an extra Enter on an already-empty
-      // composer (message already submitted) is a no-op in claude. Skipped for
-      // awaitMs=0 (fire-and-forget dispatch must not block). The waitFor below uses
-      // the pre-send cursor, so any turn that starts during this poll is not missed.
-      if (timeoutMs > 0) {
-        let started = false;
-        for (let i = 0; i < 4; i++) {
-          await new Promise((r) => setTimeout(r, 600));
-          const s = await this._controlDerivedStatus(sessionId);
-          if (s && (s.interactionState === 'busy' || s.interactionState === 'waiting_input')) { started = true; break; }
+      // F16: DELIVERY + SUBMISSION run under the per-session steering mutex so two
+      // concurrent DISTINCT steering ops on this session cannot interleave bytes
+      // (text1, text2, \r, \r). preSize/preCursor are captured INSIDE the lock,
+      // immediately before the bytes, so they bracket exactly THIS op's send. The
+      // possibly-long turn-completion await runs AFTER the lock releases, so it
+      // never blocks another command (e.g. a `respond`) on this session.
+      const phase = await this._controlSteeringLock(sessionId, async () => {
+        // Capture the transcript size BEFORE sending so F18 only matches a user
+        // entry produced by THIS message, not a pre-existing one.
+        let preSize = null;
+        if (turnClass === 'bound' && binding && binding.file) {
+          try { const stp = await this._statQuiet(binding.file); preSize = stp ? stp.size : null; } catch (_) { preSize = null; }
         }
-        if (!started) { try { await bridge.sendInput(sessionId, '\r'); } catch (_) { /* pty may have exited */ } }
+        // F13: capture the event-bus cursor BEFORE sending so the unbound reaper
+        // can distinguish a NEW activity edge (caused by THIS send) from a
+        // lingering prior-turn busy.
+        const preCursor = this.controlEventBus ? this.controlEventBus.headCursor() : null;
+
+        if (text.includes('\n')) {
+          await bridge.sendInput(sessionId, `\x1b[200~${text}\x1b[201~`);
+        } else {
+          await bridge.sendInput(sessionId, text);
+        }
+        await bridge.sendInput(sessionId, '\r');
+
+        if (turnClass === 'terminal') return { terminal: true };
+
+        let submission = 'unconfirmed';
+        if (turnClass === 'bound' && timeoutMs > 0) {
+          // F18: prove THIS message reached the composer by matching a new user
+          // entry in the transcript. Supersedes the busy-edge guesswork.
+          let submitted = await this._controlAwaitSubmission(binding, preSize, text, Math.min(remaining(), 4000));
+          if (!submitted && remaining() > 0) {
+            // Cold-boot Ink composer can drop the submit Enter; re-send ONCE (a stray
+            // Enter on an already-submitted composer is a no-op in claude), then re-check.
+            try { await bridge.sendInput(sessionId, '\r'); } catch (_) { /* pty may have exited */ }
+            submitted = await this._controlAwaitSubmission(binding, preSize, text, Math.min(remaining(), 4000));
+          }
+          submission = submitted ? 'submitted' : 'unconfirmed';
+        } else if (timeoutMs > 0) {
+          // Unbound cold-boot reaper (F13). No transcript to match against, so gate
+          // the dropped-Enter re-send on a NEW activity edge AFTER the pre-send
+          // cursor (became_busy / waiting_input — F12 emits became_busy from PTY
+          // recency even for unbound sessions), not on a lingering prior busy. The
+          // writeQueue + _controlWithIdempotency keep the retry duplicate-safe.
+          const started = await this._controlAwaitActivityEdge(sessionId, preCursor, Math.min(remaining(), 2400));
+          if (!started) { try { await bridge.sendInput(sessionId, '\r'); } catch (_) { /* pty may have exited */ } }
+          submission = 'no_turn_binding';
+        }
+        return { terminal: false, submission, preSize };
+      });
+
+      // ---- terminal / non-turn agent: honest delivery, no turn semantics (F1) ----
+      if (phase.terminal) {
+        const status = await this._controlDerivedStatus(sessionId);
+        return {
+          messageId: uuidv4(),
+          delivered: true,
+          confirmed: true,            // delivery-confirmed; a shell has no turn to await
+          confirmation: 'delivered',
+          delivery: { status: 'delivered' },
+          submission: { status: 'not_applicable' },
+          turn: { status: 'not_applicable' },
+          confidence: 'low',
+          interactionState: status ? status.interactionState : 'unknown',
+          sessionStateSeq: this._controlSessionSeqFor(sessionId),
+          duplicated: false,
+        };
       }
 
-      let confirmed = false;
-      if (this.controlEventBus && cursor && timeoutMs > 0 && typeof this.controlEventBus.waitFor === 'function') {
-        const out = await this.controlEventBus.waitFor(cursor, timeoutMs, {
-          sessionIds: [sessionId],
-          kinds: ['turn_ended'],
-        });
-        confirmed = !!(out.events || []).some((e) => e.sessionId === sessionId && e.kind === 'turn_ended');
+      const submission = phase.submission;
+      const preSize = phase.preSize;
+
+      // Turn completion (bound only) — CONTENT-BASED and tied to THIS message, run
+      // OUTSIDE the steering lock so a long turn doesn't block other commands. Watch
+      // the transcript from preSize for an assistant reply that settles AFTER our
+      // user entry (endsOnAssistant). Race-free vs a pre-send event cursor, which
+      // could miscount a lingering PRIOR turn's turn_ended (a prior turn's
+      // settle). A pending tool/permission prompt yields a tool-only assistant
+      // block (no settled text) → turnCompleted stays false → reported as
+      // submitted-but-awaiting, not a false confirmation.
+      let turnCompleted = false;
+      if (turnClass === 'bound' && submission === 'submitted' && timeoutMs > 0) {
+        turnCompleted = await this._controlAwaitTurnComplete(binding, preSize, remaining());
       }
 
       const status = await this._controlDerivedStatus(sessionId);
-      // The github-router fleet MCP tool intentionally maps confirmed=false to
-      // an MCP isError (LOUD failure). ai-or-die itself returns honest delivery
-      // data here and relies on idempotency to ensure retries never re-type.
+      const awaiting = (!turnCompleted && status && status.awaiting) ? status.awaiting : null;
+      const confirmed = turnClass === 'bound' && submission === 'submitted' && turnCompleted;
+      const confirmationTimedOut = turnClass === 'bound' && submission === 'submitted' && !turnCompleted && timeoutMs > 0;
+      // The github-router fleet MCP tool maps confirmed=false to an MCP isError today;
+      // F9 will switch it to delivery-only. ai-or-die returns honest, structured
+      // delivery/submission/turn statuses + idempotency so retries never re-type.
       return {
         messageId: uuidv4(),
         delivered: true,
         confirmed,
-        confidence: this._stickyJsonl && this._stickyJsonl.has(sessionId) ? 'high' : 'medium',
+        confirmation: confirmed ? 'turn_completed' : (submission === 'submitted' ? 'submitted' : (turnClass === 'bound' ? 'unconfirmed' : 'no_turn_binding')),
+        confirmationTimedOut,
+        delivery: { status: 'delivered' },
+        submission: { status: submission },
+        turn: { status: turnCompleted ? 'completed' : (submission === 'submitted' ? 'pending' : 'not_applicable'), ...(awaiting ? { awaiting } : {}) },
+        confidence: turnClass === 'bound' ? 'high' : 'medium',
         interactionState: status ? status.interactionState : 'unknown',
         sessionStateSeq: this._controlSessionSeqFor(sessionId),
         duplicated: false,
       };
     });
+  }
+
+  /**
+   * Classify a session's turn-detection capability (F1/F18):
+   *   'terminal' — non-claude agent (a shell has no turn model).
+   *   'unbound'  — claude whose JSONL turn-binding hasn't attached yet (cold-boot).
+   *   'bound'    — claude with a live JSONL binding (deterministic turn detection).
+   */
+  _controlIsTurnAgent(sessionId, session) {
+    if (!session || session.agent !== 'claude') return 'terminal';
+    return (this._stickyJsonl && this._stickyJsonl.has(sessionId)) ? 'bound' : 'unbound';
+  }
+
+  /** Normalise text for tolerant message↔transcript matching (F18). */
+  _controlNormalizeForMatch(s) {
+    return String(s == null ? '' : s).replace(/\s+/g, ' ').trim().toLowerCase().slice(0, 64);
+  }
+
+  /**
+   * Whether a transcript user-entry text corresponds to the sent message (F18).
+   * The transcript text may be clipped/prose-cleaned, so match by prefix
+   * containment in either direction rather than strict equality.
+   */
+  _controlUserEntryMatches(wantNorm, userText) {
+    const got = this._controlNormalizeForMatch(userText);
+    if (!got || !wantNorm) return false;
+    return got.startsWith(wantNorm) || wantNorm.startsWith(got) || got.includes(wantNorm);
+  }
+
+  /**
+   * Poll the transcript for a NEW user entry (after preSize) matching the sent
+   * message — positive proof that the message reached claude's composer (F18).
+   * Returns true on match, false on timeout. An empty message is treated as
+   * submitted (nothing to match).
+   */
+  async _controlAwaitSubmission(binding, preSize, sentText, timeoutMs) {
+    if (!binding || !binding.file || typeof preSize !== 'number') return false;
+    const want = this._controlNormalizeForMatch(sentText);
+    if (!want) return true;
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    for (;;) {
+      try {
+        const { turns } = await StickyNoteJsonl.readNewTurns(binding.file, preSize);
+        for (const t of turns) {
+          if (t && t.role === 'user' && this._controlUserEntryMatches(want, t.text)) return true;
+        }
+      } catch (_) { /* transient read error — retry */ }
+      if (Date.now() >= deadline) return false;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  }
+
+  /**
+   * Poll the transcript (from preSize) for the assistant reply that settles AFTER
+   * the message's user entry — content-based turn completion tied to THIS message
+   * (F18). Race-free vs an event cursor: a lingering prior turn cannot satisfy it
+   * because endsOnAssistant() only returns true once an assistant turn follows the
+   * last user turn (our message). A tool-only assistant block (pending permission)
+   * has no settled text, so it does NOT count as completed. Returns false on timeout.
+   */
+  async _controlAwaitTurnComplete(binding, preSize, timeoutMs) {
+    if (!binding || !binding.file || typeof preSize !== 'number') return false;
+    const endsOnAssistant = require('./sticky-note-jsonl').endsOnAssistant;
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    for (;;) {
+      try {
+        const { turns } = await StickyNoteJsonl.readNewTurns(binding.file, preSize);
+        if (endsOnAssistant(turns)) return true;
+      } catch (_) { /* transient read error — retry */ }
+      if (Date.now() >= deadline) return false;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  }
+
+  /**
+   * F17: compute a control session's readiness for driving. Returns
+   * { ready, bound, blocker? }. `bound` means a claude JSONL turn-binding is live
+   * (deterministic turn detection available). `blocker` names a concrete reason a
+   * session isn't ready yet (a startup modal, a pending binding, still starting).
+   */
+  async _controlReadinessState(sessionId) {
+    const session = this.claudeSessions.get(sessionId);
+    if (!session) return { ready: false, bound: false, blocker: { kind: 'gone', message: 'session not found' } };
+    if (!session.active) return { ready: false, bound: false, blocker: { kind: 'inactive', message: 'session is not active' } };
+    const isClaude = session.agent === 'claude';
+    const bound = isClaude && !!(this._stickyJsonl && this._stickyJsonl.has(sessionId));
+    // A folder-trust / onboarding modal on the rendered screen is a hard blocker —
+    // the agent is not driveable until it clears.
+    let blocker = null;
+    if (session._ctlTranscript) {
+      let screen = '';
+      try { screen = await session._ctlTranscript.snapshot(40); } catch (_) { screen = ''; }
+      if (TRUST_PROMPT_REGEX.test(screen)) {
+        blocker = { kind: 'trust', message: 'folder-trust prompt is awaiting acceptance' };
+      }
+    }
+    const hadOutput = !!(session.outputBuffer && session.outputBuffer.size && session.outputBuffer.size > 0);
+    if (isClaude) {
+      if (blocker) return { ready: false, bound, blocker };
+      if (!bound) return { ready: false, bound: false, blocker: { kind: 'binding_pending', message: 'claude turn-binding not attached yet' } };
+      if (!hadOutput) return { ready: false, bound: true, blocker: { kind: 'starting', message: 'no output yet' } };
+      return { ready: true, bound: true };
+    }
+    // Non-turn agent (terminal / other): ready once active with output; no binding.
+    if (blocker) return { ready: false, bound: false, blocker };
+    if (!hadOutput) return { ready: false, bound: false, blocker: { kind: 'starting', message: 'no output yet' } };
+    return { ready: true, bound: false };
+  }
+
+  /**
+   * F17: bounded wait until a freshly-started control session is ready (or a hard
+   * blocker like a trust modal appears, or the deadline passes). Lets the one-shot
+   * create_session(start:true) return a truthful ready/bound/blocker instead of
+   * succeeding the moment the PTY spawns.
+   */
+  async _controlAwaitReady(sessionId, timeoutMs) {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    let state = await this._controlReadinessState(sessionId);
+    while (!state.ready && Date.now() < deadline) {
+      // A trust/onboarding modal is terminal for this wait — surface it immediately
+      // so the driver can respond() rather than block the whole readiness window.
+      if (state.blocker && (state.blocker.kind === 'trust' || state.blocker.kind === 'inactive' || state.blocker.kind === 'gone')) break;
+      await new Promise((r) => setTimeout(r, 250));
+      state = await this._controlReadinessState(sessionId);
+    }
+    return state;
   }
 
   async _controlSendKeys(opts = {}) {
@@ -4397,10 +4851,12 @@ class ClaudeCodeWebServer {
     if (!session) throw this._controlError('SESSION_NOT_FOUND', 'Unknown session', 404);
 
     return this._controlWithIdempotency(sessionId, idempotencyKey, async () => {
-      const bridge = this._controlInputBridge(sessionId, session);
-      const data = this._controlKeyBytes(keys, raw === true);
-      await bridge.sendInput(sessionId, data);
-      return { keysId: uuidv4(), delivered: true, duplicated: false };
+      return this._controlSteeringLock(sessionId, async () => {
+        const bridge = this._controlInputBridge(sessionId, session);
+        const data = this._controlKeyBytes(keys, raw === true);
+        await bridge.sendInput(sessionId, data);
+        return { keysId: uuidv4(), delivered: true, duplicated: false };
+      });
     });
   }
 
@@ -4410,45 +4866,47 @@ class ClaudeCodeWebServer {
     if (!session) throw this._controlError('SESSION_NOT_FOUND', 'Unknown session', 404);
 
     return this._controlWithIdempotency(sessionId, idempotencyKey, async () => {
-      const binding = this._stickyJsonl && this._stickyJsonl.get(sessionId);
-      const awaiting = binding && binding.file ? await detectAwaiting(binding.file) : null;
-      let awaitingKind = awaiting ? awaitingKindForPendingTool(awaiting.pendingUserFacingTool) : null;
-      // Fallback: when the JSONL binding isn't available (e.g. a raw claude.exe
-      // whose Windows project-slug doesn't resolve), derive the pending
-      // interaction from the live rendered screen — the same signal status uses.
-      if (!awaitingKind && session._ctlTranscript) {
-        try {
-          const screenAwait = awaitingFromScreen(await session._ctlTranscript.snapshot(20));
-          if (screenAwait) awaitingKind = screenAwait.kind;
-        } catch (_) { /* transcript unavailable */ }
-      }
-      let mappedKeys;
-
-      if (keys !== undefined && keys !== null) {
-        mappedKeys = String(keys);
-      } else {
-        if (!awaitingKind) {
-          return { error: { code: 'PRECONDITION_FAILED', message: 'no pending interaction' } };
+      return this._controlSteeringLock(sessionId, async () => {
+        const binding = this._stickyJsonl && this._stickyJsonl.get(sessionId);
+        const awaiting = binding && binding.file ? await detectAwaiting(binding.file) : null;
+        let awaitingKind = awaiting ? awaitingKindForPendingTool(awaiting.pendingUserFacingTool) : null;
+        // Fallback: when the JSONL binding isn't available (e.g. a raw claude.exe
+        // whose Windows project-slug doesn't resolve), derive the pending
+        // interaction from the live rendered screen — the same signal status uses.
+        if (!awaitingKind && session._ctlTranscript) {
+          try {
+            const screenAwait = awaitingFromScreen(await session._ctlTranscript.snapshot(20));
+            if (screenAwait) awaitingKind = screenAwait.kind;
+          } catch (_) { /* transcript unavailable */ }
         }
-        mappedKeys = this._controlMapResponseKeys(awaitingKind, {
-          awaiting,
-          choice,
-          optionValue,
-          agent: session.agent,
-        });
-        if (!mappedKeys) {
-          return { error: { code: 'INVALID_ARGUMENT', message: 'could not map response to keystrokes' } };
-        }
-      }
+        let mappedKeys;
 
-      const bridge = this._controlInputBridge(sessionId, session);
-      await bridge.sendInput(sessionId, mappedKeys);
-      return {
-        delivered: true,
-        awaitingKind: awaitingKind || null,
-        mappedKeys,
-        duplicated: false,
-      };
+        if (keys !== undefined && keys !== null) {
+          mappedKeys = String(keys);
+        } else {
+          if (!awaitingKind) {
+            return { error: { code: 'PRECONDITION_FAILED', message: 'no pending interaction' } };
+          }
+          mappedKeys = this._controlMapResponseKeys(awaitingKind, {
+            awaiting,
+            choice,
+            optionValue,
+            agent: session.agent,
+          });
+          if (!mappedKeys) {
+            return { error: { code: 'INVALID_ARGUMENT', message: 'could not map response to keystrokes' } };
+          }
+        }
+
+        const bridge = this._controlInputBridge(sessionId, session);
+        await bridge.sendInput(sessionId, mappedKeys);
+        return {
+          delivered: true,
+          awaitingKind: awaitingKind || null,
+          mappedKeys,
+          duplicated: false,
+        };
+      });
     });
   }
 
@@ -4516,6 +4974,14 @@ class ClaudeCodeWebServer {
       left: '\x1b[D',
       space: ' ',
       backspace: '\x7f',
+      // Shift+Tab (CSI Z, back-tab) — claude's permission-mode cycle.
+      'shift-tab': '\x1b[Z',
+      's-tab': '\x1b[Z',
+      home: '\x1b[H',
+      end: '\x1b[F',
+      pageup: '\x1b[5~',
+      pagedown: '\x1b[6~',
+      delete: '\x1b[3~',
     };
     const key = value.toLowerCase();
     return Object.prototype.hasOwnProperty.call(named, key) ? named[key] : value;
@@ -4539,6 +5005,15 @@ class ClaudeCodeWebServer {
     if (awaitingKind === 'tool_approval') {
       if (choice === 'yes' || choice === 'allow' || choice === 'accept') return '\r';
       if (choice === 'no' || choice === 'deny' || choice === 'reject') return '\x1b';
+      return null;
+    }
+
+    // Folder-trust modal (F7): a numbered "1. Yes, proceed / 2. No, exit" list. Send
+    // the EXPLICIT numbered choice, never a bare Enter — Enter can no-op mid-render or
+    // land on a non-default option, whereas "1"/"2" deterministically pick yes/no.
+    if (awaitingKind === 'trust_prompt') {
+      if (choice === 'accept' || choice === 'yes' || choice === 'trust' || choice === 'allow') return '1\r';
+      if (choice === 'reject' || choice === 'no' || choice === 'deny') return '2\r';
       return null;
     }
 
@@ -5138,9 +5613,39 @@ class ClaudeCodeWebServer {
       binding.idleTicks = (binding.idleTicks || 0) + 1; // quiet → eligible to follow /resume
     }
 
+    // --- TURN-BOUNDARY DETECTION — ALWAYS (cheap; no model). Decoupled from the
+    // UI expand-gate so headless / fleet-spawned claude sessions (no WebSocket
+    // viewer ever expands their card) still emit turn_ended / became_busy /
+    // became_idle and keep lastGrowing/lastEndsOnAssistant fresh — the signals the
+    // control plane's await_turn + send_message confirmation depend on (F14). Uses
+    // its OWN turnOffset so it never advances the note summariser's horizon
+    // (binding.offset); the summariser below keeps its independent, expand-gated
+    // catch-up read. ---
+    if (typeof binding.turnOffset !== 'number') binding.turnOffset = st.size; // start "from now": no replay of pre-bind history
+    if (st.size < binding.turnOffset) binding.turnOffset = st.size; // truncated/rotated
+    if (st.size > binding.turnOffset) {
+      const td = await StickyNoteJsonl.readNewTurns(binding.file, binding.turnOffset);
+      if (td.offset > binding.turnOffset) {
+        binding.turnOffset = td.offset;
+        const ends = require('./sticky-note-jsonl').endsOnAssistant(td.turns);
+        binding.lastGrowing = (td.turns.length > 0 && !ends);
+        if (ends && !binding.lastEndsOnAssistant) {
+          if (typeof this._controlAppendStateEvent === 'function') {
+            this._controlAppendStateEvent(sessionId, 'turn_ended');
+          } else if (this.controlEventBus) {
+            this.controlEventBus.append(sessionId, 'turn_ended');
+          }
+          binding.lastTurnEndedAt = Date.now();
+        }
+        binding.lastEndsOnAssistant = ends;
+      }
+    }
+
     // --- NOTE INFERENCE — ONLY while a viewer has the card EXPANDED. Collapsed
     // tabs freeze the note at their horizon (binding.offset); on re-expand the
-    // next poll resumes from there in a single bounded catch-up read. ---
+    // next poll resumes from there in a single bounded catch-up read. Turn
+    // detection above already ran unconditionally, so collapsing a tab no longer
+    // blinds the control plane to turn boundaries. ---
     if (!this._isStickyExpandedActive(sessionId)) {
       await emitTransition();
       return;
@@ -5156,17 +5661,6 @@ class ClaudeCodeWebServer {
     }
     binding.offset = offset;
     this._claudeOffsets.set(binding.claudeSessionId, offset); // resume continues from here
-    const ends = require('./sticky-note-jsonl').endsOnAssistant(turns);
-    binding.lastGrowing = (turns.length > 0 && !ends);
-    if (ends && !binding.lastEndsOnAssistant) {
-      if (typeof this._controlAppendStateEvent === 'function') {
-        this._controlAppendStateEvent(sessionId, 'turn_ended');
-      } else if (this.controlEventBus) {
-        this.controlEventBus.append(sessionId, 'turn_ended');
-      }
-      binding.lastTurnEndedAt = Date.now();
-    }
-    binding.lastEndsOnAssistant = ends;
     await emitTransition();
     const text = StickyNoteJsonl.formatTurns(turns);
     if (!text) return;

--- a/test/claude-bridge.test.js
+++ b/test/claude-bridge.test.js
@@ -68,4 +68,58 @@ describe('ClaudeBridge', function() {
       assert.strictEqual(result.length, 0);
     });
   });
+
+  describe('processOutput trust auto-accept (F7)', function() {
+    function fakePty() {
+      const writes = [];
+      return { writes, write: (d) => writes.push(d) };
+    }
+    // Claude's Ink TUI interleaves ANSI escapes between words; the de-ANSI'd buffer
+    // is what the shared TRUST_PROMPT_REGEX matches. A real trust modal always shows
+    // a numbered "1. / 2." choice list, which the bridge now requires before acting.
+    const ansi = (s) => s.replace(/ /g, '\x1b[39m \x1b[1m');
+
+    it('auto-accepts the "Is this a project you trust?" variant (previously missed)', function(done) {
+      const pty = fakePty();
+      bridge.processOutput('s-trust-a', pty, ansi('Is this a project you trust? 1. Yes 2. No'));
+      setTimeout(() => {
+        try { assert.deepStrictEqual(pty.writes, ['1\r']); done(); } catch (e) { done(e); }
+      }, 700);
+    });
+
+    it('auto-accepts the "Do you trust the files in this folder?" variant', function(done) {
+      const pty = fakePty();
+      bridge.processOutput('s-trust-b', pty, ansi('Do you trust the files in this folder? 1. Yes, proceed 2. No, exit'));
+      setTimeout(() => {
+        try { assert.deepStrictEqual(pty.writes, ['1\r']); done(); } catch (e) { done(e); }
+      }, 700);
+    });
+
+    it('does NOT write for ordinary output (no trust modal)', function(done) {
+      const pty = fakePty();
+      bridge.processOutput('s-notrust', pty, 'Running tests... all green.');
+      setTimeout(() => {
+        try { assert.deepStrictEqual(pty.writes, []); done(); } catch (e) { done(e); }
+      }, 700);
+    });
+
+    it('does NOT inject on a trust PHRASE without a numbered choice list (false-positive guard)', function(done) {
+      const pty = fakePty();
+      // Claude printing the phrase in prose / a file / a commit message must NOT
+      // inject a keystroke — only a real "1./2." modal may.
+      bridge.processOutput('s-prose', pty, 'Make sure you trust this folder before you do you trust the files thing.');
+      setTimeout(() => {
+        try { assert.deepStrictEqual(pty.writes, []); done(); } catch (e) { done(e); }
+      }, 700);
+    });
+
+    it('is one-shot per session (guarded against repeat accepts)', function(done) {
+      const pty = fakePty();
+      bridge.processOutput('s-once', pty, 'trust this folder? 1. Yes 2. No');
+      bridge.processOutput('s-once', pty, 'trust this folder? 1. Yes 2. No');
+      setTimeout(() => {
+        try { assert.deepStrictEqual(pty.writes, ['1\r']); done(); } catch (e) { done(e); }
+      }, 700);
+    });
+  });
 });

--- a/test/claude-launcher.test.js
+++ b/test/claude-launcher.test.js
@@ -51,4 +51,81 @@ describe('claude launcher (always via github-router)', function () {
       assert.deepEqual(args, ['-y', 'github-router@latest', 'claude', '--browse', '--dangerously-skip-permissions']);
     });
   });
+
+  describe('F10 — ClaudeBridge.buildArgs permission mode', function () {
+    const PREFIX = ['-y', 'github-router@latest', 'claude', '--browse'];
+
+    it('appends --permission-mode <mode> AFTER the launcher prefix', function () {
+      const bridge = new ClaudeBridge();
+      const args = bridge.buildArgs({ permissionMode: 'plan' });
+      assert.deepEqual(args, [...PREFIX, '--permission-mode', 'plan']);
+    });
+
+    it('accepts every allowlisted mode', function () {
+      const bridge = new ClaudeBridge();
+      for (const mode of ['plan', 'acceptEdits', 'default', 'bypassPermissions']) {
+        assert.deepEqual(bridge.buildArgs({ permissionMode: mode }), [...PREFIX, '--permission-mode', mode]);
+      }
+    });
+
+    it('permissionMode supersedes the legacy dangerous flag (github-router drops it)', function () {
+      const bridge = new ClaudeBridge();
+      const args = bridge.buildArgs({ permissionMode: 'plan', dangerouslySkipPermissions: true });
+      assert.deepEqual(args, [...PREFIX, '--permission-mode', 'plan']);
+      assert.ok(!args.includes('--dangerously-skip-permissions'));
+    });
+
+    it('appends caller agentArgs after the permission flag', function () {
+      const bridge = new ClaudeBridge();
+      const args = bridge.buildArgs({ permissionMode: 'acceptEdits', agentArgs: ['--model', 'opus'] });
+      assert.deepEqual(args, [...PREFIX, '--permission-mode', 'acceptEdits', '--model', 'opus']);
+    });
+
+    it('rejects an unknown permissionMode with INVALID_ARGUMENT', function () {
+      const bridge = new ClaudeBridge();
+      assert.throws(
+        () => bridge.buildArgs({ permissionMode: 'yolo' }),
+        (e) => e.code === 'INVALID_ARGUMENT'
+      );
+    });
+
+    it('rejects agentArgs carrying --permission-mode (conflict) with INVALID_ARGUMENT', function () {
+      const bridge = new ClaudeBridge();
+      assert.throws(
+        () => bridge.buildArgs({ agentArgs: ['--permission-mode', 'plan'] }),
+        (e) => e.code === 'INVALID_ARGUMENT'
+      );
+      assert.throws(
+        () => bridge.buildArgs({ agentArgs: ['--permission-mode=plan'] }),
+        (e) => e.code === 'INVALID_ARGUMENT'
+      );
+    });
+
+    it('rejects agentArgs carrying --dangerously-skip-permissions (conflict) with INVALID_ARGUMENT', function () {
+      const bridge = new ClaudeBridge();
+      assert.throws(
+        () => bridge.buildArgs({ permissionMode: 'plan', agentArgs: ['--dangerously-skip-permissions'] }),
+        (e) => e.code === 'INVALID_ARGUMENT'
+      );
+    });
+
+    it('rejects a non-array agentArgs with INVALID_ARGUMENT', function () {
+      const bridge = new ClaudeBridge();
+      assert.throws(
+        () => bridge.buildArgs({ agentArgs: '--model opus' }),
+        (e) => e.code === 'INVALID_ARGUMENT'
+      );
+    });
+
+    it('no permissionMode + no dangerous flag → bare prefix (back-compat)', function () {
+      const bridge = new ClaudeBridge();
+      assert.deepEqual(bridge.buildArgs(), [...PREFIX]);
+    });
+
+    it('terminal agent ignores permissionMode/agentArgs (no flags, no throw)', function () {
+      const TerminalBridge = require('../src/terminal-bridge');
+      const bridge = new TerminalBridge();
+      assert.deepEqual(bridge.buildArgs({ permissionMode: 'plan', agentArgs: ['--permission-mode', 'x'] }), []);
+    });
+  });
 });

--- a/test/control/event-bus.test.js
+++ b/test/control/event-bus.test.js
@@ -81,4 +81,169 @@ describe('control/event-bus ControlEventBus', function () {
     assert.equal(out.events.length, 0);
     assert.equal(out.cursor.epoch, bus.epoch);
   });
+
+  it('FIX A: a fresh (cursor-less) watcher RECEIVES the event that wakes it (no drop, no double-deliver)', async function () {
+    const bus = new ControlEventBus();
+    const p = bus.waitFor(undefined, 1000, undefined); // fresh watcher, no cursor
+    bus.append('s1', 'turn_ended');
+    const r = await p;
+    assert.equal(r.events.length, 1, 'the waking event is delivered');
+    assert.equal(r.events[0].kind, 'turn_ended');
+    // Resuming from the returned cursor must not re-deliver it.
+    const r2 = await bus.waitFor(r.cursor, 50);
+    assert.equal(r2.events.length, 0, 'no double-delivery, no loss');
+  });
+
+  it('FIX D: a 0-timeout poll resolves immediately (no hang, no hot-loop)', async function () {
+    const bus = new ControlEventBus();
+    const out = await bus.waitFor(bus.headCursor(), 0);
+    assert.equal(out.events.length, 0);
+    assert.equal(out.cursor.epoch, bus.epoch);
+  });
+
+  it('FIX B (symmetry): a sessionIds:[null] filter sees the GLOBAL bucket overflow', function () {
+    const bus = new ControlEventBus({ maxEventsPerSession: 3 });
+    const start = bus.headCursor(); // seq 0
+    for (let i = 0; i < 10; i++) bus.append(null, 'session_created'); // null -> GLOBAL_KEY bucket; overflows + evicts
+    const out = bus.since(start, { sessionIds: [null] });
+    assert.ok(out.gaps.some((g) => g.reason === 'overflow'), 'null filter maps to the GLOBAL_KEY evicted watermark');
+  });
+
+  it('FIX B: a session-FILTERED watcher gets NO overflow from another session\'s eviction', function () {
+    const bus = new ControlEventBus({ maxEventsPerSession: 3 });
+    const start = bus.headCursor(); // seq 0
+    bus.append('q', 'turn_ended'); // seq 1, quiet session (never overflows)
+    for (let i = 0; i < 10; i++) bus.append('chatty', 'became_busy'); // floods + evicts chatty's own
+    // Watcher filtered to the QUIET session, polling from an old cursor.
+    const quiet = bus.since(start, { sessionIds: ['q'] });
+    assert.equal(quiet.gaps.length, 0, 'no overflow — the quiet session lost nothing');
+    assert.ok(quiet.events.some((e) => e.sessionId === 'q' && e.kind === 'turn_ended'));
+  });
+
+  it('FIX B: a FILTERED watcher on the evicted session sees overflow, and no returned event is inside the gap', function () {
+    const bus = new ControlEventBus({ maxEventsPerSession: 3 });
+    const start = bus.headCursor(); // seq 0
+    for (let i = 0; i < 10; i++) bus.append('chatty', 'became_busy'); // evicts chatty's own oldest
+    const out = bus.since(start, { sessionIds: ['chatty'] });
+    assert.ok(out.gaps.some((g) => g.reason === 'overflow'), 'overflow surfaced for the evicted session');
+    const gap = out.gaps.find((g) => g.reason === 'overflow');
+    for (const e of out.events) {
+      assert.ok(e.seq > gap.toSeq, `returned event seq ${e.seq} must be strictly after gap.toSeq ${gap.toSeq}`);
+    }
+  });
+
+  it('FIX B: unfiltered overflow never overlaps — every returned event.seq > gap.toSeq', function () {
+    const bus = new ControlEventBus({ maxEventsPerSession: 3 });
+    const start = bus.headCursor(); // seq 0
+    bus.append('a', 'became_busy'); // seq 1
+    for (let i = 0; i < 10; i++) bus.append('b', 'became_busy'); // evicts b's oldest → global floor bumps
+    const out = bus.since(start); // unfiltered, cursor older than the floor
+    assert.ok(out.gaps.some((g) => g.reason === 'overflow'));
+    const gap = out.gaps.find((g) => g.reason === 'overflow');
+    for (const e of out.events) {
+      assert.ok(e.seq > gap.toSeq, `event seq ${e.seq} overlaps the claimed-lost range up to ${gap.toSeq}`);
+    }
+  });
+
+  // ---- F15 per-session retention --------------------------------------------
+  it('F15: a chatty session evicts only its OWN events, never another session\'s turn_ended', function () {
+    const bus = new ControlEventBus({ maxEventsPerSession: 3 });
+    bus.append('quiet', 'turn_ended'); // the one turn boundary we must not lose
+    for (let i = 0; i < 50; i++) bus.append('chatty', 'became_busy'); // floods well past the cap
+    const quietEvents = bus.listEvents().filter((e) => e.sessionId === 'quiet');
+    assert.equal(quietEvents.length, 1, 'quiet session retained its event');
+    assert.equal(quietEvents[0].kind, 'turn_ended');
+    const chattyEvents = bus.listEvents().filter((e) => e.sessionId === 'chatty');
+    assert.equal(chattyEvents.length, 3, 'chatty session capped to its own ring depth');
+  });
+
+  it('F15: a stale unfiltered cursor → overflow gap; the quiet turn_ended is RETAINED (resynced via snapshot, not the in-gap stream)', function () {
+    const bus = new ControlEventBus({ maxEventsPerSession: 3 });
+    const start = bus.headCursor(); // seq 0
+    bus.append('quiet', 'turn_ended'); // seq 1
+    for (let i = 0; i < 50; i++) bus.append('chatty', 'became_busy'); // evicts chatty's own → bumps the global floor
+    const out = bus.since(start);
+    assert.equal(out.gaps.length, 1);
+    assert.equal(out.gaps[0].reason, 'overflow');
+    // FIX B: under overflow, in-gap events are deferred to the snapshot resync, so
+    // the incremental stream must NOT contradict the gap (nothing <= gap.toSeq).
+    for (const e of out.events) assert.ok(e.seq > out.gaps[0].toSeq);
+    // The quiet turn_ended was NEVER evicted — it is still retained (snapshot path).
+    const retained = bus.listEvents().find((e) => e.sessionId === 'quiet' && e.kind === 'turn_ended');
+    assert.ok(retained, 'the quiet session turn_ended survived the chatty flood (retained for snapshot resync)');
+    // And a watcher FILTERED to the quiet session sees it with NO overflow.
+    const quietView = bus.since(start, { sessionIds: ['quiet'] });
+    assert.equal(quietView.gaps.length, 0);
+    assert.ok(quietView.events.some((e) => e.kind === 'turn_ended'));
+  });
+
+  it('F15: whole-session bucket eviction past the session cap bumps the overflow floor', function () {
+    const bus = new ControlEventBus({ maxEventsPerSession: 4, maxSessions: 2 });
+    bus.append('a', 'turn_ended'); // seq 1, bucket a
+    const start = bus.headCursor(); // after seq 1
+    bus.append('b', 'became_busy'); // seq 2, bucket b
+    bus.append('c', 'became_busy'); // seq 3, bucket c → evicts bucket a (LRU)
+    assert.equal(bus.listEvents().some((e) => e.sessionId === 'a'), false, 'bucket a evicted wholesale');
+    const out = bus.since(start);
+    assert.equal(out.gaps.length === 0, true, 'cursor after seq1 lost nothing newer (a was seq1, evicted but pre-cursor)');
+    // A cursor BEFORE seq 1 must see the overflow (a's seq 1 was dropped).
+    const stale = bus.since({ epoch: bus.epoch, seq: 0 });
+    assert.equal(stale.gaps[0].reason, 'overflow');
+  });
+
+  it('F15: the returned cursor always reaches the global head and never re-triggers overflow', function () {
+    // Multiple session rings, one of which OVERFLOWS its per-session cap, queried
+    // from a cursor older than the eviction floor.
+    const bus = new ControlEventBus({ maxEventsPerSession: 3 });
+    const older = bus.headCursor(); // seq 0, before anything
+    bus.append('quiet', 'turn_ended'); // seq 1 (retained — quiet ring never overflows)
+    for (let i = 0; i < 10; i++) bus.append('chatty', 'became_busy'); // seqs 2..11, ring keeps 9..11, evicts up to seq 8
+    const head = bus._seq;
+    assert.ok(head > 0);
+
+    const out = bus.since(older);
+    // The returned cursor advances to the global head regardless of which events
+    // survived per-session eviction or got filtered.
+    assert.equal(out.cursor.seq, head, 'returned cursor === global head (_seq)');
+    assert.equal(out.cursor.seq, bus._seq);
+    assert.ok(out.gaps.some((g) => g.reason === 'overflow'), 'stale cursor saw the overflow once');
+
+    // Resuming from the returned cursor must be fully caught up: no events, NO
+    // spurious overflow re-trigger.
+    const next = bus.since(out.cursor);
+    assert.equal(next.events.length, 0, 'no events after catching up to head');
+    assert.equal(next.gaps.length, 0, 'no spurious overflow re-trigger from the advanced cursor');
+    assert.equal(next.cursor.seq, head, 'cursor stays at the head');
+  });
+
+  // ---- F22 per-watcher independent cursors ----------------------------------
+  it('F22: concurrent watchers resume independently from their own cursors (no shared position)', function () {
+    const bus = new ControlEventBus();
+    bus.append('s1', 'became_busy'); // seq 1
+    const watcherA = bus.since(bus.headCursor()).cursor; // A caught up at seq 1
+    bus.append('s1', 'turn_ended'); // seq 2
+    const outB = bus.since({ epoch: bus.epoch, seq: 0 }); // B started from the very beginning
+    const outA = bus.since(watcherA);                      // A resumes from seq 1
+    assert.equal(outB.events.length, 2, 'watcher B sees both events');
+    assert.equal(outA.events.length, 1, 'watcher A sees only the new event');
+    assert.equal(outA.events[0].kind, 'turn_ended');
+    // Reading either watcher did not advance the other — the bus holds no global cursor.
+    assert.equal(bus.since(watcherA).events.length, 1, 'A is still independently resumable');
+  });
+
+  it('F22: per-watcher filters are independent (each cursor + filter is a pure read)', async function () {
+    const bus = new ControlEventBus();
+    const start = bus.headCursor();
+    bus.append('s1', 'turn_ended');
+    bus.append('s2', 'became_busy');
+    const onlyS1 = bus.since(start, { sessionIds: ['s1'] });
+    const onlyBusy = bus.since(start, { kinds: ['became_busy'] });
+    assert.equal(onlyS1.events.length, 1);
+    assert.equal(onlyS1.events[0].sessionId, 's1');
+    assert.equal(onlyBusy.events.length, 1);
+    assert.equal(onlyBusy.events[0].kind, 'became_busy');
+    // Both advance their cursor past ALL events (so a filtered watcher won't re-scan).
+    assert.equal(onlyS1.cursor.seq, 2);
+    assert.equal(onlyBusy.cursor.seq, 2);
+  });
 });

--- a/test/control/headless-turn-detection.test.js
+++ b/test/control/headless-turn-detection.test.js
@@ -137,4 +137,78 @@ describe('F14 headless turn detection (un-gated from UI expand)', function () {
     await proto._controlEmitInteractionTransition.call(srv, sessionId); // idle → became_idle
     assert.deepEqual(events, ['became_busy', 'became_idle']);
   });
+
+  it('PROMOTE: emits turn_ended for the FIRST turn after a pending bind promotes (turnOffset from 0)', async function () {
+    const sessionId = 's-promote';
+    const tp = path.join(dir, 'proj', 'late.jsonl');
+    const events = [];
+    const session = { id: sessionId, active: true, agent: 'claude', _sidecarSeen: false, claudeBindSidecar: 'sc' };
+    const fake = {
+      _stickyJsonl: new Map(),
+      claudeSessions: new Map([[sessionId, session]]),
+      _claudeOffsets: new Map(),
+      _claudeNotes: new Map(),
+      controlEventBus: null,
+      sessionStore: { markDirty: () => {} },
+      stickyNoteSummarizer: { feedTurns: () => {}, onRebind: () => {} },
+      broadcastToSession: () => {},
+      _ownedClaudeSessions: proto._ownedClaudeSessions,
+      _bindStickyJsonl: proto._bindStickyJsonl,
+      _readClaudeBindSidecar: async () => ({ claudeSessionId: 'cs-1', transcriptPath: tp, event: 'start' }),
+      _statQuiet: async (f) => { try { const st = fs.statSync(f); return { size: st.size, mtimeMs: st.mtimeMs }; } catch { return null; } },
+      _isStickyExpandedActive: () => false,
+      _controlAppendStateEvent: (id, kind) => events.push({ id, kind }),
+      _controlEmitInteractionTransition: async () => {},
+      _applyAiTitle: () => {},
+    };
+    // Tick 1: transcript absent → pending identity bind; no turn events.
+    await proto._pumpStickyJsonl.call(fake, sessionId, dir);
+    const b1 = fake._stickyJsonl.get(sessionId);
+    assert.ok(b1 && b1.transcriptPending === true, 'pending after tick 1');
+    assert.equal(events.length, 0, 'no turn events while pending');
+    // The first turn completes and the transcript appears ALL AT ONCE (a fast turn
+    // landing within one poll interval). Promotion must tail from byte 0 so this
+    // already-complete first turn still emits turn_ended (not skipped "from now").
+    fs.mkdirSync(path.dirname(tp), { recursive: true });
+    fs.writeFileSync(tp, userLine('do it') + assistantLine('done'));
+    await proto._pumpStickyJsonl.call(fake, sessionId, dir);
+    const b2 = fake._stickyJsonl.get(sessionId);
+    assert.equal(b2.transcriptPending, false, 'promoted to a full tail');
+    assert.equal(b2.file, tp);
+    assert.equal(events.filter((e) => e.kind === 'turn_ended').length, 1, 'first turn emits turn_ended (turnOffset started at 0)');
+  });
+
+  it('PROMOTE: a >24KB first turn promotes with offset 0 (tails the whole new file, not a 24KB window)', async function () {
+    const sessionId = 's-bigturn';
+    const tp = path.join(dir, 'big', 'late.jsonl');
+    const events = [];
+    const session = { id: sessionId, active: true, agent: 'claude', _sidecarSeen: false, claudeBindSidecar: 'sc' };
+    const fake = {
+      _stickyJsonl: new Map(),
+      claudeSessions: new Map([[sessionId, session]]),
+      _claudeOffsets: new Map(),
+      _claudeNotes: new Map(),
+      controlEventBus: null,
+      sessionStore: { markDirty: () => {} },
+      stickyNoteSummarizer: { feedTurns: () => {}, onRebind: () => {} },
+      broadcastToSession: () => {},
+      _ownedClaudeSessions: proto._ownedClaudeSessions,
+      _bindStickyJsonl: proto._bindStickyJsonl,
+      _readClaudeBindSidecar: async () => ({ claudeSessionId: 'cs-big', transcriptPath: tp, event: 'start' }),
+      _statQuiet: async (f) => { try { const st = fs.statSync(f); return { size: st.size, mtimeMs: st.mtimeMs }; } catch { return null; } },
+      _isStickyExpandedActive: () => false,
+      _controlAppendStateEvent: (id, kind) => events.push({ id, kind }),
+      _controlEmitInteractionTransition: async () => {},
+      _applyAiTitle: () => {},
+    };
+    await proto._pumpStickyJsonl.call(fake, sessionId, dir); // tick 1 → pending
+    // First turn is large (> the 24KB INITIAL_WINDOW) and lands all at once.
+    fs.mkdirSync(path.dirname(tp), { recursive: true });
+    fs.writeFileSync(tp, userLine('do it') + assistantLine('x'.repeat(30000)));
+    await proto._pumpStickyJsonl.call(fake, sessionId, dir); // tick 2 → promote
+    const b = fake._stickyJsonl.get(sessionId);
+    assert.equal(b.transcriptPending, false, 'promoted');
+    assert.equal(b.offset, 0, 'note offset starts at 0 for a brand-new transcript (not size-24KB)');
+    assert.equal(events.filter((e) => e.kind === 'turn_ended').length, 1, 'the large first turn still emits turn_ended');
+  });
 });

--- a/test/control/headless-turn-detection.test.js
+++ b/test/control/headless-turn-detection.test.js
@@ -1,0 +1,140 @@
+'use strict';
+
+// F14 — turn detection must fire for a HEADLESS control-spawned claude (no
+// WebSocket viewer ever expands the sticky-note card). Before the fix, turn_ended
+// + lastGrowing/lastEndsOnAssistant were computed only inside the
+// _isStickyExpandedActive gate, so a fleet session's await_turn never unblocked.
+// We drive the real _pumpStickyJsonl on the prototype against a real temp
+// transcript, with the card reported as collapsed, and assert that turn detection
+// runs anyway while the (expensive) note summariser stays gated.
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { ClaudeCodeWebServer } = require('../../src/server');
+
+const proto = ClaudeCodeWebServer.prototype;
+
+function userLine(text) {
+  return JSON.stringify({ type: 'user', message: { content: text } }) + '\n';
+}
+function assistantLine(text) {
+  return JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text }] } }) + '\n';
+}
+
+function makeFake(file, sessionId, { expanded }) {
+  const events = [];
+  const feeds = [];
+  const session = { id: sessionId, active: true, agent: 'claude', _sidecarSeen: true };
+  const binding = {
+    file,
+    offset: 0,
+    titleOffset: 0,
+    lastTitle: null,
+    claudeSessionId: 'claude-sess-1',
+    boundMtimeMs: 0,
+    idleTicks: 0,
+    _ticks: 0,
+  };
+  const fake = {
+    _stickyJsonl: new Map([[sessionId, binding]]),
+    claudeSessions: new Map([[sessionId, session]]),
+    _claudeOffsets: new Map(),
+    controlEventBus: null,
+    stickyNoteSummarizer: { feedTurns: (id, text, title) => feeds.push({ id, text, title }) },
+    _readClaudeBindSidecar: async () => null, // _sidecarSeen=true → keep binding, skip inference
+    _statQuiet: async (f) => {
+      try { const st = fs.statSync(f); return { size: st.size, mtimeMs: st.mtimeMs }; }
+      catch { return null; }
+    },
+    _isStickyExpandedActive: () => !!expanded,
+    _controlAppendStateEvent: (id, kind) => events.push({ id, kind }),
+    _controlEmitInteractionTransition: async () => {},
+    _applyAiTitle: () => {},
+  };
+  return { fake, binding, events, feeds, session };
+}
+
+describe('F14 headless turn detection (un-gated from UI expand)', function () {
+  let dir;
+  beforeEach(function () {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'f14-'));
+  });
+  afterEach(function () {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+  });
+
+  it('emits turn_ended for a COLLAPSED (headless) session and does NOT summarise', async function () {
+    const file = path.join(dir, 'transcript.jsonl');
+    const sessionId = 's-headless';
+    // Mid-turn: only a user prompt so far.
+    fs.writeFileSync(file, userLine('hello claude'));
+    const { fake, binding, events, feeds } = makeFake(file, sessionId, { expanded: false });
+
+    // Tick 1: turnOffset initialises to current EOF ("from now"); nothing settled yet.
+    await proto._pumpStickyJsonl.call(fake, sessionId, dir);
+    assert.equal(events.filter((e) => e.kind === 'turn_ended').length, 0, 'no turn_ended before assistant completes');
+    assert.ok(!binding.lastEndsOnAssistant, 'no completed assistant turn yet');
+
+    // Assistant completes the turn.
+    fs.appendFileSync(file, assistantLine('hi, how can I help?'));
+
+    // Tick 2: a new settled assistant turn appears AFTER turnOffset → turn_ended.
+    await proto._pumpStickyJsonl.call(fake, sessionId, dir);
+    assert.equal(events.filter((e) => e.kind === 'turn_ended').length, 1, 'turn_ended fires headless');
+    assert.equal(binding.lastEndsOnAssistant, true, 'lastEndsOnAssistant updated headless');
+    assert.equal(binding.lastGrowing, false, 'settled turn is not growing');
+
+    // The note summariser (the expensive model path) stays gated while collapsed.
+    assert.equal(feeds.length, 0, 'feedTurns NOT called while collapsed');
+    // Note horizon (binding.offset) is frozen; only the independent turnOffset advanced.
+    assert.equal(binding.offset, 0, 'note offset frozen while collapsed');
+    assert.ok(binding.turnOffset > 0, 'turnOffset advanced independently');
+  });
+
+  it('marks lastGrowing=true headless while an assistant turn is still streaming', async function () {
+    const file = path.join(dir, 'transcript.jsonl');
+    const sessionId = 's-busy';
+    fs.writeFileSync(file, userLine('do a thing'));
+    const { fake, binding, events } = makeFake(file, sessionId, { expanded: false });
+    await proto._pumpStickyJsonl.call(fake, sessionId, dir); // turnOffset := EOF
+
+    // A user line then an assistant line, but the LAST turn is the user (next user
+    // prompt arrived) → not ending on assistant → growing/busy.
+    fs.appendFileSync(file, assistantLine('working...'));
+    fs.appendFileSync(file, userLine('and another'));
+    await proto._pumpStickyJsonl.call(fake, sessionId, dir);
+    assert.equal(binding.lastGrowing, true, 'ends on a user turn → growing/busy');
+    assert.equal(binding.lastEndsOnAssistant, false);
+    assert.equal(events.filter((e) => e.kind === 'turn_ended').length, 0, 'no turn_ended while busy');
+  });
+
+  it('still summarises when EXPANDED (regression: note path intact)', async function () {
+    const file = path.join(dir, 'transcript.jsonl');
+    const sessionId = 's-expanded';
+    fs.writeFileSync(file, userLine('hello'));
+    const { fake, feeds } = makeFake(file, sessionId, { expanded: true });
+    // Expanded reads from binding.offset (0) → sees the content → feeds the summariser.
+    await proto._pumpStickyJsonl.call(fake, sessionId, dir);
+    assert.ok(feeds.length >= 1, 'feedTurns called when expanded');
+  });
+
+  it('emits became_busy / became_idle headless as derived interaction state flips', async function () {
+    // _controlEmitInteractionTransition is NOT expand-gated; F14 keeps its inputs
+    // (lastGrowing/lastEndsOnAssistant) fresh headless, so transitions fire.
+    const sessionId = 's-trans';
+    const events = [];
+    const seq = ['busy', 'busy', 'idle']; let i = 0;
+    const srv = {
+      _stickyJsonl: new Map([[sessionId, {}]]),
+      _controlDerivedStatus: async () => ({ interactionState: seq[Math.min(i++, seq.length - 1)] }),
+      _controlEventKindForInteractionState: proto._controlEventKindForInteractionState,
+      _controlAppendStateEvent: (id, kind) => events.push(kind),
+    };
+    await proto._controlEmitInteractionTransition.call(srv, sessionId); // busy → became_busy
+    await proto._controlEmitInteractionTransition.call(srv, sessionId); // busy (same) → no event
+    await proto._controlEmitInteractionTransition.call(srv, sessionId); // idle → became_idle
+    assert.deepEqual(events, ['became_busy', 'became_idle']);
+  });
+});

--- a/test/control/launch-hardening.test.js
+++ b/test/control/launch-hardening.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+// F6 — control-spawned PTYs must disable interactive pagers + credential prompts
+// so a headless fleet shell can't hang on `git log | less`. We drive the real
+// _controlStartAgent on the prototype with a stub bridge that captures the
+// options.extraEnv handed to bridge.startSession.
+
+const assert = require('assert');
+const { ClaudeCodeWebServer } = require('../../src/server');
+
+const proto = ClaudeCodeWebServer.prototype;
+
+describe('F6 control-spawned pager/prompt hardening', function () {
+  async function startAndCaptureEnv(agent) {
+    const sid = 's-pager';
+    const captured = {};
+    const stubBridge = {
+      _commandReady: Promise.resolve(),
+      isAvailable: () => true,
+      startSession: async (id, options) => { captured.extraEnv = options.extraEnv; return {}; },
+    };
+    const fakeThis = {
+      claudeSessions: new Map([[sid, { id: sid, workingDir: '/tmp', outputBuffer: { push() {} }, active: false }]]),
+      getBridgeForAgent: () => stubBridge,
+      _prepareClaudeBindSidecar: () => null,
+      auth: null,
+      activityBroadcastTimestamps: new Map(),
+      sessionStore: { markDirty() {} },
+      controlEventBus: null,
+      _maybeStartStickyNotes: () => {},
+      _controlReapTrustPrompt: () => {},
+      _controlError: proto._controlError,
+    };
+    await proto._controlStartAgent.call(fakeThis, sid, agent, {});
+    return captured.extraEnv;
+  }
+
+  it('sets GIT_PAGER/PAGER/GIT_TERMINAL_PROMPT for a control-spawned terminal', async function () {
+    const env = await startAndCaptureEnv('terminal');
+    assert.equal(env.GIT_PAGER, 'cat');
+    assert.equal(env.PAGER, 'cat');
+    assert.equal(env.GIT_TERMINAL_PROMPT, '0');
+  });
+
+  it('also covers the pagers that ignore PAGER', async function () {
+    const env = await startAndCaptureEnv('terminal');
+    assert.equal(env.GH_PAGER, 'cat');
+    assert.equal(env.DELTA_PAGER, 'cat');
+    assert.equal(env.MANPAGER, 'cat');
+    assert.equal(env.AWS_PAGER, '');
+    assert.equal(env.SYSTEMD_PAGER, '');
+    assert.equal(env.LESS, 'FRX');
+  });
+
+  it('applies to a control-spawned claude too (headless agent has no human to press q)', async function () {
+    const env = await startAndCaptureEnv('claude');
+    assert.equal(env.GIT_PAGER, 'cat');
+    assert.equal(env.GIT_TERMINAL_PROMPT, '0');
+  });
+});

--- a/test/control/readiness-and-confirmation.test.js
+++ b/test/control/readiness-and-confirmation.test.js
@@ -1,0 +1,262 @@
+'use strict';
+
+// F1/F17/F18 — readiness barrier + message-targeted confirmation, exercised on the
+// real prototype methods with hand-built fakes (no live PTY), mirroring the
+// steering-helpers test style.
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { ClaudeCodeWebServer } = require('../../src/server');
+
+const proto = ClaudeCodeWebServer.prototype;
+const norm = (s) => proto._controlNormalizeForMatch.call(proto, s);
+const matches = (want, got) => proto._controlUserEntryMatches.call(proto, want, got);
+const turnClass = (id, session) => proto._controlIsTurnAgent.call({ _stickyJsonl: session._map || new Map() }, id, session);
+
+function userLine(text) {
+  return JSON.stringify({ type: 'user', message: { content: text } }) + '\n';
+}
+function assistantLine(text) {
+  return JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text }] } }) + '\n';
+}
+
+describe('F1 _controlIsTurnAgent (three-way)', function () {
+  it('non-claude agent → terminal', function () {
+    assert.equal(turnClass('s', { agent: 'terminal' }), 'terminal');
+    assert.equal(turnClass('s', { agent: 'codex' }), 'terminal');
+  });
+  it('claude with no binding → unbound; with binding → bound', function () {
+    assert.equal(turnClass('s', { agent: 'claude', _map: new Map() }), 'unbound');
+    assert.equal(turnClass('s', { agent: 'claude', _map: new Map([['s', {}]]) }), 'bound');
+  });
+});
+
+describe('F18 message↔transcript match helpers', function () {
+  it('normalises whitespace + case + clips', function () {
+    assert.equal(norm('  Hello\n  World  '), 'hello world');
+    assert.equal(norm(null), '');
+    assert.equal(norm('x'.repeat(100)).length, 64);
+  });
+  it('matches by prefix containment in either direction (tolerates clipping)', function () {
+    assert.equal(matches('hello world', 'Hello World, how are you'), true); // got starts with want
+    assert.equal(matches('the quick brown fox', 'the quick'), true);        // want starts with got
+    assert.equal(matches('run the tests', 'please run the tests now'), true); // contains
+    assert.equal(matches('hello', 'completely different'), false);
+    assert.equal(matches('', 'anything'), false);
+  });
+});
+
+describe('F18 _controlAwaitSubmission', function () {
+  let dir;
+  beforeEach(function () { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'f18-')); });
+  afterEach(function () { try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) {} });
+
+  const srv = { _controlNormalizeForMatch: proto._controlNormalizeForMatch, _controlUserEntryMatches: proto._controlUserEntryMatches };
+  const await_ = (binding, pre, text, ms) => proto._controlAwaitSubmission.call(srv, binding, pre, text, ms);
+
+  it('returns true once a matching new user entry appears after preSize', async function () {
+    const file = path.join(dir, 't.jsonl');
+    fs.writeFileSync(file, assistantLine('earlier reply'));
+    const preSize = fs.statSync(file).size;
+    fs.appendFileSync(file, userLine('please refactor the parser'));
+    assert.equal(await await_({ file }, preSize, 'please refactor the parser', 1000), true);
+  });
+
+  it('returns false when no matching entry appears (timeout)', async function () {
+    const file = path.join(dir, 't.jsonl');
+    fs.writeFileSync(file, assistantLine('earlier reply'));
+    const preSize = fs.statSync(file).size;
+    fs.appendFileSync(file, userLine('a totally unrelated thing'));
+    assert.equal(await await_({ file }, preSize, 'please refactor the parser', 400), false);
+  });
+
+  it('empty message is treated as submitted', async function () {
+    assert.equal(await await_({ file: path.join(dir, 'none.jsonl') }, 0, '', 200), true);
+  });
+});
+
+describe('F1 _controlSendMessage terminal honest delivery', function () {
+  function fakeTerminal() {
+    const inputs = [];
+    return {
+      inputs,
+      claudeSessions: new Map([['t1', { id: 't1', active: true, agent: 'terminal' }]]),
+      _stickyJsonl: new Map(),
+      _controlWithIdempotency: (id, key, fn) => fn(),
+      _controlSteeringLock: proto._controlSteeringLock,
+      _controlInputBridge: () => ({ sendInput: async (id, data) => { inputs.push(data); } }),
+      _controlClampInt: proto._controlClampInt,
+      _controlIsTurnAgent: proto._controlIsTurnAgent,
+      _controlDerivedStatus: async () => ({ interactionState: 'idle' }),
+      _statQuiet: async () => ({ size: 0 }),
+      _controlSessionSeqFor: () => 0,
+      controlEventBus: null,
+    };
+  }
+  const send = (srv, opts) => proto._controlSendMessage.call(srv, opts);
+
+  it('no false negative: confirmed:true, confirmation:delivered, no reaper Enter', async function () {
+    this.timeout(4000);
+    const srv = fakeTerminal();
+    const out = await send(srv, { sessionId: 't1', message: 'ls -la', awaitMs: 1000 });
+    assert.deepEqual(srv.inputs, ['ls -la', '\r']); // no extra reaped \r for a shell
+    assert.equal(out.confirmed, true);
+    assert.equal(out.confirmation, 'delivered');
+    assert.equal(out.submission.status, 'not_applicable');
+    assert.equal(out.turn.status, 'not_applicable');
+    assert.equal(out.confidence, 'low');
+  });
+});
+
+describe('F18 _controlSendMessage bound claude proves the specific message ran', function () {
+  let dir;
+  beforeEach(function () { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'f18s-')); });
+  afterEach(function () { try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) {} });
+
+  it('submission matched + turn_ended → confirmed with structured statuses', async function () {
+    this.timeout(5000);
+    const file = path.join(dir, 't.jsonl');
+    fs.writeFileSync(file, assistantLine('prior turn'));
+    const inputs = [];
+    const binding = { file };
+    const srv = {
+      inputs,
+      claudeSessions: new Map([['c1', { id: 'c1', active: true, agent: 'claude' }]]),
+      _stickyJsonl: new Map([['c1', binding]]),
+      _controlWithIdempotency: (id, key, fn) => fn(),
+      _controlSteeringLock: proto._controlSteeringLock,
+      // The bridge "delivers" the message: appends a matching user entry AND a
+      // settled assistant reply to the transcript (a fast completed turn), as a
+      // real claude composer + model would.
+      _controlInputBridge: () => ({ sendInput: async (id, data) => {
+        inputs.push(data);
+        if (data === 'fix the flaky test') {
+          fs.appendFileSync(file, userLine('fix the flaky test'));
+          fs.appendFileSync(file, assistantLine('done — fixed the flake'));
+        }
+      } }),
+      _controlClampInt: proto._controlClampInt,
+      _controlIsTurnAgent: proto._controlIsTurnAgent,
+      _controlNormalizeForMatch: proto._controlNormalizeForMatch,
+      _controlUserEntryMatches: proto._controlUserEntryMatches,
+      _controlAwaitSubmission: proto._controlAwaitSubmission,
+      _controlAwaitTurnComplete: proto._controlAwaitTurnComplete,
+      _statQuiet: async (f) => { const st = fs.statSync(f); return { size: st.size, mtimeMs: st.mtimeMs }; },
+      _controlDerivedStatus: async () => ({ interactionState: 'idle', awaiting: { kind: 'next_message' } }),
+      _controlSessionSeqFor: () => 1,
+      controlEventBus: null,
+    };
+    const out = await proto._controlSendMessage.call(srv, { sessionId: 'c1', message: 'fix the flaky test', awaitMs: 2000 });
+    assert.equal(out.submission.status, 'submitted', 'matched the new user entry');
+    assert.equal(out.turn.status, 'completed');
+    assert.equal(out.confirmed, true);
+    assert.equal(out.confirmation, 'turn_completed');
+    assert.equal(out.confidence, 'high');
+  });
+
+  it('submitted but turn awaits a permission prompt → not confirmed, confirmationTimedOut', async function () {
+    this.timeout(5000);
+    const file = path.join(dir, 't.jsonl');
+    fs.writeFileSync(file, assistantLine('prior turn'));
+    const binding = { file };
+    const toolUseLine = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', id: 'tu1' }] } }) + '\n';
+    const srv = {
+      claudeSessions: new Map([['c3', { id: 'c3', active: true, agent: 'claude' }]]),
+      _stickyJsonl: new Map([['c3', binding]]),
+      _controlWithIdempotency: (id, key, fn) => fn(),
+      _controlSteeringLock: proto._controlSteeringLock,
+      _controlInputBridge: () => ({ sendInput: async (id, data) => {
+        if (data === 'run a command') { fs.appendFileSync(file, userLine('run a command')); fs.appendFileSync(file, toolUseLine); }
+      } }),
+      _controlClampInt: proto._controlClampInt,
+      _controlIsTurnAgent: proto._controlIsTurnAgent,
+      _controlNormalizeForMatch: proto._controlNormalizeForMatch,
+      _controlUserEntryMatches: proto._controlUserEntryMatches,
+      _controlAwaitSubmission: proto._controlAwaitSubmission,
+      _controlAwaitTurnComplete: proto._controlAwaitTurnComplete,
+      _statQuiet: async (f) => { const st = fs.statSync(f); return { size: st.size, mtimeMs: st.mtimeMs }; },
+      _controlDerivedStatus: async () => ({ interactionState: 'waiting_input', awaiting: { kind: 'tool_approval' } }),
+      _controlSessionSeqFor: () => 1,
+      controlEventBus: null,
+    };
+    const out = await proto._controlSendMessage.call(srv, { sessionId: 'c3', message: 'run a command', awaitMs: 800 });
+    assert.equal(out.submission.status, 'submitted');
+    assert.equal(out.turn.status, 'pending');
+    assert.equal(out.confirmed, false);
+    assert.equal(out.confirmationTimedOut, true);
+    assert.deepEqual(out.turn.awaiting, { kind: 'tool_approval' });
+  });
+
+  it('unbound claude (no binding) never claims a confirmed turn', async function () {
+    this.timeout(6000);
+    const inputs = [];
+    const srv = {
+      inputs,
+      claudeSessions: new Map([['c2', { id: 'c2', active: true, agent: 'claude' }]]),
+      _stickyJsonl: new Map(), // not bound
+      _controlWithIdempotency: (id, key, fn) => fn(),
+      _controlSteeringLock: proto._controlSteeringLock,
+      _controlInputBridge: () => ({ sendInput: async (id, data) => { inputs.push(data); } }),
+      _controlClampInt: proto._controlClampInt,
+      _controlIsTurnAgent: proto._controlIsTurnAgent,
+      _controlDerivedStatus: async () => ({ interactionState: 'idle' }), // never starts → reaper
+      _controlAwaitActivityEdge: proto._controlAwaitActivityEdge,
+      _controlSessionSeqFor: () => 0,
+      controlEventBus: null,
+    };
+    const out = await proto._controlSendMessage.call(srv, { sessionId: 'c2', message: 'hello', awaitMs: 1000 });
+    assert.equal(out.confirmed, false);
+    assert.equal(out.confirmation, 'no_turn_binding');
+    assert.equal(out.submission.status, 'no_turn_binding');
+    assert.deepEqual(inputs, ['hello', '\r', '\r']); // cold-boot reaper still re-sends Enter once
+  });
+});
+
+describe('F17 readiness barrier', function () {
+  function fakeServer({ agent, bound, hadOutput, screen }) {
+    return {
+      claudeSessions: new Map([['s', {
+        id: 's', active: true, agent,
+        outputBuffer: { size: hadOutput ? 3 : 0 },
+        _ctlTranscript: screen != null ? { snapshot: async () => screen } : null,
+      }]]),
+      _stickyJsonl: bound ? new Map([['s', { file: 'x' }]]) : new Map(),
+      _controlReadinessState: proto._controlReadinessState,
+    };
+  }
+  const state = (srv) => proto._controlReadinessState.call(srv, 's');
+
+  it('claude not yet bound → ready:false, blocker binding_pending', async function () {
+    const out = await state(fakeServer({ agent: 'claude', bound: false, hadOutput: true }));
+    assert.equal(out.ready, false);
+    assert.equal(out.bound, false);
+    assert.equal(out.blocker.kind, 'binding_pending');
+  });
+
+  it('claude bound + output → ready:true, bound:true', async function () {
+    const out = await state(fakeServer({ agent: 'claude', bound: true, hadOutput: true }));
+    assert.deepEqual({ ready: out.ready, bound: out.bound }, { ready: true, bound: true });
+  });
+
+  it('trust modal on screen → blocker trust (not ready even if bound)', async function () {
+    const out = await state(fakeServer({ agent: 'claude', bound: true, hadOutput: true, screen: 'Do you trust the files in this folder?\n 1. Yes  2. No' }));
+    assert.equal(out.ready, false);
+    assert.equal(out.blocker.kind, 'trust');
+  });
+
+  it('terminal agent ready once active with output (no binding needed)', async function () {
+    const out = await state(fakeServer({ agent: 'terminal', bound: false, hadOutput: true }));
+    assert.deepEqual({ ready: out.ready, bound: out.bound }, { ready: true, bound: false });
+  });
+
+  it('_controlAwaitReady resolves once the binding attaches mid-wait', async function () {
+    this.timeout(3000);
+    const srv = fakeServer({ agent: 'claude', bound: false, hadOutput: true });
+    setTimeout(() => srv._stickyJsonl.set('s', { file: 'x' }), 400); // binding attaches late
+    const out = await proto._controlAwaitReady.call(srv, 's', 2000);
+    assert.equal(out.ready, true);
+    assert.equal(out.bound, true);
+  });
+});

--- a/test/control/routes.test.js
+++ b/test/control/routes.test.js
@@ -352,4 +352,167 @@ describe('control/routes /api/control', function () {
     assert.deepEqual(parseCursor(encodeCursor(c)), c);
     assert.equal(parseCursor(undefined), undefined);
   });
+
+  it('FIX C: parseCursor rejects negative / non-integer / non-numeric seq', function () {
+    assert.equal(parseCursor('notvalid'), undefined);
+    assert.equal(parseCursor('epoch:-5'), undefined);
+    assert.equal(parseCursor('epoch:1.5'), undefined);
+    assert.equal(parseCursor('epoch:abc'), undefined);
+    assert.deepEqual(parseCursor('epoch:0'), { epoch: 'epoch', seq: 0 }); // 0 is valid
+  });
+
+  it('FIX C: GET /events with a PRESENT-but-INVALID cursor → 400 INVALID_ARGUMENT; ABSENT cursor → 200 fresh watcher', async function () {
+    const { server, port } = await listen(buildServer(fakeDeps({ eventBus: new ControlEventBus() })));
+    try {
+      for (const bad of ['notvalid', '-5', '1.5', 'epoch:1.5']) {
+        const r = await getJson(port, `/api/control/events?cursor=${encodeURIComponent(bad)}&timeoutMs=0`);
+        assert.equal(r.status, 400, `cursor='${bad}' → 400`);
+        assert.equal(r.body.error.code, 'INVALID_ARGUMENT');
+      }
+      // No cursor at all → a fresh watcher, 200 (non-blocking poll).
+      const fresh = await getJson(port, '/api/control/events?timeoutMs=0');
+      assert.equal(fresh.status, 200);
+      assert.ok(Array.isArray(fresh.body.events));
+    } finally {
+      server.close();
+    }
+  });
+
+  // ---- F15 snapshot + cursor atomicity --------------------------------------
+  it('F15: GET /snapshot returns sessions + cursor; resume long-poll sees ONLY new events, no gap', async function () {
+    const bus = new ControlEventBus();
+    bus.append('s1', 'turn_ended'); // seq 1, pre-snapshot
+    const deps = fakeDeps({
+      eventBus: bus,
+      snapshot: async () => ({
+        sessions: [
+          { sessionId: 's1', lifecycle: 'running', interactionState: 'idle', lastTurnEndedAt: 99, awaiting: null, sessionStateSeq: 1, bound: true },
+          { sessionId: 's2', lifecycle: 'exited', interactionState: 'exited', lastTurnEndedAt: null, awaiting: null, sessionStateSeq: 0, bound: false },
+        ],
+        cursor: bus.headCursor(), // captured atomically (seq 1)
+        capturedAt: 1234,
+      }),
+    });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const snap = await getJson(port, '/api/control/snapshot');
+      assert.equal(snap.status, 200);
+      assert.equal(snap.body.sessions.length, 2);
+      assert.ok(snap.body.cursor, 'snapshot carries an encoded cursor');
+      assert.equal(snap.body.capturedAt, 1234);
+      // A new event fires AFTER the snapshot was taken.
+      bus.append('s1', 'became_busy'); // seq 2
+      // Resume the long-poll from EXACTLY the snapshot cursor.
+      const ev = await getJson(port, `/api/control/events?cursor=${encodeURIComponent(snap.body.cursor)}&timeoutMs=500`);
+      assert.equal(ev.body.events.length, 1, 'only the post-snapshot event');
+      assert.equal(ev.body.events[0].kind, 'became_busy');
+      assert.equal(ev.body.gaps.length, 0, 'valid cursor → no gap, no loss, no duplicate');
+    } finally {
+      server.close();
+    }
+  });
+
+  // ---- F19 capability negotiation -------------------------------------------
+  const FROZEN_CAP_VOCAB = new Set([
+    'readiness_barrier', 'turn_binding', 'permission_mode', 'agent_args',
+    'events_cursor', 'events_retention', 'multiplex_watch', 'session_state_seq',
+  ]);
+
+  it('F19: GET /capabilities emits the frozen { capabilities: string[], controlVersion: string } shape', async function () {
+    // Route the REAL _controlCapabilities() through the HTTP layer so we assert the
+    // actual emitted wire shape, not a hand-written stub.
+    const { ClaudeCodeWebServer } = require('../../src/server');
+    const realCaps = () => ClaudeCodeWebServer.prototype._controlCapabilities.call({ controlEventBus: new ControlEventBus() });
+    const { server, port } = await listen(buildServer(fakeDeps({ capabilities: realCaps })));
+    try {
+      const r = await getJson(port, '/api/control/capabilities');
+      assert.equal(r.status, 200);
+      // capabilities MUST be a flat string[] the client can `new Set(...)` over.
+      assert.ok(Array.isArray(r.body.capabilities), 'capabilities is an array');
+      assert.doesNotThrow(() => new Set(r.body.capabilities), 'new Set(capabilities) does not throw');
+      for (const cap of r.body.capabilities) {
+        assert.equal(typeof cap, 'string');
+        assert.ok(FROZEN_CAP_VOCAB.has(cap), `'${cap}' is in the frozen vocabulary`);
+      }
+      // controlVersion is a STRING.
+      assert.equal(typeof r.body.controlVersion, 'string');
+      // The 6 expected tokens are present.
+      const set = new Set(r.body.capabilities);
+      for (const expected of ['permission_mode', 'agent_args', 'turn_binding', 'events_cursor', 'events_retention', 'session_state_seq']) {
+        assert.ok(set.has(expected), `advertises ${expected}`);
+      }
+    } finally {
+      server.close();
+    }
+  });
+
+  it('F19: an OLD instance that omits a capability surfaces its absence (client fails closed)', async function () {
+    // A pre-F10 instance: a valid frozen-shape array that simply lacks permission_mode.
+    const deps = fakeDeps({ capabilities: () => ({ capabilities: ['turn_binding'], controlVersion: '0' }) });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const r = await getJson(port, '/api/control/capabilities');
+      assert.equal(r.status, 200);
+      assert.ok(Array.isArray(r.body.capabilities));
+      assert.equal(new Set(r.body.capabilities).has('permission_mode'), false); // absent → client must NOT assume support
+      assert.equal(typeof r.body.controlVersion, 'string');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('F19: the /capabilities fallback (no deps.capabilities) is the frozen empty shape', async function () {
+    const deps = fakeDeps();
+    delete deps.capabilities;
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const r = await getJson(port, '/api/control/capabilities');
+      assert.equal(r.status, 200);
+      assert.deepEqual(r.body.capabilities, []);
+      assert.equal(r.body.controlVersion, '0');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('F10: a create that triggers INVALID_ARGUMENT returns HTTP 400 with the structured envelope', async function () {
+    // createSession throws exactly as _controlCreateSession does on a bad mode /
+    // conflicting agentArgs: Error with .code + .statusCode, no .type.
+    const deps = fakeDeps({
+      createSession: async () => {
+        const err = new Error("agentArgs may not contain '--dangerously-skip-permissions'; use permissionMode for permission control");
+        err.code = 'INVALID_ARGUMENT';
+        err.statusCode = 400;
+        throw err;
+      },
+    });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const r = await postJson(port, '/api/control/sessions/create', { start: true, agent: 'claude', permissionMode: 'plan', agentArgs: ['--dangerously-skip-permissions'] });
+      assert.equal(r.status, 400);
+      assert.equal(r.body.error.code, 'INVALID_ARGUMENT');
+      assert.equal(typeof r.body.error.message, 'string');
+      assert.ok(r.body.error.message.length > 0);
+    } finally {
+      server.close();
+    }
+  });
+
+  // ---- F21 classifiable rate limit ------------------------------------------
+  it('F21: a throttled request returns a classifiable 429 (RATE_LIMITED + Retry-After)', async function () {
+    const deps = fakeDeps({ rateLimit: { max: 1, windowMs: 60000 } });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      await getJson(port, '/api/control/sessions'); // consumes the single-request budget
+      const r = await fetch(`http://127.0.0.1:${port}/api/control/sessions`);
+      assert.equal(r.status, 429);
+      const body = await r.json();
+      assert.equal(body.error.code, 'RATE_LIMITED');
+      assert.ok(body.error.retryAfterMs > 0);
+      assert.ok(body.error.retryAfterSec >= 1);
+      assert.ok(r.headers.get('retry-after'), 'standard Retry-After header present for backoff');
+    } finally {
+      server.close();
+    }
+  });
 });

--- a/test/control/session-status.test.js
+++ b/test/control/session-status.test.js
@@ -38,6 +38,28 @@ describe('control/session-status deriveStatus', function () {
     assert.equal(s.lastTurnEndedAt, 123);
   });
 
+  it('F8: bound+settled JSONL but the busy footer shows a running turn → busy (medium)', function () {
+    const s = deriveStatus({
+      session: { active: true, agent: 'claude', hadOutput: true },
+      jsonl: { bound: true, growing: false, endsOnAssistant: true, lastTurnEndedAt: 123 },
+      renderedTail: 'Pondering… (esc to interrupt)', // screen leads the polled transcript
+    });
+    assert.equal(s.interactionState, 'busy');
+    assert.equal(s.confidence, 'medium'); // screen raises busy; JSONL+screen disagree
+    assert.equal(s.canAcceptInput, false);
+  });
+
+  it('F8: bound+settled with NO busy footer stays idle/high (unchanged)', function () {
+    const s = deriveStatus({
+      session: { active: true, agent: 'claude', hadOutput: true },
+      jsonl: { bound: true, growing: false, endsOnAssistant: true },
+      renderedTail: '> ', // composer at rest
+    });
+    assert.equal(s.interactionState, 'idle');
+    assert.equal(s.confidence, 'high'); // JSONL + screen agree
+    assert.equal(s.awaiting.kind, 'next_message');
+  });
+
   it('pending ExitPlanMode → waiting_input plan_approval', function () {
     const s = deriveStatus({
       session: { active: true, agent: 'claude', hadOutput: true },
@@ -107,6 +129,70 @@ describe('control/session-status deriveStatus', function () {
     const s = deriveStatus({ session: { active: true, agent: 'terminal', hadOutput: true } });
     assert.equal(s.interactionState, 'unknown');
     assert.equal(s.confidence, 'low');
+  });
+
+  it('F12: unbound active + recent PTY output → busy, confidence low', function () {
+    const now = 1_000_000;
+    const s = deriveStatus({
+      session: { active: true, agent: 'terminal', hadOutput: true },
+      lastOutputAt: now - 500, // well within the quiet window
+      now,
+      quietWindowMs: 4000,
+    });
+    assert.equal(s.interactionState, 'busy');
+    assert.equal(s.confidence, 'low');
+    assert.equal(s.canAcceptInput, false);
+  });
+
+  it('F12: unbound active + quiet beyond the window → idle, confidence low', function () {
+    const now = 1_000_000;
+    const s = deriveStatus({
+      session: { active: true, agent: 'terminal', hadOutput: true },
+      lastOutputAt: now - 9000, // quiet > window
+      now,
+      quietWindowMs: 4000,
+    });
+    assert.equal(s.interactionState, 'idle');
+    assert.equal(s.confidence, 'low');
+    assert.equal(s.awaiting.kind, 'next_message');
+  });
+
+  it('F12: a busy footer with RECENT output → busy, medium confidence', function () {
+    const now = 1_000_000;
+    const s = deriveStatus({
+      session: { active: true, agent: 'terminal', hadOutput: true },
+      renderedTail: 'Generating… (esc to interrupt)',
+      lastOutputAt: now - 200, // fresh → footer corroborated
+      now,
+    });
+    assert.equal(s.interactionState, 'busy');
+    assert.equal(s.confidence, 'medium');
+  });
+
+  it('F12: a busy footer but output QUIET beyond the window → idle (stale footer)', function () {
+    const now = 1_000_000;
+    const s = deriveStatus({
+      session: { active: true, agent: 'terminal', hadOutput: true },
+      renderedTail: 'Generating… (esc to interrupt)',
+      lastOutputAt: now - 9000, // stale-quiet → footer treated as stale, recency wins
+      now,
+      quietWindowMs: 4000,
+    });
+    assert.equal(s.interactionState, 'idle');
+    assert.equal(s.confidence, 'low');
+    assert.equal(s.awaiting.kind, 'next_message');
+  });
+
+  it('F12: recency never overrides a bound session (JSONL stays authoritative)', function () {
+    const now = 1_000_000;
+    const s = deriveStatus({
+      session: { active: true, agent: 'claude', hadOutput: true },
+      jsonl: { bound: true, growing: false, endsOnAssistant: true },
+      lastOutputAt: now - 100, // recent, but bound → ignored
+      now,
+    });
+    assert.equal(s.interactionState, 'idle');
+    assert.equal(s.confidence, 'high');
   });
 
   it('awaitingKindForPendingTool mapping', function () {
@@ -208,5 +294,29 @@ describe('control/session-status awaitingFromScreen (screen-based fallback)', fu
     const live = [' output', ' output', ' output', ' output', ' Working…', ' esc to interrupt'].join('\n');
     const b = deriveStatus({ session: { active: true, agent: 'codex', hadOutput: true }, renderedTail: live });
     assert.equal(b.interactionState, 'busy');
+  });
+
+  describe('F7 folder-trust modal classification', function () {
+    const numbered = '\n 1. Yes, proceed\n 2. No, exit';
+    it('classifies "Do you trust the files in this folder?" + numbered list as trust_prompt', function () {
+      const a = awaitingFromScreen('Do you trust the files in this folder?' + numbered);
+      assert.equal(a.kind, 'trust_prompt');
+    });
+    it('classifies the "Is this a project you trust?" variant (previously missed)', function () {
+      const a = awaitingFromScreen('Is this a project you trust?\n ❯ 1. Yes\n 2. No');
+      assert.equal(a.kind, 'trust_prompt');
+    });
+    it('trust wording WITHOUT a numbered list → null (precision guard)', function () {
+      assert.equal(awaitingFromScreen('I do not trust the files in this folder, just prose here.'), null);
+    });
+    it('deriveStatus surfaces awaiting.kind=trust_prompt for a running session showing the modal', function () {
+      const s = deriveStatus({
+        session: { active: true, agent: 'claude', hadOutput: true },
+        renderedTail: 'Is this a project you trust?\n 1. Yes, proceed\n 2. No, exit',
+      });
+      assert.equal(s.interactionState, 'waiting_input');
+      assert.equal(s.awaiting.kind, 'trust_prompt');
+      assert.equal(s.canAcceptInput, true);
+    });
   });
 });

--- a/test/control/steering-helpers.test.js
+++ b/test/control/steering-helpers.test.js
@@ -46,6 +46,30 @@ describe('control steering helpers', function () {
     it('joins an array of keys', function () {
       assert.equal(keyBytes(['C-c', 'Enter'], false), '\x03\r');
     });
+
+    it('F3: maps Shift+Tab to CSI Z (back-tab) — claude permission-mode cycle', function () {
+      assert.equal(keyBytes('Shift-Tab', false), '\x1b[Z');
+      assert.equal(keyBytes('shift-tab', false), '\x1b[Z'); // case-insensitive
+      assert.equal(keyBytes('SHIFT-TAB', false), '\x1b[Z');
+      assert.equal(keyBytes('S-Tab', false), '\x1b[Z');      // alias
+    });
+
+    it('F3: maps the other added navigation/editing keys', function () {
+      assert.equal(keyBytes('Home', false), '\x1b[H');
+      assert.equal(keyBytes('End', false), '\x1b[F');
+      assert.equal(keyBytes('PageUp', false), '\x1b[5~');
+      assert.equal(keyBytes('PageDown', false), '\x1b[6~');
+      assert.equal(keyBytes('Delete', false), '\x1b[3~');
+    });
+
+    it('F3: Shift+Tab still passes through verbatim in raw mode', function () {
+      assert.equal(keyBytes('Shift-Tab', true), 'Shift-Tab');
+      assert.equal(keyBytes('\x1b[Z', true), '\x1b[Z');
+    });
+
+    it('F3: array join includes Shift+Tab translation', function () {
+      assert.equal(keyBytes(['Shift-Tab', 'Shift-Tab'], false), '\x1b[Z\x1b[Z');
+    });
   });
 
   describe('_controlMapResponseKeys (best-effort; B3 calibrates live)', function () {
@@ -66,6 +90,15 @@ describe('control steering helpers', function () {
       assert.equal(mapResp('choice_question', { optionValue: '2' }), '2\r');
     });
 
+    it('trust_prompt: accept → explicit "1\\r" (not bare Enter), reject → "2\\r"', function () {
+      assert.equal(mapResp('trust_prompt', { choice: 'accept' }), '1\r');
+      assert.equal(mapResp('trust_prompt', { choice: 'yes' }), '1\r');
+      assert.equal(mapResp('trust_prompt', { choice: 'trust' }), '1\r');
+      assert.equal(mapResp('trust_prompt', { choice: 'reject' }), '2\r');
+      assert.equal(mapResp('trust_prompt', { choice: 'no' }), '2\r');
+      assert.equal(mapResp('trust_prompt', { choice: 'maybe' }), null);
+    });
+
     it('unmappable choice returns null (caller surfaces an error / uses keys override)', function () {
       assert.equal(mapResp('plan_approval', { choice: 'maybe' }), null);
     });
@@ -79,12 +112,15 @@ describe('control steering helpers', function () {
         inputs,
         claudeSessions: new Map([['s1', { id: 's1', active: true, agent: 'claude' }]]),
         _controlWithIdempotency: (id, key, fn) => fn(),
+        _controlSteeringLock: proto._controlSteeringLock,
         _controlInputBridge: () => ({ sendInput: async (id, data) => { inputs.push(data); } }),
         _controlClampInt: proto._controlClampInt,
+        _controlIsTurnAgent: proto._controlIsTurnAgent,
         _controlDerivedStatus: async () => statusSequence[Math.min(pollIdx++, statusSequence.length - 1)],
+        _controlAwaitActivityEdge: proto._controlAwaitActivityEdge,
         _stickyJsonl: new Map(),
         _controlSessionSeqFor: () => 0,
-        controlEventBus: null, // no cursor → the confirm waitFor is skipped (keeps the test fast)
+        controlEventBus: null, // no cursor → falls back to the status-poll reaper gate
       };
     }
     const send = (srv, opts) => proto._controlSendMessage.call(srv, opts);
@@ -114,6 +150,260 @@ describe('control steering helpers', function () {
       const srv = fakeServer([{ interactionState: 'idle' }]);
       await send(srv, { sessionId: 's1', message: 'a\nb', awaitMs: 1000 });
       assert.deepEqual(srv.inputs, ['\x1b[200~a\nb\x1b[201~', '\r', '\r']);
+    });
+  });
+
+  describe('F13 — unbound reaper gates on a NEW activity edge (event bus)', function () {
+    const { ControlEventBus } = require('../../src/control/event-bus');
+
+    function fakeServerBus({ emitOnSend = false, preBusy = false } = {}) {
+      const inputs = [];
+      const bus = new ControlEventBus();
+      const srv = {
+        inputs,
+        controlEventBus: bus,
+        claudeSessions: new Map([['s1', { id: 's1', active: true, agent: 'claude' }]]),
+        _stickyJsonl: new Map(), // unbound (no JSONL binding)
+        _controlWithIdempotency: (id, key, fn) => fn(),
+        _controlSteeringLock: proto._controlSteeringLock,
+        _controlInputBridge: () => ({
+          sendInput: async (id, data) => {
+            inputs.push(data);
+            // Simulate claude producing output (PTY recency → became_busy) on submit.
+            if (emitOnSend && data === '\r') bus.append('s1', 'became_busy', { interactionState: 'busy' });
+          },
+        }),
+        _controlClampInt: proto._controlClampInt,
+        _controlIsTurnAgent: proto._controlIsTurnAgent,
+        // Only consulted on the no-bus fallback; the bus path ignores it.
+        _controlDerivedStatus: async () => ({ interactionState: 'idle' }),
+        _controlAwaitActivityEdge: proto._controlAwaitActivityEdge,
+        _controlSessionSeqFor: () => 0,
+      };
+      // A lingering PRIOR turn's busy edge, emitted BEFORE the send captures its
+      // cursor → must NOT be counted as confirmation of this message.
+      if (preBusy) bus.append('s1', 'became_busy', { interactionState: 'busy' });
+      return srv;
+    }
+    const send = (srv, opts) => proto._controlSendMessage.call(srv, opts);
+
+    it('re-sends Enter when only a lingering prior busy exists (no NEW edge)', async function () {
+      this.timeout(6000);
+      const srv = fakeServerBus({ preBusy: true, emitOnSend: false });
+      await send(srv, { sessionId: 's1', message: 'hello', awaitMs: 1000 });
+      assert.deepEqual(srv.inputs, ['hello', '\r', '\r']); // dropped Enter reaped
+    });
+
+    it('does NOT re-send when a NEW became_busy edge appears after the send', async function () {
+      this.timeout(6000);
+      const srv = fakeServerBus({ emitOnSend: true });
+      await send(srv, { sessionId: 's1', message: 'hello', awaitMs: 1000 });
+      assert.deepEqual(srv.inputs, ['hello', '\r']); // fresh edge → no reap
+    });
+  });
+
+  describe('F12 — coarse PTY-activity edges for unbound sessions', function () {
+    const { ControlEventBus } = require('../../src/control/event-bus');
+
+    function fakeServer(statusGetter, { bound = false } = {}) {
+      const bus = new ControlEventBus();
+      return {
+        controlEventBus: bus,
+        claudeSessions: new Map([['s1', { id: 's1', active: true, agent: bound ? 'claude' : 'terminal' }]]),
+        _stickyJsonl: bound ? new Map([['s1', {}]]) : new Map(),
+        _controlDerivedStatus: async () => statusGetter(),
+        _controlEmitInteractionTransition: proto._controlEmitInteractionTransition,
+        _controlEventKindForInteractionState: proto._controlEventKindForInteractionState,
+        _controlAppendStateEvent: proto._controlAppendStateEvent,
+        _controlBumpSessionSeq: proto._controlBumpSessionSeq,
+        _controlSessionSeqFor: proto._controlSessionSeqFor,
+      };
+    }
+    const emit = (srv) => proto._controlEmitInteractionTransition.call(srv, 's1');
+
+    it('emits became_busy then became_idle across a PTY activity→quiet edge (debounced)', async function () {
+      let state = 'busy';
+      const srv = fakeServer(() => ({ interactionState: state, confidence: 'low' }));
+      await emit(srv);             // rising edge → became_busy
+      await emit(srv);             // unchanged → debounced, no duplicate
+      state = 'idle';
+      await emit(srv);             // falling edge → became_idle
+      const kinds = srv.controlEventBus.listEvents().map((e) => e.kind);
+      assert.deepEqual(kinds, ['became_busy', 'became_idle']);
+    });
+
+    it('never emits turn_ended from the coarse unbound signal', async function () {
+      const srv = fakeServer(() => ({ interactionState: 'idle', confidence: 'low' }));
+      await emit(srv);
+      const kinds = srv.controlEventBus.listEvents().map((e) => e.kind);
+      assert.ok(!kinds.includes('turn_ended'));
+      assert.deepEqual(kinds, ['became_idle']);
+    });
+
+    it('_controlRecordPtyOutput records recency but skips the coarse path for bound sessions', function () {
+      const bus = new ControlEventBus();
+      const session = { id: 's1', active: true, agent: 'claude' };
+      const srv = {
+        controlEventBus: bus,
+        claudeSessions: new Map([['s1', session]]),
+        _stickyJsonl: new Map([['s1', {}]]), // BOUND → JSONL turn detector is authoritative
+        _controlEmitInteractionTransition: () => { throw new Error('bound sessions must not use the coarse edge path'); },
+      };
+      proto._controlRecordPtyOutput.call(srv, 's1');
+      assert.equal(typeof session._ctlLastOutputAt, 'number'); // recency still recorded
+      assert.ok(!session._ctlIdleTimer);                       // no coarse idle-debounce timer
+      assert.equal(bus.listEvents().length, 0);                       // no coarse edge emitted
+    });
+
+    it('_controlRecordPtyOutput skips the rising-edge re-derive while already busy (no per-chunk flood)', function () {
+      const bus = new ControlEventBus();
+      const session = { id: 's1', active: true, agent: 'terminal', _lastInteractionState: 'busy' };
+      let emitCalls = 0;
+      const srv = {
+        controlEventBus: bus,
+        claudeSessions: new Map([['s1', session]]),
+        _stickyJsonl: new Map(), // unbound
+        _controlEmitInteractionTransition: () => { emitCalls++; return Promise.resolve(); },
+      };
+      proto._controlRecordPtyOutput.call(srv, 's1');
+      assert.equal(emitCalls, 0);                              // already busy → no expensive re-derive
+      assert.equal(typeof session._ctlLastOutputAt, 'number'); // recency still refreshed
+      assert.ok(session._ctlIdleTimer);                        // idle timer still re-armed
+      clearTimeout(session._ctlIdleTimer);
+    });
+  });
+
+  describe('F16 — per-session steering mutex (_controlSteeringLock)', function () {
+    it('serialises ops per session in submission order; a failure never wedges the queue', async function () {
+      const srv = {};
+      const log = [];
+      const op = (label, ms, fail) => () => new Promise((resolve, reject) => {
+        log.push(`${label}:start`);
+        setTimeout(() => { log.push(`${label}:end`); fail ? reject(new Error(label)) : resolve(label); }, ms);
+      });
+      const p1 = proto._controlSteeringLock.call(srv, 's1', op('A', 20, false));
+      const p2 = proto._controlSteeringLock.call(srv, 's1', op('B', 5, true)).catch(() => 'B-failed');
+      const p3 = proto._controlSteeringLock.call(srv, 's1', op('C', 5, false));
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+      assert.equal(r1, 'A');
+      assert.equal(r2, 'B-failed');           // B rejected, but the queue kept draining
+      assert.equal(r3, 'C');
+      assert.deepEqual(log, ['A:start', 'A:end', 'B:start', 'B:end', 'C:start', 'C:end']); // no overlap
+    });
+
+    it('different sessions are NOT serialised against each other', async function () {
+      const srv = {};
+      const log = [];
+      const op = (label, ms) => () => new Promise((resolve) => { log.push(`${label}:s`); setTimeout(() => { log.push(`${label}:e`); resolve(); }, ms); });
+      await Promise.all([
+        proto._controlSteeringLock.call(srv, 'x', op('X', 25)),
+        proto._controlSteeringLock.call(srv, 'y', op('Y', 5)),
+      ]);
+      assert.ok(log.indexOf('Y:e') < log.indexOf('X:e'), 'session y finished while x was still running');
+    });
+
+    it('two concurrent send_message to ONE session do not interleave bytes', async function () {
+      this.timeout(4000);
+      const inputs = [];
+      const srv = {
+        inputs,
+        claudeSessions: new Map([['s1', { id: 's1', active: true, agent: 'terminal' }]]),
+        _stickyJsonl: new Map(),
+        _controlWithIdempotency: (id, key, fn) => fn(), // distinct keys → both ops actually run
+        _controlSteeringLock: proto._controlSteeringLock,
+        _controlInputBridge: () => ({ sendInput: async (id, data) => {
+          inputs.push(`${data}#s`);
+          await new Promise((r) => setTimeout(r, 15)); // widen the overlap window
+          inputs.push(`${data}#e`);
+        } }),
+        _controlClampInt: proto._controlClampInt,
+        _controlIsTurnAgent: proto._controlIsTurnAgent,
+        _controlDerivedStatus: async () => ({ interactionState: 'idle' }),
+        _controlSessionSeqFor: () => 0,
+        controlEventBus: null,
+      };
+      await Promise.all([
+        proto._controlSendMessage.call(srv, { sessionId: 's1', message: 'AAA', awaitMs: 0, idempotencyKey: 'k1' }),
+        proto._controlSendMessage.call(srv, { sessionId: 's1', message: 'BBB', awaitMs: 0, idempotencyKey: 'k2' }),
+      ]);
+      // Each op writes text then '\r'. The mutex guarantees the first op's '\r'
+      // completes before the second op's text begins (no AAA/BBB byte interleave).
+      const idxAtext = inputs.indexOf('AAA#s');
+      const idxBtext = inputs.indexOf('BBB#s');
+      const firstText = Math.min(idxAtext, idxBtext);
+      const secondText = Math.max(idxAtext, idxBtext);
+      // Between the first op's text and the second op's text, the first op's '\r'
+      // must have fully completed.
+      const between = inputs.slice(firstText, secondText);
+      assert.ok(between.includes('\r#e'), 'first op fully submitted (text + Enter) before the second op started typing');
+    });
+  });
+
+  describe('F15 — _controlSnapshot atomic batch', function () {
+    const { ControlEventBus } = require('../../src/control/event-bus');
+    it('captures the cursor + every session status with the documented shape', async function () {
+      const bus = new ControlEventBus();
+      bus.append('s1', 'turn_ended'); // seq 1
+      const srv = {
+        controlEventBus: bus,
+        claudeSessions: new Map([
+          ['s1', { name: 'one', agent: 'claude', workingDir: '/w', lastActivity: 5 }],
+          ['s2', { name: 'two', agent: 'terminal', workingDir: '/w', lastActivity: 6 }],
+        ]),
+        _stickyJsonl: new Map([['s1', {}]]),
+        _controlSessionSeqFor: (id) => (id === 's1' ? 3 : 0),
+        _controlDerivedStatus: async (id) => (id === 's1'
+          ? { lifecycle: 'running', interactionState: 'idle', canAcceptInput: true, confidence: 'high', lastTurnEndedAt: 99, awaiting: { kind: 'next_message' } }
+          : { lifecycle: 'exited', interactionState: 'exited', canAcceptInput: false, confidence: 'low' }),
+      };
+      const snap = await proto._controlSnapshot.call(srv);
+      assert.equal(snap.cursor.seq, 1, 'cursor captured from the event bus');
+      assert.equal(snap.sessions.length, 2);
+      const s1 = snap.sessions.find((s) => s.sessionId === 's1');
+      assert.equal(s1.bound, true);
+      assert.equal(s1.sessionStateSeq, 3);
+      assert.equal(s1.lastTurnEndedAt, 99);
+      assert.equal(s1.interactionState, 'idle');
+      assert.deepEqual(s1.awaiting, { kind: 'next_message' });
+      const s2 = snap.sessions.find((s) => s.sessionId === 's2');
+      assert.equal(s2.bound, false);
+      assert.equal(s2.lastTurnEndedAt, null); // normalised from undefined
+      assert.equal(s2.awaiting, null);
+    });
+  });
+
+  describe('F19 — _controlCapabilities contract shape', function () {
+    const FROZEN_CAP_VOCAB = new Set([
+      'readiness_barrier', 'turn_binding', 'permission_mode', 'agent_args',
+      'events_cursor', 'events_retention', 'multiplex_watch', 'session_state_seq',
+    ]);
+
+    it('returns the frozen { capabilities: string[], controlVersion: string } shape', function () {
+      const { EVENT_KINDS } = require('../../src/control/event-bus');
+      const { VALID_PERMISSION_MODES } = require('../../src/claude-bridge');
+      const { ControlEventBus } = require('../../src/control/event-bus');
+      const srv = { controlEventBus: new ControlEventBus() };
+      const cap = proto._controlCapabilities.call(srv);
+
+      // capabilities is a FLAT string[] the fleet client can `new Set(...)` over.
+      assert.ok(Array.isArray(cap.capabilities), 'capabilities is an array');
+      assert.doesNotThrow(() => new Set(cap.capabilities), 'new Set(capabilities) does not throw');
+      for (const token of cap.capabilities) {
+        assert.equal(typeof token, 'string');
+        assert.ok(FROZEN_CAP_VOCAB.has(token), `'${token}' is in the frozen vocabulary`);
+      }
+      // The 6 expected tokens are present.
+      const set = new Set(cap.capabilities);
+      for (const expected of ['permission_mode', 'agent_args', 'turn_binding', 'events_cursor', 'events_retention', 'session_state_seq']) {
+        assert.ok(set.has(expected), `advertises ${expected}`);
+      }
+      // controlVersion is a STRING.
+      assert.equal(typeof cap.controlVersion, 'string');
+
+      // Additive extras still present (the client ignores unknown keys; useful for debug).
+      assert.deepEqual(cap.permissionModes, VALID_PERMISSION_MODES);
+      assert.deepEqual(cap.events, EVENT_KINDS);
+      assert.equal(cap.limits.eventsPerSession, srv.controlEventBus.maxEventsPerSession);
     });
   });
 });

--- a/test/control/steering-helpers.test.js
+++ b/test/control/steering-helpers.test.js
@@ -52,6 +52,8 @@ describe('control steering helpers', function () {
       assert.equal(keyBytes('shift-tab', false), '\x1b[Z'); // case-insensitive
       assert.equal(keyBytes('SHIFT-TAB', false), '\x1b[Z');
       assert.equal(keyBytes('S-Tab', false), '\x1b[Z');      // alias
+      assert.equal(keyBytes('backtab', false), '\x1b[Z');    // alias
+      assert.equal(keyBytes('BackTab', false), '\x1b[Z');    // case-insensitive alias
     });
 
     it('F3: maps the other added navigation/editing keys', function () {

--- a/test/longevity/event-loop-tolerance.test.js
+++ b/test/longevity/event-loop-tolerance.test.js
@@ -1,0 +1,137 @@
+'use strict';
+
+/**
+ * Regression tests for the event_loop gate's isolated-runner-stall tolerance.
+ *
+ * Background: the longevity PR-blocking smoke (5-min soak, 20s interval, ~15
+ * samples) flaked on shared Windows CI when an IDLE process (0 sessions, 0 ws,
+ * ~28MB RSS) hit ONE 20s window with p99 ~70ms / max ~1345ms — a single GC/OS
+ * scheduling stall, not app latency. The old `every(row.pass)` verdict failed
+ * the whole soak on that one window. The fix tolerates at most ONE isolated
+ * outlier window while still hard-failing every SUSTAINED signal: an extreme
+ * stall (max >= 2000ms), >= 2 CONSECUTIVE bad windows, or > 1 bad window total.
+ * Tolerance only applies with >= 10 samples.
+ *
+ * These tests pin that behavior so a future change can't silently widen the
+ * tolerance (masking real regressions) or revert it (re-introducing the flake).
+ */
+
+const assert = require('assert');
+
+const { GateEvaluator } = require('./harness/gate-evaluator');
+
+// One sample window = a p99_ms row + a max_ms row sharing a timestamp (the
+// sampler emits both per tick). tsOffsetMs spaces windows 20s apart, matching
+// the smoke's --interval=20s.
+function ingestWindow(evaluator, { p99, max }, tsOffsetMs) {
+  const ts = new Date(2026, 0, 1, 0, 0, 0, 0).getTime() + tsOffsetMs;
+  const iso = new Date(ts).toISOString();
+  evaluator.ingest({ ts: iso, gate: 'event_loop', metric: 'p99_ms', value: p99, threshold: 50, pass: p99 < 50 });
+  evaluator.ingest({ ts: iso, gate: 'event_loop', metric: 'max_ms', value: max, threshold: 200, pass: max < 200 });
+}
+
+// Build N windows from a generator(i) -> {p99, max}, 20s apart.
+function ingestWindows(evaluator, n, gen) {
+  for (let i = 0; i < n; i++) ingestWindow(evaluator, gen(i), i * 20_000);
+}
+
+function evalEventLoop(evaluator) {
+  return evaluator.evaluate().gates.find(g => g.name === 'event_loop');
+}
+
+const HEALTHY = () => ({ p99: 5, max: 30 });
+
+describe('Gate evaluator — event_loop isolated-stall tolerance', () => {
+  it('PASSes a clean 15-sample run (no bad windows)', () => {
+    const ev = new GateEvaluator({ gates: ['event_loop'] });
+    ingestWindows(ev, 15, HEALTHY);
+    const g = evalEventLoop(ev);
+    assert.strictEqual(g.pass, true, g.summary);
+    assert.strictEqual(g.bad_windows, 0);
+    assert.strictEqual(g.tolerated_outlier, false);
+  });
+
+  it('PASSes 15 samples with ONE isolated runner stall (the exact CI flake: p99 69.67, max 1345.32)', () => {
+    const ev = new GateEvaluator({ gates: ['event_loop'] });
+    ingestWindows(ev, 15, (i) => (i === 7 ? { p99: 69.67, max: 1345.32 } : HEALTHY()));
+    const g = evalEventLoop(ev);
+    assert.strictEqual(g.pass, true, `the one-stall CI scenario should PASS, got ${g.pass} (${g.summary})`);
+    assert.strictEqual(g.bad_windows, 1);
+    assert.strictEqual(g.tolerated_outlier, true, 'the outlier should be reported as tolerated');
+    assert.ok(Math.abs(g.max_peak_ms - 1345.32) < 0.01);
+    assert.ok(Math.abs(g.p99_peak_ms - 69.67) < 0.01);
+  });
+
+  it('counts a window breaching BOTH p99 and max as ONE bad window, not two', () => {
+    const ev = new GateEvaluator({ gates: ['event_loop'] });
+    ingestWindows(ev, 15, (i) => (i === 3 ? { p99: 120, max: 900 } : HEALTHY()));
+    const g = evalEventLoop(ev);
+    assert.strictEqual(g.bad_windows, 1, 'a window failing both metrics is one bad window');
+    assert.strictEqual(g.pass, true, g.summary);
+  });
+
+  it('FAILs on TWO non-consecutive bad windows (one p99-only, one max-only)', () => {
+    const ev = new GateEvaluator({ gates: ['event_loop'] });
+    ingestWindows(ev, 15, (i) => {
+      if (i === 4) return { p99: 80, max: 40 };
+      if (i === 11) return { p99: 5, max: 500 };
+      return HEALTHY();
+    });
+    const g = evalEventLoop(ev);
+    assert.strictEqual(g.pass, false, 'two separate bad windows should FAIL');
+    assert.strictEqual(g.bad_windows, 2);
+  });
+
+  it('FAILs on TWO CONSECUTIVE bad windows even within the count tolerance (sustained hot-loop)', () => {
+    const ev = new GateEvaluator({ gates: ['event_loop'] });
+    ingestWindows(ev, 15, (i) => (i === 6 || i === 7 ? { p99: 70, max: 250 } : HEALTHY()));
+    const g = evalEventLoop(ev);
+    assert.strictEqual(g.pass, false, 'consecutive bad windows should FAIL (sustained)');
+    assert.ok(g.max_consecutive_bad >= 2, `expected >=2 consecutive, got ${g.max_consecutive_bad}`);
+  });
+
+  it('FAILs on a sustained low-grade p99 hot-loop (many consecutive windows just over limit)', () => {
+    const ev = new GateEvaluator({ gates: ['event_loop'] });
+    ingestWindows(ev, 15, () => ({ p99: 55, max: 60 }));
+    const g = evalEventLoop(ev);
+    assert.strictEqual(g.pass, false, 'sustained p99 just-over-limit should FAIL');
+    assert.strictEqual(g.bad_windows, 15);
+  });
+
+  it('FAILs on an EXTREME isolated stall (max >= 2000ms ceiling) even as the only outlier', () => {
+    const ev = new GateEvaluator({ gates: ['event_loop'] });
+    ingestWindows(ev, 15, (i) => (i === 9 ? { p99: 90, max: 5000 } : HEALTHY()));
+    const g = evalEventLoop(ev);
+    assert.strictEqual(g.pass, false, 'an extreme 5s stall must FAIL despite being isolated');
+    assert.ok(/extreme/i.test(g.summary), `summary should cite the ceiling: ${g.summary}`);
+  });
+
+  it('tolerates an isolated stall right UP TO but under the 2000ms ceiling', () => {
+    const ev = new GateEvaluator({ gates: ['event_loop'] });
+    ingestWindows(ev, 15, (i) => (i === 2 ? { p99: 60, max: 1999 } : HEALTHY()));
+    const g = evalEventLoop(ev);
+    assert.strictEqual(g.pass, true, '1999ms < 2000ms ceiling should still be tolerated as one outlier');
+  });
+
+  it('does NOT tolerate the only bad window when sample count is below the floor (< 10 samples)', () => {
+    const ev = new GateEvaluator({ gates: ['event_loop'] });
+    ingestWindows(ev, 6, (i) => (i === 2 ? { p99: 69.67, max: 1345.32 } : HEALTHY()));
+    const g = evalEventLoop(ev);
+    assert.strictEqual(g.pass, false, 'with < 10 samples a single bad window should FAIL (no tolerance)');
+    assert.strictEqual(g.bad_windows, 1);
+  });
+
+  it('PASSes a clean short run below the sample floor (zero bad windows, no tolerance needed)', () => {
+    const ev = new GateEvaluator({ gates: ['event_loop'] });
+    ingestWindows(ev, 6, HEALTHY);
+    const g = evalEventLoop(ev);
+    assert.strictEqual(g.pass, true, g.summary);
+    assert.strictEqual(g.bad_windows, 0);
+  });
+
+  it('returns pass:null when there are no event-loop samples', () => {
+    const ev = new GateEvaluator({ gates: ['event_loop'] });
+    const g = evalEventLoop(ev);
+    assert.strictEqual(g.pass, null);
+  });
+});

--- a/test/longevity/harness/gates.js
+++ b/test/longevity/harness/gates.js
@@ -179,7 +179,7 @@ const GATES = [
 
   {
     name: 'event_loop',
-    description: 'perf_hooks histogram — p99 < 50ms; no sample > 200ms.',
+    description: 'perf_hooks histogram — p99 < 50ms; no sample > 200ms (one isolated runner stall tolerated, see evaluate).',
     metrics: [
       {
         name: 'p50_ms',
@@ -202,19 +202,117 @@ const GATES = [
         extract: ({ eventLoop }) => eventLoop && eventLoop.mean_ms,
       },
     ],
+    // The per-window p99/max come from a perf_hooks histogram that is RESET each
+    // sample tick, so each row is that one 20s window's worst-case event-loop
+    // delay — NOT a running aggregate. The old verdict was `every(row.pass)`:
+    // a SINGLE breaching window failed the whole soak. On a shared CI runner an
+    // IDLE process (0 sessions, 0 ws, ~28MB RSS) can hit one window with a
+    // ~1.3s GC/OS scheduling stall — runner noise, not app latency — and that
+    // one window pegs both its p99 (histogram dragged up) and its max. That
+    // tripped the PR-blocking smoke deterministically while Linux/macOS passed.
+    //
+    // Principled fix: tolerate at most ONE ISOLATED outlier window while keeping
+    // every SUSTAINED signal a hard FAIL. A real event-loop hot-loop pegs
+    // CONSECUTIVE 20s windows and/or many windows; an isolated GC pause does
+    // not. Concretely:
+    //   - A window is BAD if its p99 >= 50ms OR its max >= 200ms (union per
+    //     window — a single noisy window that breaches both metrics is still
+    //     ONE bad window, not two).
+    //   - HARD CEILING: any window with max >= 2000ms is an extreme stall and
+    //     ALWAYS fails, even as the single tolerated outlier — the gate must
+    //     still bound absolute worst-case latency (an isolated 1.3s stall is
+    //     tolerated; a 5s hang is never).
+    //   - SUSTAINED: >= 2 CONSECUTIVE bad windows (adjacent in time order) =>
+    //     FAIL. A hot-loop pegs back-to-back windows; isolated noise does not.
+    //   - COUNT: > 1 bad window total => FAIL.
+    //   - Tolerance only applies with >= 10 samples; below that we can't tell
+    //     noise from signal, so zero tolerance (any bad window => FAIL). The
+    //     5-min/20s smoke takes ~15 samples, comfortably above the floor; a
+    //     short ad-hoc soak stays strict.
+    // The per-row spotChecks above are left intact for diagnostics; only this
+    // end-of-run verdict changes.
     evaluate(rows) {
+      const P99_LIMIT_MS = 50;
+      const MAX_LIMIT_MS = 200;
+      // An isolated outlier is tolerated only up to this absolute ceiling; an
+      // extreme synchronous stall always fails so the gate still bounds
+      // worst-case latency (the observed runner noise was ~1.3s, well under).
+      const MAX_HARD_CEILING_MS = 2000;
+      const MIN_SAMPLES_FOR_TOLERANCE = 10;
+      const MAX_TOLERATED_BAD_WINDOWS = 1;
+
       const p99 = filterMetric(rows, 'p99_ms');
       const max = filterMetric(rows, 'max_ms');
       if (!p99.length || !max.length) return { pass: null, summary: 'no event-loop samples' };
+
       const p99Peak = Math.max(...p99.map(r => r.value));
       const maxPeak = Math.max(...max.map(r => r.value));
-      const p99Pass = p99.every(r => r.pass !== false);
-      const maxPass = max.every(r => r.pass !== false);
+
+      // Join p99 + max into per-window records keyed by timestamp so a window
+      // that breaches BOTH metrics counts once, not twice (filterMetric already
+      // sorted each metric ascending by ts).
+      const byTs = new Map();
+      for (const r of p99) {
+        const w = byTs.get(r.ts) || { ts: r.ts };
+        w.p99 = r.value;
+        byTs.set(r.ts, w);
+      }
+      for (const r of max) {
+        const w = byTs.get(r.ts) || { ts: r.ts };
+        w.max = r.value;
+        byTs.set(r.ts, w);
+      }
+      const windows = [...byTs.values()].sort((a, b) => a.ts - b.ts);
+      const sampleCount = windows.length;
+
+      const isBad = (w) => (w.p99 != null && w.p99 >= P99_LIMIT_MS) ||
+                           (w.max != null && w.max >= MAX_LIMIT_MS);
+      const badWindows = windows.filter(isBad);
+
+      // Extreme stall — never tolerated, regardless of count/adjacency.
+      const extreme = windows.some(w => w.max != null && w.max >= MAX_HARD_CEILING_MS);
+
+      // Sustained — >= 2 consecutive bad windows in time order.
+      let consecutiveBad = 0, maxConsecutiveBad = 0;
+      for (const w of windows) {
+        if (isBad(w)) { consecutiveBad++; if (consecutiveBad > maxConsecutiveBad) maxConsecutiveBad = consecutiveBad; }
+        else consecutiveBad = 0;
+      }
+      const sustained = maxConsecutiveBad >= 2;
+
+      // Tolerance only kicks in with enough samples to separate noise from signal.
+      const toleranceApplies = sampleCount >= MIN_SAMPLES_FOR_TOLERANCE;
+      const withinCount = toleranceApplies
+        ? badWindows.length <= MAX_TOLERATED_BAD_WINDOWS
+        : badWindows.length === 0;
+
+      const pass = !extreme && !sustained && withinCount;
+
+      const tolerated = pass && badWindows.length > 0;
+      const reasons = [];
+      if (extreme) reasons.push(`extreme stall (max ≥ ${MAX_HARD_CEILING_MS}ms)`);
+      if (sustained) reasons.push(`${maxConsecutiveBad} consecutive bad windows (sustained)`);
+      if (!withinCount && !extreme && !sustained) {
+        reasons.push(toleranceApplies
+          ? `${badWindows.length} bad windows (> ${MAX_TOLERATED_BAD_WINDOWS} tolerated)`
+          : `${badWindows.length} bad windows with only ${sampleCount} samples (< ${MIN_SAMPLES_FOR_TOLERANCE}; no tolerance)`);
+      }
+
+      const summary = pass
+        ? `event-loop OK: ${badWindows.length}/${sampleCount} bad windows`
+          + (tolerated ? ` (1 isolated runner outlier tolerated)` : ``)
+          + `; raw p99 peak ${p99Peak.toFixed(2)}ms (limit ${P99_LIMIT_MS}), raw max peak ${maxPeak.toFixed(2)}ms (limit ${MAX_LIMIT_MS}, ceiling ${MAX_HARD_CEILING_MS})`
+        : `event-loop FAIL: ${reasons.join('; ')}; ${badWindows.length}/${sampleCount} bad windows, raw p99 peak ${p99Peak.toFixed(2)}ms (limit ${P99_LIMIT_MS}), raw max peak ${maxPeak.toFixed(2)}ms (limit ${MAX_LIMIT_MS}, ceiling ${MAX_HARD_CEILING_MS})`;
+
       return {
-        pass: p99Pass && maxPass,
-        summary: `event-loop p99 peak ${p99Peak.toFixed(2)}ms (limit 50), single-sample peak ${maxPeak.toFixed(2)}ms (limit 200)`,
+        pass,
+        summary,
         p99_peak_ms: p99Peak,
         max_peak_ms: maxPeak,
+        bad_windows: badWindows.length,
+        samples: sampleCount,
+        max_consecutive_bad: maxConsecutiveBad,
+        tolerated_outlier: tolerated,
       };
     },
   },

--- a/test/sticky-note-server-wiring.test.js
+++ b/test/sticky-note-server-wiring.test.js
@@ -213,6 +213,46 @@ describe('sticky-note server wiring', function () {
     assert.strictEqual(self._summarizerCalls[1][0], 'enable');
   });
 
+  it('DECOUPLE: _maybeStartStickyNotes starts the JSONL poll even with the engine OFF, without enabling the summariser', function () {
+    let pollStarted = 0;
+    const self = makeStub({
+      stickyNoteEngine: { _enabled: false, getStatus: () => 'unavailable', getDownloadProgress: () => null },
+      _startStickyJsonlPoll: () => { pollStarted++; },
+    });
+    self.claudeSessions.set('ctl', { stickyNotesEnabled: true, stickyNote: null });
+    ClaudeCodeWebServer.prototype._maybeStartStickyNotes.call(self, 'ctl', 'claude', 80, 24);
+    // The model-free binding + turn-detection pump must run for control/fleet claude
+    // sessions regardless of the optional summariser engine.
+    assert.strictEqual(pollStarted, 1, 'JSONL poll started so binding/turn detection runs');
+    assert.strictEqual(
+      self._summarizerCalls.filter((c) => c[0] === 'enable').length, 0,
+      'summariser NOT enabled when the engine is off',
+    );
+  });
+
+  it('DECOUPLE: _maybeStartStickyNotes still binds a sidecar-bound claude session that opted OUT of sticky notes (engine off)', function () {
+    let pollStarted = 0;
+    const self = makeStub({
+      stickyNoteEngine: { _enabled: false, getStatus: () => 'unavailable', getDownloadProgress: () => null },
+      _startStickyJsonlPoll: () => { pollStarted++; },
+    });
+    // stickyNotesEnabled:false (e.g. AIORDIE_DISABLE_STICKY_NOTES=1) + a bind sidecar:
+    // turn-binding is a control-plane need and must not be defeated by the opt-out.
+    self.claudeSessions.set('ctl', { stickyNotesEnabled: false, claudeBindSidecar: '/x/ctl.json', stickyNote: null });
+    ClaudeCodeWebServer.prototype._maybeStartStickyNotes.call(self, 'ctl', 'claude', 80, 24);
+    assert.strictEqual(pollStarted, 1, 'poll started for control-plane binding despite opt-out + engine off');
+    assert.strictEqual(self._summarizerCalls.filter((c) => c[0] === 'enable').length, 0, 'summariser NOT enabled');
+  });
+
+  it('_maybeStartStickyNotes skips an opted-out tab with NO bind sidecar', function () {
+    let pollStarted = 0;
+    const self = makeStub({ _startStickyJsonlPoll: () => { pollStarted++; } });
+    self.claudeSessions.set('off', { stickyNotesEnabled: false, stickyNote: null }); // opted out, no sidecar
+    ClaudeCodeWebServer.prototype._maybeStartStickyNotes.call(self, 'off', 'claude', 80, 24);
+    assert.strictEqual(pollStarted, 0, 'no binding need + opted out → nothing started');
+    assert.strictEqual(self._summarizerCalls.filter((c) => c[0] === 'enable').length, 0);
+  });
+
   it('_onStickyNoteResult mirrors the note into _claudeNotes by claude sessionId', function () {
     const self = makeStub();
     self._claudeNotes = new Map();
@@ -342,17 +382,98 @@ describe('sticky-note JSONL binding (ownership + resume)', function () {
     assert.strictEqual(self._stickyJsonl.get('tab1').file, bfile);
   });
 
-  it('SIDECAR: waits (no inference) when the transcript file does not exist yet', async function () {
+  it('SIDECAR: identity-binds (pending) when the transcript file does not exist yet — never the stranger', async function () {
     const cwd = '/Users/x/proj';
-    writeSession(cwd, 'stranger.jsonl', null, 1); // a stranger session that inference would grab
+    const stranger = writeSession(cwd, 'stranger.jsonl', null, 1); // inference would grab this
     const self = makeBindStub();
     const sidecar = path.join(dir, 'tab1.json');
+    const nope = path.join(dir, 'nope', 'pending.jsonl');
     fs.writeFileSync(sidecar, JSON.stringify({
-      schema: 1, claudeSessionId: 'pending', transcriptPath: path.join(dir, 'nope', 'pending.jsonl'), cwd, event: 'start', at: Date.now(),
+      schema: 1, claudeSessionId: 'pending', transcriptPath: nope, cwd, event: 'start', at: Date.now(),
     }));
     self.claudeSessions.set('tab1', { nameIsUserSet: false, claudeBindSidecar: sidecar });
     await self._pumpStickyJsonl('tab1', cwd);
-    assert.strictEqual(self._stickyJsonl.get('tab1'), undefined, 'does NOT bind to the stranger session while waiting');
+    const b = self._stickyJsonl.get('tab1');
+    // Claude Code creates the .jsonl only on the FIRST turn, so a fresh idle fleet
+    // session has a sidecar but no transcript yet. Bind on the sidecar IDENTITY
+    // immediately (so it reports bound:true for the readiness barrier), pending the
+    // transcript — and crucially bound to its OWN session, never the stranger.
+    assert.ok(b, 'identity-bound even though the transcript does not exist yet');
+    assert.strictEqual(b.claudeSessionId, 'pending', 'binds the sidecar session, not the stranger');
+    assert.strictEqual(b.file, null, 'no transcript file yet');
+    assert.strictEqual(b.transcriptPending, true, 'marked transcript-pending');
+    assert.strictEqual(b.pendingTranscriptPath, nope);
+    assert.notStrictEqual(b.file, stranger, 'never adopts the stranger transcript');
+    assert.strictEqual(self.claudeSessions.get('tab1').claudePinnedSessionId, 'pending', 'reserved so other tabs cannot steal it');
+  });
+
+  it('SIDECAR: promotes a pending bind to a full tail once the transcript appears', async function () {
+    const cwd = '/Users/x/proj';
+    const self = makeBindStub();
+    const sidecar = path.join(dir, 'tab1.json');
+    const tp = path.join(dir, 'late', 'appears.jsonl');
+    fs.writeFileSync(sidecar, JSON.stringify({
+      schema: 1, claudeSessionId: 'late', transcriptPath: tp, cwd, event: 'start', at: Date.now(),
+    }));
+    self.claudeSessions.set('tab1', { nameIsUserSet: false, claudeBindSidecar: sidecar });
+    // Tick 1: transcript absent → pending identity bind (stays bound, nothing to tail).
+    await self._pumpStickyJsonl('tab1', cwd);
+    let b = self._stickyJsonl.get('tab1');
+    assert.ok(b && b.transcriptPending === true && b.file === null, 'pending after tick 1');
+    // Claude's first turn creates the .jsonl.
+    fs.mkdirSync(path.dirname(tp), { recursive: true });
+    fs.writeFileSync(tp, JSON.stringify({ type: 'user', message: { role: 'user', content: 'hi' } }) + '\n');
+    // Tick 2: the same binding promotes to a full tail (same identity, real file).
+    await self._pumpStickyJsonl('tab1', cwd);
+    b = self._stickyJsonl.get('tab1');
+    assert.ok(b, 'still bound after promotion');
+    assert.strictEqual(b.transcriptPending, false, 'no longer pending');
+    assert.strictEqual(b.file, tp, 'promoted to the real transcript file');
+    assert.strictEqual(b.claudeSessionId, 'late', 'same identity across promotion');
+  });
+
+  it('SIDECAR: a pending bind follows a transcriptPath that drifts under the same session id (never stranded)', async function () {
+    const cwd = '/Users/x/proj';
+    const self = makeBindStub();
+    const sidecar = path.join(dir, 'tab1.json');
+    const wrong = path.join(dir, 'wrong', 'a.jsonl'); // never created
+    const right = path.join(dir, 'right', 'a.jsonl');
+    fs.writeFileSync(sidecar, JSON.stringify({ schema: 1, claudeSessionId: 'cs', transcriptPath: wrong, cwd, event: 'start', at: Date.now() }));
+    self.claudeSessions.set('tab1', { nameIsUserSet: false, claudeBindSidecar: sidecar });
+    await self._pumpStickyJsonl('tab1', cwd);
+    let b = self._stickyJsonl.get('tab1');
+    assert.ok(b && b.transcriptPending && b.pendingTranscriptPath === wrong, 'pending on the first (wrong) path');
+    // The sidecar is rewritten with a corrected transcriptPath (SAME session id).
+    fs.writeFileSync(sidecar, JSON.stringify({ schema: 1, claudeSessionId: 'cs', transcriptPath: right, cwd, event: 'start', at: Date.now() }));
+    const t = Date.now() / 1000 + 5; fs.utimesSync(sidecar, t, t);
+    await self._pumpStickyJsonl('tab1', cwd);
+    b = self._stickyJsonl.get('tab1');
+    assert.strictEqual(b.pendingTranscriptPath, right, 'followed the corrected path, not stranded on the wrong one');
+  });
+
+  it('DECOUPLE: _pollStickyJsonl pumps a sidecar-bound claude session even when the summariser is OFF and the tab opted out', async function () {
+    const pumped = [];
+    const srv = {
+      _pollingStickyJsonl: false,
+      dev: false,
+      claudeSessions: new Map([
+        // claude + sidecar + EXPLICITLY opted out (e.g. AIORDIE_DISABLE_STICKY_NOTES=1)
+        // → STILL pumped: turn-binding is a control-plane invariant, not a UI feature.
+        ['ctl', { active: true, agent: 'claude', claudeBindSidecar: '/x/ctl.json', workingDir: '/proj', stickyNotesEnabled: false }],
+        ['ui', { active: true, agent: 'claude', workingDir: '/proj' }],            // claude, no sidecar
+        ['term', { active: true, agent: 'terminal', claudeBindSidecar: '/x/t.json', workingDir: '/proj' }],
+      ]),
+      // summariser disabled for everyone (e.g. --no-sticky-notes / node-llama-cpp missing)
+      stickyNoteSummarizer: { isEnabled: () => false },
+      _isAiAgent: ClaudeCodeWebServer.prototype._isAiAgent,
+      _isStickyEligible: ClaudeCodeWebServer.prototype._isStickyEligible,
+      _pumpStickyJsonl: async (id) => { pumped.push(id); },
+    };
+    await ClaudeCodeWebServer.prototype._pollStickyJsonl.call(srv);
+    // Only the sidecar-bound CLAUDE session is pumped for binding/turn events even
+    // with the summariser off and the tab opted out; a no-sidecar claude and a
+    // terminal (no claude binding) are skipped.
+    assert.deepStrictEqual(pumped.sort(), ['ctl']);
   });
 
   it('SIDECAR: _ownedClaudeSessions reserves a tab pinned via sidecar', function () {


### PR DESCRIPTION
Cluster-4 scale workstream for the fleet control plane: per-session event retention with atomic snapshot+cursor resync (F15), per-session steering mutex (F16), capabilities negotiation endpoint (F19), classifiable 429 rate-limiting (F21), and stateless per-watcher long-poll cursors (F22).

## Contract audit
Two wire-shape divergences from the frozen control-plane contract were fixed:
- GET /api/control/capabilities now emits `{ capabilities: string[], controlVersion: string }` (6 snake_case tokens) — was an object-of-booleans the consumer's `new Set(...)` would have thrown on, silently degrading capability negotiation to fail-open.
- The create-path INVALID_ARGUMENT now returns a structured `400 {error:{code,message}}` — was Express's default HTML body, so the consumer surfaced an HTML blob instead of the actionable validation reason.

## Cross-lab review fixes
- CRITICAL: a fresh (cursor-less) long-poll watcher dropped the event that woke it (since(undefined) re-resolved empty and advanced past the event). waitFor now anchors a baseline cursor to head so the waking event is delivered exactly once.
- Filter-aware overflow: a session-filtered watcher no longer reports overflow caused by another session's eviction (per-bucket evicted watermark), and returned events never contradict the reported gap (collect after max(cursor, floor)).
- Present-but-invalid /events cursor → 400 INVALID_ARGUMENT (absent cursor → fresh watcher).
- 0/omitted timeout no longer hot-loops via setTimeout(0).

## Verification
- Full gate: 1619 passing, 0 failing (the prior outage-stalled E2E now passes normally).
- 9-scenario acceptance matrix: 7 PASS on the ai-or-die side (each citing a named green test), 1 PARTIAL (clean-HOME startup — theme/onboarding suppression is github-router's synthetic config), 1 covered in the github-router client repo (no-host vs wrong-URL diagnosis).

## Failure modes considered and tested
Fresh-watcher first-poll event delivery; concurrent same-session steering interleave; cursor-gap overflow + snapshot resync; present-but-invalid cursor; 0/omitted timeout; filtered vs unfiltered overflow boundary; capabilities Set()-safety; the previously outage-stalled multi-session WebSocket E2E.
