### PR TITLE
Activate artifact-review panel for standalone (manual tab) + auto live-reload

### DIFF
--- a/src/artifact-review.js
+++ b/src/artifact-review.js
@@ -487,7 +487,45 @@ function createArtifactReviewRouter(options) {
   if (typeof validatePath !== 'function') throw new TypeError('validatePath is required');
   if (typeof mintAssetToken !== 'function') throw new TypeError('mintAssetToken is required');
 
+  // Auto live-reload: one chokidar watcher per session, scoped to the canonical
+  // artifact file. On a settled write we broadcast a reload SIGNAL (the panel
+  // cache-busts the iframe; the feedback box lives outside it and survives).
+  // Capped, replaced on re-open, and torn down on /end. Best-effort: chokidar
+  // is loaded lazily so tests/headless runs without it degrade to no reload.
+  const MAX_WATCHERS = 64;
+  const watchers = new Map(); // sessionId -> { watcher, file }
+  function stopWatch(sessionId) {
+    const w = watchers.get(sessionId);
+    if (!w) return;
+    watchers.delete(sessionId);
+    try { w.watcher.close(); } catch (_) { /* already closed */ }
+  }
+  function startWatch(sessionId, file) {
+    const existing = watchers.get(sessionId);
+    if (existing) { if (existing.file === file) return; stopWatch(sessionId); }
+    if (watchers.size >= MAX_WATCHERS) { const first = watchers.keys().next().value; if (first) stopWatch(first); }
+    let chokidar;
+    try { chokidar = require('chokidar'); } catch (_) { return; }
+    let watcher;
+    try {
+      watcher = chokidar.watch(file, {
+        ignoreInitial: true,
+        depth: 0,
+        awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 30 },
+      });
+    } catch (_) { return; }
+    const onChange = () => {
+      if (!store.get(sessionId)) { stopWatch(sessionId); return; }
+      broadcastToSession(sessionId, { type: 'artifact_review_reload', sessionId });
+    };
+    watcher.on('change', onChange);
+    watcher.on('add', onChange);
+    watcher.on('error', () => stopWatch(sessionId));
+    watchers.set(sessionId, { watcher, file });
+  }
+
   const router = express.Router();
+
 
   router.post('/:sessionId/open', (req, res) => {
     const sessionId = req.params.sessionId;
@@ -510,6 +548,7 @@ function createArtifactReviewRouter(options) {
     }
 
     const review = store.open(sessionId, validation.path);
+    startWatch(sessionId, validation.path);
     const viewUrl = artifactPath(sessionId, '/view', req);
     broadcastToSession(sessionId, {
       type: 'artifact_review_opened',
@@ -688,6 +727,7 @@ function createArtifactReviewRouter(options) {
   router.post('/:sessionId/end', (req, res) => {
     const sessionId = req.params.sessionId;
     const review = store.end(sessionId);
+    stopWatch(sessionId);
     if (!review) return res.status(404).json({ error: 'artifact review not found' });
     broadcastToSession(sessionId, { type: 'artifact_review_ended', sessionId });
     res.json({ ok: true, status: review.status });

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -2738,6 +2738,10 @@ class ClaudeCodeWebInterface {
                 if (this._artifactPanel) this._artifactPanel.endReview(message);
                 break;
 
+            case 'artifact_review_reload':
+                if (this._artifactPanel) this._artifactPanel.reloadReview(message);
+                break;
+
             case 'artifact_agent_reply':
                 if (this._artifactPanel) this._artifactPanel.agentReply(message);
                 break;

--- a/src/public/artifact-panel.js
+++ b/src/public/artifact-panel.js
@@ -172,6 +172,14 @@
       this._iframe.src = review.viewUrl + sep + '_r=' + Date.now();
     }
 
+    // Server-driven auto live-reload: file changed under review. Only the active
+    // tab's iframe is cache-busted; the chat/feedback box is untouched.
+    reloadReview(message) {
+      const sessionId = message && message.sessionId ? String(message.sessionId) : this.activeSessionId;
+      if (!sessionId || sessionId !== this.activeSessionId || !this.reviews.has(sessionId)) return;
+      this.reload();
+    }
+
     // ---- iframe <-> server bridge ----------------------------------------
     _handleIframeMessage(event) {
       const data = event && event.data;

--- a/src/server.js
+++ b/src/server.js
@@ -5159,6 +5159,19 @@ class ClaudeCodeWebServer {
         if (sidecarPath) terminalExtraEnv.AIORDIE_CLAUDE_BIND = sidecarPath;
       }
 
+      // Artifact-review parity for the manual (non-fleet) claude tab: a normally
+      // started claude tab gets the same env trio that _controlStartAgent injects,
+      // so the in-tab agent's artifact_* tools activate standalone — no control
+      // plane required. Always-on when auth is set; never injected without auth
+      // (so the artifact routes stay non-public). Token leak to nested children
+      // is blocked by github-router's STRIPPED_PARENT_ENV_KEYS.
+      const claudeArtifactEnv = {};
+      if (toolName === 'claude' && this.auth) {
+        claudeArtifactEnv.AIORDIE_BASE_URL = `${this.useHttps ? 'https' : 'http'}://127.0.0.1:${this.port}`;
+        claudeArtifactEnv.AIORDIE_TOKEN = this.auth;
+        claudeArtifactEnv.AIORDIE_SESSION_ID = sessionId;
+      }
+
       const osc7Hooks = (toolName === 'terminal') ? {
         validatePath: (p) => this.validatePath(p),
         onCwdChange: (cwd, prev) => {
@@ -5238,12 +5251,11 @@ class ClaudeCodeWebServer {
           this.broadcastSessionActivity(sessionId, 'session_error');
         },
         ...options,
-        extraEnv: toolName === 'terminal'
-          ? {
-              ...((options.extraEnv && typeof options.extraEnv === 'object') ? options.extraEnv : {}),
-              ...terminalExtraEnv,
-            }
-          : options.extraEnv
+        extraEnv: {
+          ...((options.extraEnv && typeof options.extraEnv === 'object') ? options.extraEnv : {}),
+          ...terminalExtraEnv,
+          ...claudeArtifactEnv,
+        }
       });
 
       session.lastActivity = new Date();

--- a/test/artifact-panel.test.js
+++ b/test/artifact-panel.test.js
@@ -165,4 +165,15 @@ describe('artifact-panel.js (DOM: iframe + SSE + postMessage bridge)', function 
     panel.notifyActiveSessionChanged('sid-1');
     assert.equal(panel.el.hidden, false);
   });
+
+  it('reloadReview() cache-busts the active iframe and ignores other/inactive sessions', function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: '/api/artifact/sid-1/view' });
+    const before = panel._iframe.src;
+    panel.reloadReview({ sessionId: 'sid-2' }); // foreign session: no-op
+    assert.equal(panel._iframe.src, before);
+    panel.reloadReview({ sessionId: 'sid-1' }); // active: cache-busted
+    assert.ok(panel._iframe.src.includes('_r='), 'iframe src should be cache-busted');
+  });
 });


### PR DESCRIPTION
## What
Makes the artifact-review panel work on a standalone single machine — no fleet/control plane required.

- **Activation:** `startToolSession` injects the artifact env trio (`AIORDIE_BASE_URL`/`AIORDIE_TOKEN`/`AIORDIE_SESSION_ID`) for a manually started `claude` tab when auth is set, mirroring `_controlStartAgent`. Always-on when authed; never injected without auth (artifact routes stay non-public).
- **Auto live-reload:** per-session chokidar watcher on the artifact file (awaitWriteFinish, capped, closed on end) broadcasts `artifact_review_reload`; the panel cache-busts the iframe while the feedback box survives.

## Verified
- Standalone run on port 11888 (authed): full loop open→view(live edit)→end over the API; traversal guard intact.
- Trio injection smoke test: present for claude tab, absent for terminal.
- Tests 19/19 (incl. new reloadReview).

Pairs with github-router `artifact_end` tool. Follow-up: scoped per-session token (v1 reuses global token = parity).