### PR TITLE
fix: artifact viewer under --disable-auth + repaint tab on refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-or-die",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-or-die",
-      "version": "0.1.81",
+      "version": "0.1.82",
       "license": "MIT",
       "dependencies": {
         "@lydell/node-pty": "1.2.0-beta.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-or-die",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "description": "Universal AI coding terminal — Claude, Copilot, Gemini & more in your browser",
   "main": "src/server.js",
   "bin": {

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -286,8 +286,13 @@ class ClaudeCodeWebInterface {
         console.log('[Init] Checking sessions, tabs.size:', this.sessionTabManager.tabs.size);
         if (this.sessionTabManager.tabs.size > 0) {
             console.log('[Init] Found sessions, switching to first tab...');
-            // Sessions exist - switch to the first one (this will handle connecting)
-            const firstTabId = this.sessionTabManager.tabs.keys().next().value;
+            // Sessions exist - switch to the last-active one (persisted across
+            // reloads) so a refresh returns to the tab you were on, not tab #1.
+            let restoreId = null;
+            try { restoreId = localStorage.getItem('cc-active-session'); } catch (_) { /* private mode */ }
+            const firstTabId = (restoreId && this.sessionTabManager.tabs.has(restoreId))
+                ? restoreId
+                : this.sessionTabManager.tabs.keys().next().value;
             console.log('[Init] Switching to tab:', firstTabId);
             await this.sessionTabManager.switchToTab(firstTabId);
             // The session_joined handler decides the overlay state:
@@ -2524,8 +2529,13 @@ class ClaudeCodeWebInterface {
                     this.pendingJoinSessionId = null;
                 }
                 
-                // Replay output buffer if available
-                if (message.outputBuffer && message.outputBuffer.length > 0) {
+                // Repaint: prefer the rendered snapshot (clean last screen) so a
+                // refresh doesn't blank or show broken control sequences; fall
+                // back to raw outputBuffer replay when there's no snapshot.
+                if (message.renderedSnapshot) {
+                    this.terminal.clear();
+                    this.terminal.write(message.renderedSnapshot.replace(/\n/g, '\r\n'));
+                } else if (message.outputBuffer && message.outputBuffer.length > 0) {
                     this.terminal.clear();
                     message.outputBuffer.forEach(data => {
                         // Filter out focus tracking sequences (^[[I and ^[[O)

--- a/src/public/session-manager.js
+++ b/src/public/session-manager.js
@@ -737,6 +737,7 @@ class SessionTabManager {
         tab.classList.add('active');
         tab.setAttribute('aria-selected', 'true');
         this.activeTabId = sessionId;
+        try { localStorage.setItem('cc-active-session', sessionId); } catch (_) { /* private mode */ }
         this.ensureTabVisible(sessionId);
 
         // Update last accessed timestamp and clear unread indicator

--- a/src/server.js
+++ b/src/server.js
@@ -3944,7 +3944,12 @@ class ClaudeCodeWebServer {
     this._pushEvictionEntry(claudeSessionId); // PROC-04
     session.lastAccessed = Date.now();
 
-    // Send session info and replay buffer
+    // Send session info and replay buffer. Prefer a live rendered tail, but
+    // never block the join on a slow drain — fall back to the stored snapshot.
+    let renderedSnapshot = session.renderedSnapshot || null;
+    if (session._ctlTranscript) {
+      renderedSnapshot = (await this._peekWithTimeout(session._ctlTranscript, 200, 300)) || renderedSnapshot;
+    }
     this.sendToWebSocket(wsInfo.ws, {
       type: 'session_joined',
       sessionId: claudeSessionId,
@@ -3954,6 +3959,7 @@ class ClaudeCodeWebServer {
       wasActive: session.wasActive || false,
       agent: session.agent || null,
       outputBuffer: session.outputBuffer.slice(-200), // Send last 200 lines
+      renderedSnapshot, // rendered last screen so idle/empty-buffer joins repaint
       stickyNote: session.stickyNote || null,
       autoTitle: session.nameIsUserSet ? null : (session.autoTitle || null),
       stickyNotesEnabled: session.stickyNotesEnabled !== false,
@@ -4462,6 +4468,43 @@ class ClaudeCodeWebServer {
     setTimeout(tick, 1500);
   }
 
+  // Artifact-review env trio for a spawned claude session. Injected whenever the
+  // server can serve /api/artifact — that's when auth is set OR auth is disabled
+  // (noAuth leaves the routes public, server.js:1179). Without it the in-tab
+  // agent's artifact_* tools stay dark and the viewer never opens. Token is the
+  // real bearer, or a 'noauth' sentinel under --disable-auth (the routes ignore
+  // it). Returns {} when the server is closed (auth required but unset), so a
+  // misconfigured instance never points the agent at routes it can't reach.
+  _artifactEnvForSession(sessionId) {
+    if (!this.auth && !this.noAuth) return {};
+    return {
+      AIORDIE_BASE_URL: `${this.useHttps ? 'https' : 'http'}://127.0.0.1:${this.port}`,
+      AIORDIE_TOKEN: this.auth || 'noauth',
+      AIORDIE_SESSION_ID: sessionId,
+    };
+  }
+
+  // Read a transcript's rendered tail, but never block longer than `ms` — a
+  // wedged xterm drain must not stall a join or strand a dispose. Resolves null
+  // on timeout/error so callers fall back to the stored snapshot.
+  _peekWithTimeout(t, lines, ms) {
+    return Promise.race([
+      Promise.resolve().then(() => t.peek(lines)).catch(() => null),
+      new Promise((r) => setTimeout(() => r(null), ms)),
+    ]);
+  }
+
+  // Capture the last rendered screen, then ALWAYS dispose — so a refresh
+  // repaints an exited session, without leaking the buffer if peek hangs.
+  _persistSnapshotAndDispose(s) {
+    const t = s._ctlTranscript;
+    if (!t) return;
+    s._ctlTranscript = null;
+    this._peekWithTimeout(t, 200, 1000)
+      .then((snap) => { if (snap) s.renderedSnapshot = snap; })
+      .finally(() => { try { t.dispose(); } catch (_) { /* already disposed */ } });
+  }
+
   // Headless agent spawn (no WebSocket): reuses the same bridge.startSession +
   async _controlStartAgent(sessionId, toolName, opts = {}) {
     const session = this.claudeSessions.get(sessionId);
@@ -4500,12 +4543,9 @@ class ClaudeCodeWebServer {
       const sidecar = this._prepareClaudeBindSidecar(sessionId, session);
       if (sidecar) extraEnv.AIORDIE_CLAUDE_BIND = sidecar; // deterministic JSONL turn detection (ADR-0026)
     } catch (_) { /* sidecar best-effort */ }
-    if (this.auth) {
-      // So a github-router-claude spawned here can drive the artifact-review loop.
-      extraEnv.AIORDIE_BASE_URL = `${this.useHttps ? 'https' : 'http'}://127.0.0.1:${this.port}`;
-      extraEnv.AIORDIE_TOKEN = this.auth;
-      extraEnv.AIORDIE_SESSION_ID = sessionId;
-    }
+    // So a github-router-claude spawned here can drive the artifact-review loop
+    // (works standalone and under --disable-auth; see _artifactEnvForSession).
+    Object.assign(extraEnv, this._artifactEnvForSession(sessionId));
 
     try { session._ctlTranscript = new TranscriptBuffer({ cols, rows }); } catch (_) { session._ctlTranscript = null; }
     session.active = true;
@@ -4540,7 +4580,9 @@ class ClaudeCodeWebServer {
             s.agent = null;
             s._lastExit = { code, signal };
             this.sessionStore.markDirty();
-            try { if (s._ctlTranscript) { s._ctlTranscript.dispose(); s._ctlTranscript = null; } } catch (_) { /* isolate */ }
+            // Persist the last rendered screen before disposing so a refresh
+            // repaints an idle/exited session instead of blank (always disposes).
+            this._persistSnapshotAndDispose(s);
             // F12: stop the coarse idle-debounce timer for unbound sessions.
             try { if (s._ctlIdleTimer) { clearTimeout(s._ctlIdleTimer); s._ctlIdleTimer = null; } } catch (_) { /* isolate */ }
           }
@@ -5162,15 +5204,15 @@ class ClaudeCodeWebServer {
       // Artifact-review parity for the manual (non-fleet) claude tab: a normally
       // started claude tab gets the same env trio that _controlStartAgent injects,
       // so the in-tab agent's artifact_* tools activate standalone — no control
-      // plane required. Always-on when auth is set; never injected without auth
-      // (so the artifact routes stay non-public). Token leak to nested children
-      // is blocked by github-router's STRIPPED_PARENT_ENV_KEYS.
-      const claudeArtifactEnv = {};
-      if (toolName === 'claude' && this.auth) {
-        claudeArtifactEnv.AIORDIE_BASE_URL = `${this.useHttps ? 'https' : 'http'}://127.0.0.1:${this.port}`;
-        claudeArtifactEnv.AIORDIE_TOKEN = this.auth;
-        claudeArtifactEnv.AIORDIE_SESSION_ID = sessionId;
-      }
+      // plane required. Injected when auth is set OR --disable-auth (routes are
+      // public then), so the viewer works standalone. Token leak to nested
+      // children is blocked by github-router's STRIPPED_PARENT_ENV_KEYS.
+      const claudeArtifactEnv = toolName === 'claude' ? this._artifactEnvForSession(sessionId) : {};
+
+      // Rendered-screen buffer so a refresh/reconnect can repaint the last
+      // screen even when the session is idle and the raw outputBuffer is empty
+      // (manual-tab parity with the control path; mirrors 4523).
+      try { session._ctlTranscript = new TranscriptBuffer({ cols: cols || 80, rows: rows || 24 }); } catch (_) { session._ctlTranscript = null; }
 
       const osc7Hooks = (toolName === 'terminal') ? {
         validatePath: (p) => this.validatePath(p),
@@ -5202,6 +5244,7 @@ class ClaudeCodeWebServer {
           const currentSession = this.claudeSessions.get(sessionId);
           if (!currentSession) return;
           currentSession.outputBuffer.push(data);
+          try { if (currentSession._ctlTranscript) currentSession._ctlTranscript.write(data); } catch (_) { /* isolate */ }
           this.sessionStore.markDirty();
           this._throttledOutputBroadcast(sessionId, data);
           // Tap for the local-LLM summariser (off the hot path: this only
@@ -5231,6 +5274,9 @@ class ClaudeCodeWebServer {
             currentSession.agent = null;
             currentSession._lastExit = { code, signal };
             this.sessionStore.markDirty();
+            // Persist the last rendered screen before disposing so a later
+            // refresh/join repaints an idle session instead of going blank.
+            this._persistSnapshotAndDispose(currentSession);
           }
           // Final sticky-note flush to capture the "done" state, then stop.
           this.stickyNoteSummarizer.flushExit(sessionId);

--- a/src/sticky-note-transcript.js
+++ b/src/sticky-note-transcript.js
@@ -99,6 +99,31 @@ class TranscriptBuffer {
     return result;
   }
 
+  /**
+   * Like snapshot() but does NOT reset the new-output counters — a read-only
+   * view of the rendered tail for repaint-on-join, so it never steals delta
+   * lines from the sticky-note volume trigger.
+   * @param {number} [maxLines]
+   * @returns {Promise<string>}
+   */
+  async peek(maxLines) {
+    const limit = maxLines || this._maxDeltaLines;
+    await this._drain();
+    const buf = this._term.buffer.active;
+    const cursorRow = buf.baseY + buf.cursorY;
+    const rowText = (i) => {
+      const line = buf.getLine(i);
+      return line ? line.translateToString(true) : '';
+    };
+    let lastNonEmpty = cursorRow;
+    while (lastNonEmpty >= 0 && rowText(lastNonEmpty) === '') lastNonEmpty--;
+    if (lastNonEmpty < 0) return '';
+    const start = Math.max(0, lastNonEmpty - limit + 1);
+    const lines = [];
+    for (let i = start; i <= lastNonEmpty; i++) lines.push(rowText(i));
+    return lines.join('\n');
+  }
+
   /** Resolve once xterm has parsed everything written so far. */
   _drain() {
     return new Promise((resolve) => this._term.write('', resolve));

--- a/test/artifact-env-disable-auth.test.js
+++ b/test/artifact-env-disable-auth.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// Fix A: artifact-review env trio must inject for a standalone instance under
+// --disable-auth (noAuth), not just an authed one — otherwise the in-tab
+// agent's artifact_* tools stay dark and the viewer never opens.
+
+const assert = require('assert');
+const { ClaudeCodeWebServer } = require('../src/server');
+
+describe('artifact env trio (--disable-auth)', function () {
+  it('injects the trio with a sentinel token when auth is disabled', function () {
+    const server = new ClaudeCodeWebServer({ noAuth: true, port: 7777, https: true });
+    const env = server._artifactEnvForSession('sess-1');
+    assert.strictEqual(env.AIORDIE_BASE_URL, 'https://127.0.0.1:7777');
+    assert.strictEqual(env.AIORDIE_TOKEN, 'noauth');
+    assert.strictEqual(env.AIORDIE_SESSION_ID, 'sess-1');
+  });
+
+  it('injects the real bearer when auth is set', function () {
+    const server = new ClaudeCodeWebServer({ auth: 'tok-x', port: 7777, https: false });
+    const env = server._artifactEnvForSession('sess-2');
+    assert.strictEqual(env.AIORDIE_BASE_URL, 'http://127.0.0.1:7777');
+    assert.strictEqual(env.AIORDIE_TOKEN, 'tok-x');
+    assert.strictEqual(env.AIORDIE_SESSION_ID, 'sess-2');
+  });
+
+  it('injects nothing only when both auth and noAuth are absent', function () {
+    const server = new ClaudeCodeWebServer({ port: 7777 });
+    assert.deepStrictEqual(server._artifactEnvForSession('sess-3'), {});
+  });
+});

--- a/test/control/launch-hardening.test.js
+++ b/test/control/launch-hardening.test.js
@@ -30,6 +30,7 @@ describe('F6 control-spawned pager/prompt hardening', function () {
       _maybeStartStickyNotes: () => {},
       _controlReapTrustPrompt: () => {},
       _controlError: proto._controlError,
+      _artifactEnvForSession: proto._artifactEnvForSession,
     };
     await proto._controlStartAgent.call(fakeThis, sid, agent, {});
     return captured.extraEnv;

--- a/test/transcript-peek.test.js
+++ b/test/transcript-peek.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// Fix B: TranscriptBuffer.peek() is a read-only rendered-tail view used to
+// repaint a tab on refresh/join. It must return the rendered screen WITHOUT
+// resetting the delta counters (snapshot does reset), so it never steals lines
+// from the sticky-note volume trigger.
+
+const assert = require('assert');
+const TranscriptBuffer = require('../src/sticky-note-transcript');
+
+describe('TranscriptBuffer.peek (repaint-on-join)', function () {
+  it('returns the rendered tail and does NOT reset new-output counters', async function () {
+    const t = new TranscriptBuffer({ cols: 40, rows: 10 });
+    t.write('alpha\r\nbravo\r\ncharlie\r\n');
+    const peeked = await t.peek(5); // peek drains; counters preserved
+    const before = t.newLineCount();
+    assert.ok(/charlie/.test(peeked), 'peek shows rendered content');
+    assert.ok(before > 0, 'lines counted after drain');
+    await t.peek(5);
+    assert.strictEqual(t.newLineCount(), before, 'peek leaves counters intact');
+  });
+
+  it('snapshot DOES reset counters (contrast)', async function () {
+    const t = new TranscriptBuffer({ cols: 40, rows: 10 });
+    t.write('one\r\ntwo\r\n');
+    await t.peek(5); // drain so the LF counter is committed
+    assert.ok(t.newLineCount() > 0);
+    await t.snapshot(5);
+    assert.strictEqual(t.newLineCount(), 0, 'snapshot consumes the delta');
+  });
+});


### PR DESCRIPTION
## Problem
On a standalone (no-fleet) instance launched with `--disable-auth`, two bugs surfaced:

1. **Artifact viewer never opened.** The artifact env trio (`AIORDIE_BASE_URL/TOKEN/SESSION_ID`) was injected only `if (this.auth)`, but `--disable-auth` sets `this.auth = null`. So `artifactToolsEnabled()` stayed false, `artifact_open` never fired, and the panel never showed.
2. **A browser refresh left the tab blank.** `joinClaudeSession` replayed only `outputBuffer.slice(-200)` (raw chunks) and never a rendered screen; manual tabs had no transcript at all. An idle/empty-buffer session repainted blank.

## Fix
- `_artifactEnvForSession()` injects the trio when auth is set **OR** disabled (routes are public under `noAuth`), with a `noauth` sentinel token; used in both control and manual spawn paths (no drift).
- Manual tabs now keep a rendered `TranscriptBuffer`; the last screen is persisted before dispose, sent as `renderedSnapshot` on join, and repainted client-side (preferred over raw buffer). Active tab persisted to localStorage so refresh returns to the right tab.
- New non-destructive `TranscriptBuffer.peek()` so sticky-note deltas aren't stolen; join + dispose are time-bounded so a slow drain can't stall a join or leak the buffer.

## Failure modes considered
- Hung `peek()` blocking dispose → bounded + always-dispose helper.
- Join stalling on drain → 300ms cap with stored-snapshot fallback.
- Sticky-note volume trigger losing lines → `peek()` doesn't reset counters.
- Sentinel/token collision under auth → token only used when auth absent.

## Tests
`test/artifact-env-disable-auth.test.js` (3), `test/transcript-peek.test.js` (2); 56 adjacent session/sticky-note/panel tests stay green. Live smoke on a free port >11K below.