### PR TITLE
fix: artifact viewer for github-router claude in a terminal tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-or-die",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-or-die",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "license": "MIT",
       "dependencies": {
         "@lydell/node-pty": "1.2.0-beta.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-or-die",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "description": "Universal AI coding terminal — Claude, Copilot, Gemini & more in your browser",
   "main": "src/server.js",
   "bin": {

--- a/src/server.js
+++ b/src/server.js
@@ -5201,13 +5201,18 @@ class ClaudeCodeWebServer {
         if (sidecarPath) terminalExtraEnv.AIORDIE_CLAUDE_BIND = sidecarPath;
       }
 
-      // Artifact-review parity for the manual (non-fleet) claude tab: a normally
-      // started claude tab gets the same env trio that _controlStartAgent injects,
-      // so the in-tab agent's artifact_* tools activate standalone — no control
-      // plane required. Injected when auth is set OR --disable-auth (routes are
-      // public then), so the viewer works standalone. Token leak to nested
-      // children is blocked by github-router's STRIPPED_PARENT_ENV_KEYS.
-      const claudeArtifactEnv = toolName === 'claude' ? this._artifactEnvForSession(sessionId) : {};
+      // Artifact-review parity for the manual (non-fleet) claude tab AND a
+      // terminal tab where the user runs `github-router claude` themselves: both
+      // get the env trio _controlStartAgent injects, so the in-tab agent's
+      // artifact_* tools activate standalone — no control plane required. For a
+      // terminal tab the trio rides the shell env and the github-router PROXY
+      // (which serves the artifact_* MCP tools) inherits it; the proxy strips
+      // AIORDIE_TOKEN only from the claude CHILD it spawns, so a nested re-invoke
+      // still can't hijack. Per-tab sessionId keeps multiple terminal claudes
+      // isolated. Injected when auth is set OR --disable-auth (routes are public
+      // then), so the viewer works standalone.
+      const claudeArtifactEnv = (toolName === 'claude' || toolName === 'terminal')
+        ? this._artifactEnvForSession(sessionId) : {};
 
       // Rendered-screen buffer so a refresh/reconnect can repaint the last
       // screen even when the session is idle and the raw outputBuffer is empty

--- a/test/artifact-env-terminal.test.js
+++ b/test/artifact-env-terminal.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+// A terminal tab where the user runs `github-router claude` themselves gets the
+// same artifact-review trio a claude tab gets (server.js:5210). The trio embeds
+// the per-tab sessionId, so multiple terminal claudes never share a review.
+
+const assert = require('assert');
+const { ClaudeCodeWebServer } = require('../src/server');
+
+const proto = ClaudeCodeWebServer.prototype;
+
+describe('artifact env trio (terminal tab)', function () {
+  it('produces a complete trio for a terminal-tab session', function () {
+    const server = new ClaudeCodeWebServer({ noAuth: true, port: 7777, https: true });
+    const env = server._artifactEnvForSession('term-1');
+    assert.strictEqual(env.AIORDIE_BASE_URL, 'https://127.0.0.1:7777');
+    assert.strictEqual(env.AIORDIE_TOKEN, 'noauth');
+    assert.strictEqual(env.AIORDIE_SESSION_ID, 'term-1');
+  });
+
+  it('keeps two terminal tabs isolated by distinct AIORDIE_SESSION_ID', function () {
+    const server = new ClaudeCodeWebServer({ auth: 'tok-x', port: 7777 });
+    const a = server._artifactEnvForSession('term-a');
+    const b = server._artifactEnvForSession('term-b');
+    assert.strictEqual(a.AIORDIE_SESSION_ID, 'term-a');
+    assert.strictEqual(b.AIORDIE_SESSION_ID, 'term-b');
+    assert.notStrictEqual(a.AIORDIE_SESSION_ID, b.AIORDIE_SESSION_ID);
+  });
+});
+
+// Regression: the GATE lives in the manual startToolSession path. Before the
+// fix it was `toolName === 'claude'`, so a terminal tab got no trio and an
+// in-terminal github-router stayed NOT_IN_AIORDIE_TAB. Drive the real method
+// with a stub bridge and capture the extraEnv handed to bridge.startSession.
+describe('startToolSession injects artifact trio for terminal + claude tabs', function () {
+  async function captureEnv(toolName) {
+    const sid = 'sess-gate';
+    const captured = {};
+    const bridge = {
+      _commandReady: Promise.resolve(),
+      isAvailable: () => true,
+      startSession: async (id, options) => { captured.extraEnv = options.extraEnv; return {}; },
+    };
+    const fakeThis = {
+      webSocketConnections: new Map([['ws1', { ws: {}, claudeSessionId: sid }]]),
+      claudeSessions: new Map([[sid, { id: sid, workingDir: '/tmp', outputBuffer: { push() {} }, active: false }]]),
+      getBridgeForAgent: () => bridge,
+      _prepareClaudeBindSidecar: () => '/tmp/bind.json',
+      _artifactEnvForSession: proto._artifactEnvForSession,
+      auth: null, noAuth: true, port: 7778, useHttps: false,
+      activityBroadcastTimestamps: new Map(),
+      sessionStore: { markDirty() {} },
+      sendToWebSocket() {}, broadcastToSession() {}, broadcastSessionActivity() {},
+      _pushEvictionEntry() {}, _maybeStartStickyNotes() {}, validatePath: () => true, dev: false,
+    };
+    await proto.startToolSession.call(fakeThis, 'ws1', toolName, bridge, {}, 80, 24);
+    return captured.extraEnv;
+  }
+
+  it('terminal tab gets the trio (the fix)', async function () {
+    const env = await captureEnv('terminal');
+    assert.strictEqual(env.AIORDIE_BASE_URL, 'http://127.0.0.1:7778');
+    assert.strictEqual(env.AIORDIE_TOKEN, 'noauth');
+    assert.strictEqual(env.AIORDIE_SESSION_ID, 'sess-gate');
+    assert.strictEqual(env.AIORDIE_CLAUDE_BIND, '/tmp/bind.json'); // sidecar still rides along
+  });
+
+  it('claude tab still gets the trio', async function () {
+    const env = await captureEnv('claude');
+    assert.strictEqual(env.AIORDIE_SESSION_ID, 'sess-gate');
+    assert.ok(env.AIORDIE_BASE_URL && env.AIORDIE_TOKEN);
+  });
+
+  it('codex tab gets NO trio (gate unchanged for others)', async function () {
+    const env = await captureEnv('codex');
+    assert.strictEqual(env.AIORDIE_BASE_URL, undefined);
+    assert.strictEqual(env.AIORDIE_SESSION_ID, undefined);
+  });
+});


### PR DESCRIPTION
## Problem

Running `npx github-router claude` inside an ai-or-die **Terminal** tab left the artifact viewer dark. The review env trio (`AIORDIE_BASE_URL/TOKEN/SESSION_ID`) was injected only for `toolName === 'claude'` tabs (`src/server.js`), so the in-proxy `artifact_*` tools returned `NOT_IN_AIORDIE_TAB`. PR #131 fixed the claude-tab path under `--disable-auth`; this closes the terminal-tab gap.

## Fix

One-line gate change: inject the trio for `terminal` tabs too. The trio rides the shell env; the github-router proxy that serves the tools inherits it. `AIORDIE_TOKEN` is still stripped from the spawned claude *child* (nested re-invoke can't hijack), and each tab's unique `uuidv4` sessionId keeps multiple terminal claudes isolated (store/router/sidecar all sessionId-keyed). No github-router change needed.

## Failure modes tested

- Terminal tab gets the trio; claude tab still does; codex/others get none — driven through real `startToolSession`, capturing `extraEnv`. **Fails on pre-fix code**, passes after (verified by reverting the line).
- Two distinct sessions yield distinct `AIORDIE_SESSION_ID` (no overlap).
- Viewer pipeline confirmed headless: `POST /open` → SDK-injected `/view` under `--disable-auth`.

## Not covered

Live browser-panel render (needs extension/manual UI); verified via routes + unit, not a screenshot.