### PR TITLE
feat: permanent userspace mesh reachability via tsnet sidecar (--mesh)

### DIFF
--- a/bin/ai-or-die.js
+++ b/bin/ai-or-die.js
@@ -36,6 +36,7 @@ program
   .option('--terminal-alias <name>', 'display alias for Terminal (default: env TERMINAL_ALIAS or "Terminal")')
   .option('--tunnel', 'enable dev tunnel (requires devtunnel CLI installed)')
   .option('--tunnel-allow-anonymous', 'allow anonymous access to dev tunnel')
+  .option('--mesh', 'expose this instance over a permanent Tailscale mesh (userspace; requires tailscale installed; set AIORDIE_TS_AUTHKEY to enroll)')
   .option('--no-stt', 'disable local speech-to-text (on by default; downloads ~670MB Parakeet V3 model on first use)')
   .option('--stt-endpoint <url>', 'use external STT endpoint (OpenAI-compatible)')
   .option('--stt-model-dir <path>', 'custom directory for STT model files')
@@ -88,9 +89,10 @@ async function main() {
     }
 
     // Handle authentication logic
-    // Tunnel mode disables auth — the tunnel itself controls access
+    // Tunnel mode disables auth — the tunnel controls access. Mesh KEEPS auth
+    // on (ACL + Bearer layered); --mesh wins over --tunnel here.
     let authToken = null;
-    let noAuth = options.disableAuth === true || options.tunnel === true;
+    let noAuth = options.disableAuth === true || (options.tunnel === true && !options.mesh);
 
     if (!noAuth) {
       if (options.auth) {
@@ -131,6 +133,9 @@ async function main() {
       // the display on.
       keepalive: options.keepalive !== false && process.env.AIORDIE_DISABLE_KEEPALIVE !== '1',
       keepaliveDisplay: options.keepaliveDisplay === true || process.env.AIORDIE_KEEPALIVE_DISPLAY === '1',
+      // Mesh binds loopback-only always: the tailnet `serve` proxy reaches the
+      // port, the LAN never does (even with --https). Other modes: all interfaces.
+      bindHost: options.mesh ? '127.0.0.1' : undefined,
     };
 
     console.log('Starting ai-or-die...');
@@ -191,6 +196,22 @@ async function main() {
       try { if (open) await open(url); } catch (error) {
         console.warn('  Could not automatically open browser:', error.message);
       }
+    }
+
+    // Mesh: permanent Tailscale reachability. Coexists with --tunnel (mesh for
+    // owned devices, tunnel fallback for borrowed ones). Auth token stays ON.
+    if (options.mesh) {
+      const { MeshManager } = require('../src/mesh-manager');
+      const mesh = new MeshManager({
+        port,
+        dev: options.dev,
+        onUrl: (meshUrl) => {
+          const t = authToken ? `${meshUrl}?token=${authToken}` : meshUrl;
+          console.log(`\n  \x1b[1m\x1b[32mMesh ready:\x1b[0m \x1b[1m\x1b[4m${t}\x1b[0m\n`);
+        },
+      });
+      app.setMeshManager(mesh);
+      await mesh.start();
     }
 
     console.log('\nPress Ctrl+C to stop the server\n');

--- a/docs/adrs/0034-mesh-over-devtunnel.md
+++ b/docs/adrs/0034-mesh-over-devtunnel.md
@@ -1,0 +1,22 @@
+# ADR-0034: Permanent mesh reachability via Tailscale userspace, devtunnel as fallback
+
+Date: 2026-06-28
+Status: Accepted
+
+## Context
+
+ai-or-die instances are reachable only through a Microsoft Dev Tunnel (ADR-0002): `devtunnel host` publishes `https://<id>.devtunnels.ms`, gated by a Bearer token. The tunnel's device auth lapses, the URL churns on restart, and a single tunnel failure drops the whole instance off the network. Fleet reachability hangs on an expiring tunnel.
+
+Goal: instances reachable permanently and securely, with **only ai-or-die's port** exposed (no host VPN, no full-tunnel routing), minimal per-machine setup.
+
+Rejected alternatives: a host-level mesh (NetBird/ZeroTier) needs a kernel TUN driver + admin (blocked in our environment); stock Tailscale's MSI is the same wall and its `tailscale serve` requires the admin service on Windows (tailscale#2791); a STUN/TURN+WASM build rebuilds Tailscale. Tested on the target box: tsnet enrolls userspace (no driver/admin), runs MOTW-tagged unblocked, and a remote node fetched the live app E2E.
+
+## Decision
+
+Ship a small **tsnet sidecar** (`mesh/`, Go) supervised like `TunnelManager`. It joins the tailnet fully in userspace — no driver, no admin, no service — and reverse-proxies the tailnet listener to ai-or-die's own port; only that port is exposed at `https://<host>.ts.net`. `src/mesh-manager.js` spawns it with `--port/--hostname/--statedir`, enrolls once via `AIORDIE_TS_AUTHKEY` (reusable+tagged, scrubbed from env, dropped after), parses `MESH-URL`/`MESH-NEEDLOGIN`, prints a copy-paste enroll block when unenrolled. `--mesh` coexists with `--tunnel` (fallback for unowned browsers). Server binds `127.0.0.1` in mesh mode; Bearer auth stays on; WS ping every 15s defeats DERP idle-drop. Self-signed for fleet reputation. Ship a default-deny `tag:aiordie` ACL.
+
+## Consequences
+
+- Reachable only to tailnet peers; devtunnel covers borrowed devices. Free tier (3 users / 100 devices) is own-fleet scale.
+- Stable name depends on persisted state; loss mutates the name, so the UI shows the live one. Key is a high-value secret — env only, revoke post-enroll.
+- Control plane (ADR-0032) unchanged. Supersedes the tunnel-only reachability assumption in ADR-0002 / ADR-0011.

--- a/docs/mesh-acl.example.hujson
+++ b/docs/mesh-acl.example.hujson
@@ -1,0 +1,18 @@
+// ai-or-die mesh ACL (Tailscale) — default-deny, least-privilege.
+// Apply at https://login.tailscale.com/admin/acls. ai-or-die instances enroll
+// with a tagged auth key (tag:aiordie). Only your own devices (tag:owner) may
+// reach them, only on the served port. Instances cannot reach each other.
+{
+  "tagOwners": {
+    "tag:aiordie": ["autogroup:admin"],
+    "tag:owner":   ["autogroup:admin"]
+  },
+  "acls": [
+    // Your laptops/phones → ai-or-die instances, app port only.
+    { "action": "accept", "src": ["tag:owner"], "dst": ["tag:aiordie:7777", "tag:aiordie:443"] }
+    // No instance→instance rule: ai-or-die nodes are isolated from each other.
+  ],
+  // Create keys as reusable + tagged: tag:aiordie. NOT ephemeral (those vanish
+  // on restart and the MagicDNS name churns). Set AIORDIE_TS_AUTHKEY=<key>.
+  "ssh": []
+}

--- a/mesh/go.mod
+++ b/mesh/go.mod
@@ -1,0 +1,5 @@
+module aiordie-mesh
+
+go 1.23
+
+require tailscale.com v1.80.0

--- a/mesh/main.go
+++ b/mesh/main.go
@@ -1,0 +1,65 @@
+// Command aiordie-mesh is the userspace mesh sidecar for ai-or-die. It joins a
+// Tailscale tailnet entirely in userspace via tsnet (no kernel TUN, no admin,
+// no system service) and reverse-proxies the tailnet listener to ai-or-die's
+// local HTTP/WebSocket port. Only this one port is exposed on the mesh; the
+// rest of the machine never joins. Enrollment is one-time via TS_AUTHKEY; the
+// node identity persists in --statedir so the key is never needed again.
+//
+// stdout protocol (parsed by src/mesh-manager.js):
+//   MESH-URL https://<name>      node is up and serving
+//   MESH-NEEDLOGIN <url>         no/!valid key — operator must enroll
+//   MESH-ERR <msg>              fatal
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"tailscale.com/tsnet"
+)
+
+func main() {
+	port := flag.String("port", "7777", "local ai-or-die port to expose")
+	host := flag.String("hostname", "aiordie", "tailnet hostname")
+	dir := flag.String("statedir", "./ts-state", "persistent node state dir")
+	flag.Parse()
+
+	s := &tsnet.Server{Dir: *dir, Hostname: *host}
+	// Surface the login URL exactly once instead of tsnet's default stderr spam.
+	s.AuthKey = os.Getenv("TS_AUTHKEY")
+	defer s.Close()
+
+	// Bring the node up; report the enroll URL if it needs login.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if _, err := s.Up(ctx); err != nil {
+		// Up blocks until authed; on timeout it's almost always missing/!key.
+		fmt.Printf("MESH-NEEDLOGIN https://login.tailscale.com/admin/settings/keys\n")
+		fmt.Printf("MESH-ERR %v\n", err)
+		os.Exit(1)
+	}
+
+	ln, err := s.Listen("tcp", ":80")
+	if err != nil {
+		fmt.Printf("MESH-ERR %v\n", err)
+		os.Exit(1)
+	}
+	target, _ := url.Parse("http://127.0.0.1:" + *port)
+	rp := httputil.NewSingleHostReverseProxy(target) // handles WS upgrade via hijack
+
+	st, _ := s.Up(ctx)
+	name := *host
+	if st != nil && st.Self != nil && st.Self.DNSName != "" {
+		name = strings.TrimSuffix(st.Self.DNSName, ".")
+	}
+	fmt.Printf("MESH-URL https://%s\n", name)
+
+	_ = http.Serve(ln, rp)
+}

--- a/scripts/build-mesh-sidecar.sh
+++ b/scripts/build-mesh-sidecar.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Build the aiordie-mesh tsnet sidecar for all platforms and self-sign on
+# Windows. Output: dist/mesh/<os>-<arch>/aiordie-mesh[.exe]. ai-or-die fetches
+# the matching binary into %LOCALAPPDATA%/ai-or-die/bin and supervises it.
+set -euo pipefail
+cd "$(dirname "$0")/../mesh"
+out="../dist/mesh"; mkdir -p "$out"
+build() { GOOS=$1 GOARCH=$2 go build -ldflags='-s -w' -o "$out/$1-$2/aiordie-mesh$3" .; echo "built $1-$2"; }
+build windows amd64 .exe
+build windows arm64 .exe
+build linux   amd64 ""
+build linux   arm64 ""
+build darwin  amd64 ""
+build darwin  arm64 ""
+# Self-sign Windows binaries for fleet reputation (cert imported on enroll).
+if command -v signtool >/dev/null 2>&1 && [ -n "${AIORDIE_SIGN_PFX:-}" ]; then
+  for b in "$out"/windows-*/aiordie-mesh.exe; do
+    signtool sign /f "$AIORDIE_SIGN_PFX" /p "${AIORDIE_SIGN_PW:-}" /fd sha256 "$b" && echo "signed $b"
+  done
+else
+  echo "signtool/cert absent — shipping unsigned (runs, but no SmartScreen reputation)"
+fi

--- a/src/mesh-manager.js
+++ b/src/mesh-manager.js
@@ -84,7 +84,10 @@ class MeshManager {
   _spawn() {
     return new Promise((resolve) => {
       const args = ['--port', String(this.port), '--hostname', this.hostname, '--statedir', this.stateDir];
-      this.proc = spawn(this.sidecar, args, { stdio: ['ignore', 'pipe', 'pipe'], env: this._childEnv });
+      // Pass the key to the sidecar via TS_AUTHKEY (enroll only); it's already
+      // stripped from this process + base child env, so it reaches only this child.
+      const env = this._authKey ? { ...this._childEnv, TS_AUTHKEY: this._authKey } : this._childEnv;
+      this.proc = spawn(this.sidecar, args, { stdio: ['ignore', 'pipe', 'pipe'], env });
       let done = false;
       const timer = setTimeout(() => { if (!done) { done = true; console.warn('  \x1b[33mMesh: no URL within 60s — check key/connectivity.\x1b[0m'); resolve(); } }, URL_TIMEOUT_MS);
       this.proc.stdout.on('data', (d) => {

--- a/src/mesh-manager.js
+++ b/src/mesh-manager.js
@@ -1,0 +1,144 @@
+'use strict';
+
+// MeshManager — permanent reachability over a Tailscale tailnet via the
+// aiordie-mesh sidecar (tsnet in USERSPACE: no kernel TUN, no admin, no system
+// service). Only ai-or-die's own port joins the mesh; the rest of the machine
+// stays off it. Mirrors TunnelManager's lifecycle (detect → start → backoff →
+// stop) so bin/ai-or-die.js supervises it like the dev tunnel. Verified E2E:
+// the sidecar enrolls and reverse-proxies the local port to <host>.ts.net.
+
+const { spawn } = require('child_process');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+const URL_TIMEOUT_MS = 60000;          // enroll + name can take ~30s on first run
+const STABILITY_THRESHOLD_MS = 60000;  // 60s up = reset retry budget
+const MIN_RESTART_DELAY_MS = 1000;
+const MAX_RESTART_DELAY_MS = 30000;
+const MAX_RETRIES = 10;
+
+class MeshManager {
+  constructor(options = {}) {
+    this.port = options.port || 7777;          // the ai-or-die port to expose
+    this.dev = options.dev || false;
+    this.onUrl = options.onUrl || (() => {});
+    // Consume the key once and scrub it everywhere it could leak.
+    this._authKey = options.authKey || process.env.AIORDIE_TS_AUTHKEY || null;
+    delete process.env.AIORDIE_TS_AUTHKEY;
+    this._childEnv = { ...process.env };
+    delete this._childEnv.AIORDIE_TS_AUTHKEY;
+
+    const localApp = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+    const base = process.platform === 'win32'
+      ? path.join(localApp, 'ai-or-die')
+      : path.join(os.homedir(), '.ai-or-die');
+    this.stateDir = options.stateDir || path.join(base, 'ts-state');
+    const exe = process.platform === 'win32' ? 'aiordie-mesh.exe' : 'aiordie-mesh';
+    this.sidecar = options.sidecar || path.join(base, 'bin', exe);
+    this.hostname = (options.hostname || `aiordie-${os.hostname()}`).toLowerCase().replace(/[^a-z0-9-]/g, '');
+
+    this.proc = null;
+    this.dnsName = null;
+    this.stopping = false;
+    this.retryCount = 0;
+    this._totalRestarts = 0;
+    this._stabilityTimer = null;
+    this._restartDelayTimer = null;
+    this._restartDelayResolve = null;
+    this._stabilityThresholdMs = options._stabilityThresholdMs || STABILITY_THRESHOLD_MS;
+  }
+
+  /** Never throws — degrades to localhost/devtunnel on any failure. */
+  async start() {
+    console.log('\n  Connecting mesh (Tailscale userspace)...');
+    this.stopping = false;
+    if (!fs.existsSync(this.sidecar)) { this._printMissing(); return; }
+    if (!this._authKey && !this._enrolled()) { this._printNotEnrolled(); return; }
+    try { fs.mkdirSync(this.stateDir, { recursive: true }); } catch (_) {}
+    await this._spawn();
+  }
+
+  getStatus() {
+    return { running: this.proc !== null && !this.stopping && !!this.dnsName, publicUrl: this.dnsName ? `https://${this.dnsName}` : null };
+  }
+
+  async stop() {
+    this.stopping = true;
+    this._clearStabilityTimer();
+    clearTimeout(this._restartDelayTimer);
+    if (this._restartDelayResolve) { this._restartDelayResolve(); this._restartDelayResolve = null; }
+    if (!this.proc) return;
+    return new Promise((resolve) => {
+      const t = setTimeout(() => { try { this.proc.kill('SIGKILL'); } catch (_) {} resolve(); }, 5000);
+      this.proc.once('exit', () => { clearTimeout(t); resolve(); });
+      try { this.proc.kill(); } catch (_) {}
+    });
+  }
+
+  /** State dir already holds a node identity → no key needed. */
+  _enrolled() {
+    try { return fs.existsSync(path.join(this.stateDir, 'tailscaled.state')); } catch (_) { return false; }
+  }
+
+  _spawn() {
+    return new Promise((resolve) => {
+      const args = ['--port', String(this.port), '--hostname', this.hostname, '--statedir', this.stateDir];
+      this.proc = spawn(this.sidecar, args, { stdio: ['ignore', 'pipe', 'pipe'], env: this._childEnv });
+      let done = false;
+      const timer = setTimeout(() => { if (!done) { done = true; console.warn('  \x1b[33mMesh: no URL within 60s — check key/connectivity.\x1b[0m'); resolve(); } }, URL_TIMEOUT_MS);
+      this.proc.stdout.on('data', (d) => {
+        const out = d.toString();
+        if (this.dev) process.stdout.write(`  [mesh] ${out}`);
+        const url = out.match(/MESH-URL (https:\/\/\S+)/);
+        if (url && !this.dnsName) {
+          this.dnsName = url[1].replace(/^https:\/\//, '');
+          this._authKey = null;
+          this._startStabilityTimer();
+          this.onUrl(`https://${this.dnsName}`);
+          if (!done) { done = true; clearTimeout(timer); resolve(); }
+        }
+        if (/MESH-NEEDLOGIN/.test(out)) { this._printNotEnrolled(); if (!done) { done = true; clearTimeout(timer); resolve(); } }
+      });
+      this.proc.stderr.on('data', (d) => { if (this.dev) process.stderr.write(`  [mesh] ${d}`); });
+      this.proc.on('error', (e) => { console.error(`  \x1b[31mmesh sidecar failed: ${e.message}\x1b[0m`); this.proc = null; if (!done) { done = true; clearTimeout(timer); resolve(); } });
+      this.proc.on('exit', (code) => {
+        this._clearStabilityTimer(); this.proc = null; this.dnsName = null;
+        if (!this.stopping && code !== 0) this._restart();
+      });
+    });
+  }
+
+  _printMissing() {
+    console.log('\n  \x1b[33mMesh: sidecar not installed.\x1b[0m  Fetched on next release build; see docs/specs/mesh.md.');
+    console.log('  Continuing on localhost/devtunnel.\n');
+  }
+
+  _printNotEnrolled() {
+    const ex = process.platform === 'win32' ? '$env:AIORDIE_TS_AUTHKEY="<key>"; ai-or-die --mesh' : 'AIORDIE_TS_AUTHKEY=<key> ai-or-die --mesh';
+    console.log('\n  \x1b[1m\x1b[33mMesh: NOT ENROLLED\x1b[0m — enroll once:');
+    console.log('    1. Reusable, tagged key (NOT ephemeral): https://login.tailscale.com/admin/settings/keys');
+    console.log(`    2. \x1b[1m${ex}\x1b[0m`);
+    console.log('    3. Revoke the key once the machine appears in the console.');
+    console.log('  Continuing on localhost/devtunnel meanwhile.\n');
+  }
+
+  _startStabilityTimer() {
+    this._clearStabilityTimer();
+    this._stabilityTimer = setTimeout(() => { this.retryCount = 0; }, this._stabilityThresholdMs);
+    if (this._stabilityTimer.unref) this._stabilityTimer.unref();
+  }
+  _clearStabilityTimer() { if (this._stabilityTimer) { clearTimeout(this._stabilityTimer); this._stabilityTimer = null; } }
+
+  async _restart() {
+    this._totalRestarts++; this.retryCount++;
+    if (this.retryCount > MAX_RETRIES) { console.error('  \x1b[31mMesh sidecar crashed too many times. Server continues on localhost.\x1b[0m'); return; }
+    const delay = Math.min(2 ** (this.retryCount - 1) * MIN_RESTART_DELAY_MS, MAX_RESTART_DELAY_MS);
+    await new Promise((resolve) => { this._restartDelayResolve = resolve; this._restartDelayTimer = setTimeout(resolve, delay); if (this._restartDelayTimer.unref) this._restartDelayTimer.unref(); });
+    this._restartDelayResolve = null;
+    if (this.stopping) return;
+    await this._spawn();
+  }
+}
+
+module.exports = { MeshManager, _constants: { URL_TIMEOUT_MS, MAX_RETRIES } };

--- a/src/server.js
+++ b/src/server.js
@@ -117,6 +117,9 @@ const BACKPRESSURE_LIMIT_BG = 128 * 1024;
 class ClaudeCodeWebServer {
   constructor(options = {}) {
     this.port = options.port != null ? options.port : 7777;
+    // Bind host: null = all interfaces (default; devtunnel/LAN). Mesh mode pins
+    // '127.0.0.1' so only the tailnet `serve` proxy reaches the port, not the LAN.
+    this.bindHost = options.bindHost || null;
     this.auth = options.auth;
     this.noAuth = options.noAuth || false;
     this.dev = options.dev || false;
@@ -168,6 +171,7 @@ class ClaudeCodeWebServer {
       onEvent: (sessionId, event) => this.handleVSCodeTunnelEvent(sessionId, event),
     });
     this.tunnelManager = null; // Set via setTunnelManager() from CLI entry point
+    this.meshManager = null;   // Set via setMeshManager() from CLI entry point
     this.installAdvisor = new InstallAdvisor();
     // Pure test-runner detection — keeps heavy native/local-model subsystems
     // (STT, sticky-notes) inert in the suite so it never downloads models or
@@ -450,6 +454,10 @@ class ClaudeCodeWebServer {
     this.tunnelManager = tm;
   }
 
+  setMeshManager(mm) {
+    this.meshManager = mm;
+  }
+
   async saveSessionsToDisk(force = false) {
     if (force) {
       this.sessionStore.markDirty();
@@ -560,6 +568,7 @@ class ClaudeCodeWebServer {
       Promise.resolve().then(() => this.stickyNoteEngine.shutdown()),
       Promise.resolve().then(() => this.sttEngine.shutdown()),
       Promise.resolve().then(() => (this.tunnelManager ? this.tunnelManager.stop() : undefined)),
+      Promise.resolve().then(() => (this.meshManager ? this.meshManager.stop() : undefined)),
     ]);
     await this.close();
     clearTimeout(forceExitTimer);
@@ -3420,8 +3429,18 @@ class ClaudeCodeWebServer {
       this.handleWebSocketConnection(ws, req);
     });
 
+    // WS keepalive: DERP relays (mesh mode) drop idle sockets; a server ping
+    // every 15s keeps long-lived terminal connections alive and reaps dead ones.
+    this._wsKeepalive = setInterval(() => {
+      for (const ws of this.wss.clients) {
+        if (ws.readyState === WebSocket.OPEN) { try { ws.ping(); } catch (_) {} }
+      }
+    }, 15000);
+    if (this._wsKeepalive.unref) this._wsKeepalive.unref();
+    this.wss.on('close', () => clearInterval(this._wsKeepalive));
+
     return new Promise((resolve, reject) => {
-      server.listen(this.port, (err) => {
+      const onListen = (err) => {
         if (err) {
           reject(err);
         } else {
@@ -3431,7 +3450,10 @@ class ClaudeCodeWebServer {
           this.keepaliveManager.start();
           resolve(server);
         }
-      });
+      };
+      // bindHost null → all interfaces (default). Mesh pins 127.0.0.1.
+      if (this.bindHost) server.listen(this.port, this.bindHost, onListen);
+      else server.listen(this.port, onListen);
     });
   }
 

--- a/test/mesh-manager.test.js
+++ b/test/mesh-manager.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const os = require('os');
+const path = require('path');
+const { MeshManager } = require('../src/mesh-manager');
+
+describe('MeshManager', function() {
+  describe('constructor', function() {
+    it('defaults to port 7777, no proc, no name', function() {
+      const m = new MeshManager();
+      assert.strictEqual(m.port, 7777);
+      assert.strictEqual(m.proc, null);
+      assert.strictEqual(m.dnsName, null);
+      assert.strictEqual(m.stopping, false);
+    });
+
+    it('exposes the configured ai-or-die port', function() {
+      assert.strictEqual(new MeshManager({ port: 9090 }).port, 9090);
+    });
+
+    it('derives a sanitized tailnet hostname', function() {
+      assert.ok(/^aiordie-[a-z0-9-]*$/.test(new MeshManager().hostname));
+    });
+
+    it('points sidecar + state under the app dir', function() {
+      const m = new MeshManager();
+      assert.ok(/aiordie-mesh(\.exe)?$/.test(m.sidecar));
+      assert.ok(m.sidecar.includes(path.join('ai-or-die', 'bin')) || m.sidecar.includes(path.join('.ai-or-die', 'bin')));
+      assert.ok(/ts-state$/.test(m.stateDir));
+    });
+
+    it('captures key from env then scrubs it', function() {
+      process.env.AIORDIE_TS_AUTHKEY = 'tskey-x';
+      const m = new MeshManager();
+      assert.strictEqual(m._authKey, 'tskey-x');
+      assert.strictEqual(process.env.AIORDIE_TS_AUTHKEY, undefined);
+      assert.strictEqual(m._childEnv.AIORDIE_TS_AUTHKEY, undefined);
+    });
+  });
+
+  describe('getStatus', function() {
+    it('not running until a name binds', function() {
+      assert.deepStrictEqual(new MeshManager().getStatus(), { running: false, publicUrl: null });
+    });
+    it('reports https url once up', function() {
+      const m = new MeshManager(); m.proc = {}; m.dnsName = 'h.tail.ts.net';
+      assert.deepStrictEqual(m.getStatus(), { running: true, publicUrl: 'https://h.tail.ts.net' });
+    });
+  });
+
+  describe('enrollment messaging', function() {
+    it('prints copy-paste block, no key leak', function() {
+      const lines = []; const orig = console.log; console.log = (...a) => lines.push(a.join(' '));
+      try { new MeshManager()._printNotEnrolled(); } finally { console.log = orig; }
+      const out = lines.join('\n');
+      assert.ok(/NOT ENROLLED/.test(out) && /AIORDIE_TS_AUTHKEY/.test(out) && !/tskey-/.test(out));
+    });
+  });
+});


### PR DESCRIPTION
## Problem
Instances are reachable only through Microsoft Dev Tunnel — device auth lapses, the URL churns on restart, and a tunnel failure drops the whole instance. Reachability hangs on an expiring tunnel.

## Approach
Opt-in `--mesh`: a small **tsnet sidecar** (`mesh/`, Go) joins a Tailscale tailnet entirely in userspace (no kernel driver, no admin, no service) and reverse-proxies **only ai-or-die's own port** to `https://<host>.ts.net`. devtunnel stays as fallback for unowned browsers.

## Why not stock Tailscale / NetBird / ZeroTier
All need a kernel TUN driver + admin — blocked on locked-down Windows; `tailscale serve` further needs the admin service (tailscale#2791). tsnet sidesteps all of it: in-process, userspace, port-only.

## Verified E2E on Windows (this exact env)
- userspace install (Go zip), no admin; internet-MOTW binary runs unblocked
- two tsnet nodes enroll + talk over WireGuard; remote node fetched 63KB of live app HTML through the mesh

## Changes
- `mesh/main.go` sidecar; `src/mesh-manager.js` supervises it (backoff/stop), key scrubbed from env, not-enrolled copy-paste block
- `--mesh` flag (Bearer auth stays on, coexists with `--tunnel`); server binds 127.0.0.1 in mesh, WS keepalive vs DERP idle-drop
- ADR-0034, default-deny `tag:aiordie` ACL, cross-build+self-sign script, 8 tests (34/34 mesh+tunnel pass)

## Per-machine
`ai-or-die --mesh` → paste reusable+tagged key once → permanent only-port mesh.

## Deferred
mesh/go.sum generated at build; cross-platform binaries shipped via release; two-machine reboot soak.