### PR TITLE
fix(artifact): emit AIORDIE_INSECURE_TLS for self-signed loopback

### DIFF
--- a/.github/workflows/longevity-smoke.yml
+++ b/.github/workflows/longevity-smoke.yml
@@ -46,7 +46,12 @@ jobs:
     # "Longevity Smoke (PR-blocking) / smoke (ubuntu-latest)" etc.
     name: smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 12
+    # 18 (was 12): on Windows runners this job legitimately approaches 12 min
+    # (npm ci + `playwright install chromium` + longevity regression + a fixed
+    # 5-min soak), so a 12-min cap had zero headroom and intermittently canceled
+    # mid-soak. Linux/macOS finish in ~7.5 min; the extra headroom is Windows-only
+    # insurance, not a slower test.
+    timeout-minutes: 18
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ docs/factory/state/
 # upload endpoint runs against a fixture.
 test-results/
 e2e/.claude-attachments/
+# e2e artifact-panel test fixtures (created under repo root for validateArtifactPath)
+.tmp-e2e-artifact-*/

--- a/e2e/tests/55-artifact-panel-chrome.spec.js
+++ b/e2e/tests/55-artifact-panel-chrome.spec.js
@@ -1,0 +1,203 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+const { createServer, createSessionViaApi } = require('../helpers/server-factory');
+const {
+  waitForAppReady,
+  setupPageCapture,
+  attachFailureArtifacts,
+} = require('../helpers/terminal-helpers');
+
+// Real-browser verification of the artifact-review panel CHROME (move / resize /
+// minimize / persistence / off-screen clamp). jsdom can't do layout, so these
+// behaviors are only meaningfully testable in a real browser. The panel mounts
+// on the `artifact_review_opened` broadcast for the ACTIVE session, so each test
+// joins a session (which calls _artifactPanel.notifyActiveSessionChanged) and
+// POSTs /api/artifact/:sessionId/open with a small HTML file under the repo root
+// (validateArtifactPath's baseFolder is process.cwd()).
+
+const LAYOUT_KEY = 'ai-or-die:artifact-panel:layout';
+
+// A temp dir UNDER the repo root so validateArtifactPath (baseFolder = cwd)
+// accepts the artifact file. Cleaned up in afterAll.
+let artifactDir;
+let artifactFile;
+
+function writeArtifactFixture() {
+  artifactDir = fs.mkdtempSync(path.join(process.cwd(), '.tmp-e2e-artifact-'));
+  artifactFile = path.join(artifactDir, 'plan.html');
+  fs.writeFileSync(
+    artifactFile,
+    '<!doctype html><html><head><title>Plan</title></head><body>' +
+    '<h1 data-source-line="1">Test plan</h1><p data-source-line="3">Some content to review.</p>' +
+    '</body></html>'
+  );
+}
+
+async function openArtifactForActiveSession(page, port, sessionId) {
+  // Make the session active for the panel via the SAME call app.js makes on
+  // session_joined (notifyActiveSessionChanged), and dismiss the welcome overlay
+  // so the panel header is the topmost element (the overlay's .overlay-content
+  // otherwise sits over the panel and swallows the drag mousedown). This drives
+  // the REAL panel deterministically without racing the join→navigation flow.
+  await page.waitForFunction(
+    () => window.app && window.app._artifactPanel && typeof window.app.hideOverlay === 'function',
+    { timeout: 20000 }
+  );
+  await page.evaluate((sid) => {
+    window.app.hideOverlay();
+    window.app._artifactPanel.notifyActiveSessionChanged(sid);
+  }, sessionId);
+
+  // Open the artifact via the server route (broadcasts artifact_review_opened to
+  // the client, which the real panel handles).
+  const res = await fetch(`http://127.0.0.1:${port}/api/artifact/${encodeURIComponent(sessionId)}/open`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ file: artifactFile }),
+  });
+  expect(res.ok).toBeTruthy();
+
+  // The panel becomes visible once the broadcast lands.
+  await expect(page.locator('#artifactPanel')).toBeVisible({ timeout: 15000 });
+}
+
+test.describe('Artifact panel chrome: move / resize / minimize / persistence', () => {
+  let server, port, url;
+
+  test.beforeAll(async () => {
+    writeArtifactFixture();
+    ({ server, port, url } = await createServer());
+  });
+
+  test.afterAll(async () => {
+    if (server) await server.close();
+    if (artifactDir) { try { fs.rmSync(artifactDir, { recursive: true, force: true }); } catch (_) { /* ignore */ } }
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    await attachFailureArtifacts(page, testInfo);
+  });
+
+  test('drag moves, corner resizes, minimize collapses + restores, geometry persists, off-screen clamps', async ({ page }) => {
+    setupPageCapture(page);
+
+    const sessionId = await createSessionViaApi(port, 'Artifact Chrome');
+
+    // Start from a clean persisted layout so we control the geometry.
+    await page.goto(url);
+    await waitForAppReady(page);
+    // Start from a clean persisted layout (one-time, NOT an init script — an
+    // init script would re-run on the later reload and wipe the geometry we are
+    // trying to verify persists).
+    await page.evaluate((key) => { try { window.localStorage.removeItem(key); } catch (_) { /* ignore */ } }, LAYOUT_KEY);
+    await openArtifactForActiveSession(page, port, sessionId);
+
+    const panel = page.locator('#artifactPanel');
+    const header = page.locator('#artifactPanel .artifact-panel__header');
+    const resizeHandle = page.locator('#artifactPanel .artifact-panel__resize');
+
+    // ---- (a) DRAG the header moves the panel ------------------------------
+    const before = await panel.boundingBox();
+    expect(before).not.toBeNull();
+
+    const headerBox = await header.boundingBox();
+    // Grab a point on the header that is NOT over a button (left side, past the title).
+    const grabX = headerBox.x + 30;
+    const grabY = headerBox.y + headerBox.height / 2;
+    await page.mouse.move(grabX, grabY);
+    await page.mouse.down();
+    // Move left + up in steps so the drag handler tracks it (no arbitrary sleeps).
+    await page.mouse.move(grabX - 120, grabY - 80, { steps: 8 });
+    await page.mouse.up();
+
+    await expect.poll(async () => {
+      const b = await panel.boundingBox();
+      return Math.round(b.x);
+    }, { timeout: 5000 }).toBeLessThan(Math.round(before.x) - 40);
+    const afterMove = await panel.boundingBox();
+    expect(afterMove.y).toBeLessThan(before.y - 40);
+
+    // ---- (b) DRAG the resize handle changes size --------------------------
+    const sizeBefore = await panel.boundingBox();
+    const handleBox = await resizeHandle.boundingBox();
+    const hx = handleBox.x + handleBox.width / 2;
+    const hy = handleBox.y + handleBox.height / 2;
+    await page.mouse.move(hx, hy);
+    await page.mouse.down();
+    await page.mouse.move(hx + 90, hy + 70, { steps: 8 });
+    await page.mouse.up();
+
+    await expect.poll(async () => {
+      const b = await panel.boundingBox();
+      return Math.round(b.width);
+    }, { timeout: 5000 }).toBeGreaterThan(Math.round(sizeBefore.width) + 40);
+    const afterResize = await panel.boundingBox();
+    expect(afterResize.height).toBeGreaterThan(sizeBefore.height + 40);
+
+    // ---- (c) MINIMIZE collapses to the header bar; restore brings it back -
+    const fullHeight = (await panel.boundingBox()).height;
+    const minBtn = page.locator('#artifactPanel .artifact-panel__btn[aria-label="Minimize panel"]');
+    await minBtn.click();
+    // Body hidden + panel shrinks to ~header height.
+    await expect(page.locator('#artifactPanel .artifact-panel__body')).toBeHidden({ timeout: 5000 });
+    await expect.poll(async () => {
+      const b = await panel.boundingBox();
+      return Math.round(b.height);
+    }, { timeout: 5000 }).toBeLessThan(Math.round(fullHeight) - 80);
+
+    const restoreBtn = page.locator('#artifactPanel .artifact-panel__btn[aria-label="Restore panel"]');
+    await restoreBtn.click();
+    await expect(page.locator('#artifactPanel .artifact-panel__body')).toBeVisible({ timeout: 5000 });
+    await expect.poll(async () => {
+      const b = await panel.boundingBox();
+      return Math.round(b.height);
+    }, { timeout: 5000 }).toBeGreaterThan(Math.round(fullHeight) - 40);
+
+    // ---- (d) geometry PERSISTS across a page reload -----------------------
+    const persistedBox = await panel.boundingBox();
+    const storedRaw = await page.evaluate((key) => window.localStorage.getItem(key), LAYOUT_KEY);
+    expect(storedRaw, 'layout persisted to localStorage').toBeTruthy();
+    const stored = JSON.parse(storedRaw);
+    expect(typeof stored.left).toBe('number');
+    expect(typeof stored.width).toBe('number');
+
+    await page.reload();
+    await waitForAppReady(page);
+    await openArtifactForActiveSession(page, port, sessionId);
+
+    await expect.poll(async () => {
+      const b = await panel.boundingBox();
+      return Math.round(b.width);
+    }, { timeout: 5000 }).toBeGreaterThan(Math.round(sizeBefore.width) + 40);
+    const afterReload = await panel.boundingBox();
+    // Position + size survived (allow a couple px tolerance for sub-pixel rounding).
+    expect(Math.abs(afterReload.x - persistedBox.x)).toBeLessThan(4);
+    expect(Math.abs(afterReload.y - persistedBox.y)).toBeLessThan(4);
+    expect(Math.abs(afterReload.width - persistedBox.width)).toBeLessThan(4);
+
+    // ---- (e) a persisted OFF-SCREEN position is clamped back on load ------
+    const viewport = page.viewportSize();
+    await page.evaluate(({ key, w, h }) => {
+      window.localStorage.setItem(key, JSON.stringify({ left: 99999, top: 99999, width: 420, height: 360, minimized: false }));
+    }, { key: LAYOUT_KEY, w: viewport.width, h: viewport.height });
+
+    await page.reload();
+    await waitForAppReady(page);
+    await openArtifactForActiveSession(page, port, sessionId);
+
+    await expect.poll(async () => {
+      const b = await panel.boundingBox();
+      // The header must be on-screen and grabbable.
+      return b && b.x >= 0 && b.y >= 0
+        && b.x < viewport.width - 40
+        && b.y < viewport.height - 20;
+    }, { timeout: 5000 }).toBe(true);
+
+    const clamped = await panel.boundingBox();
+    expect(clamped.x).toBeGreaterThanOrEqual(0);
+    expect(clamped.y).toBeGreaterThanOrEqual(0);
+    expect(clamped.x).toBeLessThan(viewport.width - 40);
+    expect(clamped.y).toBeLessThan(viewport.height - 20);
+  });
+});

--- a/e2e/tests/55-artifact-panel-chrome.spec.js
+++ b/e2e/tests/55-artifact-panel-chrome.spec.js
@@ -120,6 +120,10 @@ test.describe('Artifact panel chrome: move / resize / minimize / persistence', (
 
     // ---- (b) DRAG the resize handle changes size --------------------------
     const sizeBefore = await panel.boundingBox();
+    // The iframe content area must grow WITH the panel (flex:1/width:100%) so the
+    // artifact reflows into the larger space — capture it before resizing.
+    const frame = page.locator('#artifactPanel .artifact-panel__frame');
+    const frameBefore = await frame.boundingBox();
     const handleBox = await resizeHandle.boundingBox();
     const hx = handleBox.x + handleBox.width / 2;
     const hy = handleBox.y + handleBox.height / 2;
@@ -134,6 +138,10 @@ test.describe('Artifact panel chrome: move / resize / minimize / persistence', (
     }, { timeout: 5000 }).toBeGreaterThan(Math.round(sizeBefore.width) + 40);
     const afterResize = await panel.boundingBox();
     expect(afterResize.height).toBeGreaterThan(sizeBefore.height + 40);
+    // The iframe (artifact content viewport) grew with the panel, so content reflows.
+    const frameAfter = await frame.boundingBox();
+    expect(frameAfter.width).toBeGreaterThan(frameBefore.width + 30);
+    expect(frameAfter.height).toBeGreaterThan(frameBefore.height + 30);
 
     // ---- (c) MINIMIZE collapses to the header bar; restore brings it back -
     const fullHeight = (await panel.boundingBox()).height;

--- a/e2e/tests/55-artifact-panel-chrome.spec.js
+++ b/e2e/tests/55-artifact-panel-chrome.spec.js
@@ -162,6 +162,32 @@ test.describe('Artifact panel chrome: move / resize / minimize / persistence', (
       return Math.round(b.height);
     }, { timeout: 5000 }).toBeGreaterThan(Math.round(fullHeight) - 40);
 
+    // ---- (c2) MAXIMIZE fills the wrapper; restore returns to the prior size -
+    const preMax = await panel.boundingBox();
+    const wrapperBox = await page.evaluate(() => {
+      const r = document.getElementById('artifactPanel').parentElement.getBoundingClientRect();
+      return { width: r.width, height: r.height };
+    });
+    await page.locator('#artifactPanel .artifact-panel__btn[aria-label="Maximize panel"]').click();
+    await expect(panel).toHaveClass(/artifact-panel--maximized/);
+    await expect.poll(async () => {
+      const b = await panel.boundingBox();
+      return Math.round(b.width);
+    }, { timeout: 5000 }).toBeGreaterThan(Math.round(wrapperBox.width) - 60);
+    const maxBox = await panel.boundingBox();
+    expect(maxBox.width).toBeGreaterThan(preMax.width + 120);
+    expect(maxBox.height).toBeGreaterThan(wrapperBox.height - 60);
+
+    await page.locator('#artifactPanel .artifact-panel__btn[aria-label="Restore panel size"]').click();
+    await expect(panel).not.toHaveClass(/artifact-panel--maximized/);
+    await expect.poll(async () => {
+      const b = await panel.boundingBox();
+      return Math.round(b.width);
+    }, { timeout: 5000 }).toBeLessThan(Math.round(maxBox.width) - 60);
+    const restoredBox = await panel.boundingBox();
+    expect(Math.abs(restoredBox.width - preMax.width)).toBeLessThan(6);
+    expect(Math.abs(restoredBox.height - preMax.height)).toBeLessThan(6);
+
     // ---- (d) geometry PERSISTS across a page reload -----------------------
     const persistedBox = await panel.boundingBox();
     const storedRaw = await page.evaluate((key) => window.localStorage.getItem(key), LAYOUT_KEY);

--- a/src/artifact-review.js
+++ b/src/artifact-review.js
@@ -267,6 +267,91 @@ function safeJson(value) {
   return JSON.stringify(value).replace(/<\//g, '<\\/');
 }
 
+function isMarkdownFile(file) {
+  const lower = String(file || '').toLowerCase();
+  return lower.endsWith('.md') || lower.endsWith('.markdown');
+}
+
+// Build a self-contained HTML shell that renders markdown SOURCE through the
+// existing client renderer (window.markdownRender.renderInto). This is the
+// fallback path for /view when an artifact is markdown rather than HTML — most
+// plans arrive already-HTML, but a markdown plan must NEVER be shown as raw
+// bytes. The shell is later passed through injectLavishSdk so the annotation
+// SDK loads on top.
+//
+// Absolute script paths are load-bearing: injectLavishSdk inserts a
+// <base href="/api/artifact/:id/asset/..."> and a path-relative
+// "markdown-render.js" would resolve against that asset base (404). The renderer
+// itself lazy-loads /vendor/marked.min.js + /vendor/purify.min.js with absolute
+// paths too, so they survive the base. All three are served by the pre-auth
+// express.static mount, so the sandboxed iframe loads them same-origin without a
+// token.
+function markdownArtifactShell(source, options) {
+  options = options || {};
+  const title = options.title ? String(options.title) : 'Markdown artifact';
+  const src = source == null ? '' : String(source);
+  return [
+    '<!doctype html>',
+    '<html lang="en">',
+    '<head>',
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    '<title>' + escapeAttr(title) + '</title>',
+    '<style>',
+    ':root{color-scheme:light}',
+    'html,body{margin:0;padding:0;background:#fbfbfa;color:#1f2328}',
+    'body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Serif",Georgia,serif;',
+    'font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}',
+    '.md-reading-column{max-width:760px;margin:0 auto;padding:40px 28px 96px;box-sizing:border-box}',
+    '.fb-markdown-rendered,.fb-md-fallback{overflow-wrap:break-word;word-break:break-word}',
+    '.fb-markdown-rendered h1,.fb-markdown-rendered h2,.fb-markdown-rendered h3{line-height:1.25;font-weight:650;margin:1.6em 0 .6em}',
+    '.fb-markdown-rendered h1{font-size:1.9em;border-bottom:1px solid #e2e2df;padding-bottom:.3em}',
+    '.fb-markdown-rendered h2{font-size:1.45em;border-bottom:1px solid #e8e8e5;padding-bottom:.25em}',
+    '.fb-markdown-rendered h3{font-size:1.2em}',
+    '.fb-markdown-rendered p,.fb-markdown-rendered ul,.fb-markdown-rendered ol{margin:.7em 0}',
+    '.fb-markdown-rendered code,.fb-markdown-rendered pre{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"Liberation Mono",monospace}',
+    '.fb-markdown-rendered code{background:#f1f1ef;border-radius:4px;padding:.15em .35em;font-size:.88em}',
+    '.fb-markdown-rendered pre{background:#f6f6f4;border:1px solid #e6e6e3;border-radius:8px;padding:14px 16px;overflow:auto;line-height:1.5}',
+    '.fb-markdown-rendered pre code{background:none;padding:0;font-size:.86em}',
+    '.fb-markdown-rendered blockquote{margin:.8em 0;padding:.1em 1em;border-left:3px solid #d7d7d3;color:#56595f}',
+    '.fb-markdown-rendered table{border-collapse:collapse;margin:1em 0;display:block;overflow:auto}',
+    '.fb-markdown-rendered th,.fb-markdown-rendered td{border:1px solid #e2e2df;padding:6px 12px}',
+    '.fb-markdown-rendered img{max-width:100%}',
+    '.fb-markdown-rendered a{color:#0b66c3}',
+    '.fb-md-loading{color:#8a8d92;font-size:14px}',
+    '.fb-md-feature-unavailable{color:#9a6b00;background:#fff7e0;border:1px solid #f0dca0;border-radius:6px;padding:8px 10px;font-size:13px;margin:0 0 10px}',
+    '.fb-md-fallback pre{white-space:pre-wrap;word-break:break-word;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;background:#f6f6f4;border:1px solid #e6e6e3;border-radius:8px;padding:14px 16px;margin:0}',
+    '</style>',
+    '</head>',
+    '<body>',
+    '<main class="md-reading-column"><div id="md-artifact-root" class="fb-md-loading">Rendering markdown...</div></main>',
+    '<script type="application/json" id="md-artifact-source">' + safeJson(src) + '</script>',
+    '<script src="/markdown-render.js"></script>',
+    '<script>(function(){',
+    'function boot(){',
+    'var root=document.getElementById("md-artifact-root");',
+    'var raw=document.getElementById("md-artifact-source");',
+    'var source="";try{source=JSON.parse(raw.textContent||\'""\');}catch(e){source=raw.textContent||"";}',
+    'if(!root)return;',
+    'if(window.markdownRender&&typeof window.markdownRender.renderInto==="function"){',
+    'window.markdownRender.renderInto(root,source,{enableMermaid:true,enableKatex:true}).catch(function(){renderRaw(root,source);});',
+    '}else{renderRaw(root,source);}',
+    '}',
+    'function renderRaw(root,source){',
+    'while(root.firstChild)root.removeChild(root.firstChild);',
+    'root.className="fb-md-fallback";',
+    'var note=document.createElement("div");note.className="fb-md-feature-unavailable";',
+    'note.textContent="Markdown renderer unavailable; showing source.";',
+    'var pre=document.createElement("pre");pre.textContent=source;',
+    'root.appendChild(note);root.appendChild(pre);',
+    '}',
+    'if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",boot,{once:true});}else{boot();}',
+    '})();</script>',
+    '</body>',
+    '</html>',
+  ].join('\n');
+}
+
 function injectLavishSdk(html, options) {
   options = options || {};
   const sessionId = options.sessionId;
@@ -574,8 +659,14 @@ function createArtifactReviewRouter(options) {
     try {
       const stat = fs.statSync(validation.path);
       if (!stat.isFile()) return res.status(400).json({ error: 'file must be a regular file' });
-      html = fs.readFileSync(validation.path, 'utf8');
+      const raw = fs.readFileSync(validation.path, 'utf8');
       review.file = validation.path;
+      // Markdown FALLBACK: a .md/.markdown artifact is wrapped in a self-contained
+      // renderer shell (never shown as raw bytes). HTML and everything else keep
+      // the raw path. Both then flow through injectLavishSdk so annotation works.
+      html = isMarkdownFile(validation.path)
+        ? markdownArtifactShell(raw, { title: path.basename(validation.path) })
+        : raw;
     } catch (err) {
       if (err && err.code === 'ENOENT') return res.status(404).json({ error: 'file not found' });
       return res.status(500).json({ error: 'read failed', message: err.message });
@@ -834,5 +925,7 @@ module.exports = {
   createArtifactReviewRouter,
   feedbackHasData,
   injectLavishSdk,
+  isMarkdownFile,
+  markdownArtifactShell,
   resolveArtifactAsset,
 };

--- a/src/artifact-sdk-client.js
+++ b/src/artifact-sdk-client.js
@@ -1,10 +1,35 @@
 (function () {
   'use strict';
 
+  // In-iframe annotation SDK (served at /api/artifact/:sessionId/sdk.js, injected
+  // into the artifact via injectLavishSdk). Adapted from lavish-axi's
+  // artifact-sdk.js. Lets a human point at the rendered artifact and tell the
+  // agent what to change:
+  //
+  //   - hover highlights the block under the cursor (brass outline)
+  //   - clicking a block OR selecting text opens a shadow-DOM popover card
+  //     ("Tell the agent what to change…"; Enter queues, Cmd/Ctrl+Enter sends
+  //     the batch now, Esc cancels), positioned near the target and clamped to
+  //     the viewport
+  //   - each comment becomes a structured annotation object the panel renders as
+  //     a pill and (on Send) POSTs to /prompts via the EXISTING transport
+  //
+  // The panel owns the queue + the network. This SDK only emits postMessages
+  // (source 'ai-or-die-artifact-sdk') the panel consumes. The lavish layout
+  // overflow audit/gate is intentionally NOT ported (not useful for plans).
+
   var config = window.__AI_OR_DIE_ARTIFACT_REVIEW__ || {};
+  var SOURCE = 'ai-or-die-artifact-sdk';
+  var HOST_SOURCE = 'ai-or-die-artifact-host';
   var targetOrigin = '*';
-  var pending = Object.create(null);
-  var nextId = 1;
+
+  var annotationMode = true;
+  var hovered = null;
+  var selected = null;
+  var ignoreNextClick = false;
+  var shadow = null;
+  var counter = 0;
+  var ids = new WeakMap();
 
   function clone(value) {
     if (value == null) return value;
@@ -16,36 +41,19 @@
   }
 
   function post(type, payload) {
-    var id = 'artifact-' + Date.now() + '-' + (nextId++);
     var message = {
-      source: 'ai-or-die-artifact-sdk',
+      source: SOURCE,
       type: type,
-      id: id,
       sessionId: config.sessionId || null,
       key: config.key || null,
       payload: payload || {},
     };
-    if (window.parent && window.parent !== window) {
-      window.parent.postMessage(message, targetOrigin);
-    } else {
-      window.postMessage(message, targetOrigin);
+    var target = (window.parent && window.parent !== window) ? window.parent : window;
+    try {
+      target.postMessage(message, targetOrigin);
+    } catch (_) {
+      /* parent gone / cross-origin denial — non-fatal */
     }
-    return id;
-  }
-
-  function request(type, payload, timeoutMs) {
-    var id = post(type, payload);
-    return new Promise(function (resolve, reject) {
-      var timeout = setTimeout(function () {
-        delete pending[id];
-        reject(new Error('Timed out waiting for artifact host response'));
-      }, typeof timeoutMs === 'number' ? timeoutMs : 30000);
-      pending[id] = {
-        resolve: resolve,
-        reject: reject,
-        timeout: timeout,
-      };
-    });
   }
 
   function readDomSnapshot() {
@@ -54,7 +62,6 @@
         title: document.title || '',
         url: String(window.location.href || ''),
         bodyText: document.body ? document.body.innerText.slice(0, 20000) : '',
-        html: document.documentElement ? document.documentElement.outerHTML.slice(0, 200000) : '',
         viewport: {
           width: window.innerWidth,
           height: window.innerHeight,
@@ -66,15 +73,460 @@
     }
   }
 
+  // ---- target identification -------------------------------------------------
+
+  function uid(el) {
+    if (!ids.has(el)) ids.set(el, String(++counter));
+    return ids.get(el);
+  }
+
+  function cssEscape(value) {
+    if (window.CSS && typeof window.CSS.escape === 'function') return window.CSS.escape(value);
+    // Minimal fallback for environments without CSS.escape.
+    return String(value).replace(/[^a-zA-Z0-9_-]/g, function (ch) {
+      return '\\' + ch;
+    });
+  }
+
+  function selector(el) {
+    if (!el || !el.tagName) return '';
+    var parts = [];
+    var node = el;
+    while (node && node.nodeType === 1 && parts.length < 5) {
+      var part = node.tagName.toLowerCase();
+      if (node.id) {
+        part += '#' + cssEscape(node.id);
+        parts.unshift(part);
+        break;
+      }
+      var parent = node.parentElement;
+      if (parent) {
+        var same = Array.prototype.filter.call(parent.children, function (x) {
+          return x.tagName === node.tagName;
+        });
+        if (same.length > 1) part += ':nth-of-type(' + (same.indexOf(node) + 1) + ')';
+      }
+      parts.unshift(part);
+      node = parent;
+    }
+    return parts.join(' > ');
+  }
+
+  // Pull the original markdown/source line from the nearest ancestor carrying a
+  // data-source-line attribute (renderers that emit source maps set it). Absent
+  // → undefined, so the agent only sees a line number when one truly exists.
+  function sourceLineOf(el) {
+    var node = el;
+    while (node && node.nodeType === 1) {
+      if (node.hasAttribute && node.hasAttribute('data-source-line')) {
+        var n = parseInt(node.getAttribute('data-source-line'), 10);
+        if (Number.isFinite(n)) return n;
+      }
+      node = node.parentElement;
+    }
+    return undefined;
+  }
+
+  function context(el) {
+    var ctx = {
+      uid: uid(el),
+      selector: selector(el),
+      tag: (el.tagName || '').toLowerCase(),
+      text: (el.innerText || el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 240),
+    };
+    var line = sourceLineOf(el);
+    if (line !== undefined) ctx.sourceLine = line;
+    return ctx;
+  }
+
+  // ---- text-range selection context -----------------------------------------
+
+  function closestElement(node) {
+    if (!node) return document.body;
+    if (node.nodeType === 1) return node;
+    return node.parentElement || document.body;
+  }
+
+  function nodePath(node, root) {
+    var path = [];
+    var current = node;
+    while (current && current !== root) {
+      var parentNode = current.parentNode;
+      if (!parentNode) break;
+      path.unshift(Array.prototype.indexOf.call(parentNode.childNodes, current));
+      current = parentNode;
+    }
+    return path;
+  }
+
+  function rangeBoundary(node, offset) {
+    var el = closestElement(node);
+    return {
+      selector: selector(el),
+      path: nodePath(node, el),
+      offset: Number(offset) || 0,
+    };
+  }
+
+  function textSelectionContext(selection) {
+    if (!selection || selection.rangeCount === 0) return null;
+    var range = selection.getRangeAt(0);
+    var text = selection.toString().trim().replace(/\s+/g, ' ');
+    if (range.collapsed || !text) return null;
+
+    var ancestor = closestElement(range.commonAncestorContainer);
+    if (isAnnotationUi(ancestor)) return null;
+
+    var commonAncestorSelector = selector(ancestor);
+    var target = {
+      type: 'text-range',
+      text: text,
+      selector: commonAncestorSelector,
+      commonAncestorSelector: commonAncestorSelector,
+      start: rangeBoundary(range.startContainer, range.startOffset),
+      end: rangeBoundary(range.endContainer, range.endOffset),
+    };
+
+    var ctx = {
+      uid: '',
+      selector: commonAncestorSelector,
+      tag: 'text',
+      text: text.slice(0, 240),
+      target: target,
+      element: ancestor,
+      range: range.cloneRange(),
+    };
+    var line = sourceLineOf(ancestor);
+    if (line !== undefined) ctx.sourceLine = line;
+    return ctx;
+  }
+
+  function isAnnotationUi(el) {
+    return !!(el && el.closest && el.closest('[data-ai-or-die-ui]'));
+  }
+
+  // Native interactive controls should behave natively, not trigger annotation.
+  function isInteractiveControl(el) {
+    return !!(
+      el &&
+      el.closest &&
+      el.closest(
+        "button,input,select,textarea,option,optgroup,label,summary,[contenteditable]:not([contenteditable='false'])"
+      )
+    );
+  }
+
+  function shouldIgnore(target) {
+    return !annotationMode || isAnnotationUi(target) || isInteractiveControl(target);
+  }
+
+  // ---- highlighting ----------------------------------------------------------
+
+  function highlightElement(el) {
+    if (!el || !el.style) return;
+    el.style.outline = 'var(--aod-annotate-outline,2px solid #f4c95d)';
+    el.style.outlineOffset = 'var(--aod-annotate-offset,2px)';
+  }
+
+  function clearHighlight(el) {
+    if (el && el.style) el.style.outline = '';
+  }
+
+  function clearTextHighlight() {
+    if (!shadow) return;
+    var marks = shadow.querySelectorAll('.aod-text-highlight');
+    for (var i = 0; i < marks.length; i++) marks[i].remove();
+  }
+
+  function highlightTextRange(range) {
+    clearTextHighlight();
+    var root = ensureShadow();
+    var rects;
+    try {
+      rects = range.getClientRects ? range.getClientRects() : [];
+    } catch (_) {
+      rects = [];
+    }
+    for (var i = 0; i < rects.length; i++) {
+      var rect = rects[i];
+      if (rect.width <= 0 || rect.height <= 0) continue;
+      var mark = document.createElement('div');
+      mark.className = 'aod-text-highlight';
+      mark.style.left = rect.left + 'px';
+      mark.style.top = rect.top + 'px';
+      mark.style.width = rect.width + 'px';
+      mark.style.height = rect.height + 'px';
+      root.appendChild(mark);
+    }
+  }
+
+  function setAnnotationMode(enabled) {
+    annotationMode = !!enabled;
+    var style = document.getElementById('aod-cursor-style');
+    if (annotationMode && !style) {
+      style = document.createElement('style');
+      style.id = 'aod-cursor-style';
+      style.textContent =
+        ":root{--aod-accent:#f4c95d;--aod-annotate-outline:2px solid var(--aod-accent);--aod-annotate-offset:2px}" +
+        "*{cursor:default!important}" +
+        "input,textarea,[contenteditable]:not([contenteditable='false']){cursor:text!important}" +
+        "button,select,label,option,summary,a{cursor:pointer!important}";
+      document.head.appendChild(style);
+    }
+    if (!annotationMode && style) style.remove();
+    if (!annotationMode) closeCard();
+  }
+
+  // ---- queue / send transport (panel owns the queue) ------------------------
+
+  function queueAnnotation(annotation) {
+    post('artifact-annotation-queued', { annotation: clone(annotation) });
+  }
+
+  function sendQueued() {
+    post('artifact-annotations-send', { domSnapshot: readDomSnapshot() });
+  }
+
+  function buildAnnotation(ctx, promptText) {
+    var item = {
+      uid: ctx.uid || '',
+      selector: ctx.selector || '',
+      tag: ctx.tag || '',
+      text: ctx.text || '',
+      prompt: String(promptText || ''),
+    };
+    if (ctx.sourceLine !== undefined) item.sourceLine = ctx.sourceLine;
+    if (ctx.target) item.target = ctx.target;
+    return item;
+  }
+
+  // ---- shadow-DOM popover card ----------------------------------------------
+
+  function ensureShadow() {
+    if (shadow) return shadow;
+    var host = document.createElement('div');
+    host.className = 'aod-annotation-root';
+    host.setAttribute('data-ai-or-die-ui', 'annotation-root');
+    document.documentElement.appendChild(host);
+
+    shadow = host.attachShadow({ mode: 'open' });
+    var style = document.createElement('style');
+    style.textContent =
+      ":host{all:initial;position:fixed;z-index:2147483647;left:0;top:0;color-scheme:dark;" +
+      "--aod-accent:#f4c95d;--aod-accent-hover:#ffd877;--aod-ink:#17130a;" +
+      "--aod-bg-panel:#11141a;--aod-bg:#0f1115;--aod-fg:#f7f3ea;--aod-fg-faint:#aeb6c6;--aod-border:#303745;" +
+      "--aod-font:Geist,ui-sans-serif,system-ui,-apple-system,'Segoe UI',sans-serif;" +
+      "font-family:var(--aod-font)}" +
+      "*{box-sizing:border-box}" +
+      ":focus-visible{outline:2px solid var(--aod-accent);outline-offset:2px}" +
+      ".aod-text-highlight{position:fixed;pointer-events:none;background:rgba(244,201,93,.28);border-radius:2px;box-shadow:0 0 0 1px rgba(244,201,93,.45)}" +
+      ".aod-annotation-card{position:fixed;width:min(320px,calc(100vw - 24px));padding:12px;border-radius:14px;" +
+      "background:var(--aod-bg-panel);color:var(--aod-fg);border:1px solid var(--aod-accent);" +
+      "box-shadow:0 20px 70px rgba(0,0,0,.35);font:14px/1.4 var(--aod-font)}" +
+      ".aod-heading{font-weight:700;margin-bottom:6px}" +
+      ".aod-annotation-card textarea{width:100%;min-height:86px;resize:vertical;border-radius:10px;" +
+      "border:1px solid var(--aod-border);background:var(--aod-bg);color:var(--aod-fg);padding:9px;font:inherit;font-family:var(--aod-font)}" +
+      ".aod-annotation-card textarea::placeholder{color:var(--aod-fg-faint)}" +
+      ".aod-hint{margin-top:6px;font-size:11px;color:var(--aod-fg-faint)}" +
+      ".aod-row{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}" +
+      ".aod-annotation-card button{border:0;border-radius:10px;padding:8px 10px;font-family:var(--aod-font);font-size:13px;font-weight:700;cursor:pointer}" +
+      ".aod-annotation-card button:active{opacity:.85}" +
+      ".aod-send{background:var(--aod-accent);color:var(--aod-ink)}" +
+      ".aod-send:hover{background:var(--aod-accent-hover)}" +
+      ".aod-cancel{background:#2a2f3a;color:var(--aod-fg)}";
+    shadow.appendChild(style);
+    return shadow;
+  }
+
+  function closeCard() {
+    if (shadow) {
+      var cards = shadow.querySelectorAll('.aod-annotation-card');
+      for (var i = 0; i < cards.length; i++) cards[i].remove();
+    }
+    clearHighlight(hovered);
+    clearHighlight(selected);
+    hovered = null;
+    clearTextHighlight();
+    selected = null;
+  }
+
+  function isMac() {
+    return /Mac|iP(hone|ad|od)/.test((navigator && navigator.platform) || '');
+  }
+
+  function escapeText(value) {
+    return String(value).replace(/[&<>"']/g, function (ch) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch];
+    });
+  }
+
+  function showAnnotationCard(target, options) {
+    options = options || {};
+    var root = ensureShadow();
+    closeCard();
+
+    var ctx = options.context || context(target);
+    if (options.range) {
+      highlightTextRange(options.range);
+    } else {
+      selected = target;
+      highlightElement(selected);
+    }
+
+    var rect;
+    try {
+      var src = options.range || target;
+      rect = src && src.getBoundingClientRect ? src.getBoundingClientRect() : null;
+    } catch (_) {
+      rect = null;
+    }
+    if (!rect) rect = { left: 12, bottom: 12, top: 12, right: 12, width: 0, height: 0 };
+    var card = document.createElement('div');
+    card.className = 'aod-annotation-card';
+    card.setAttribute('data-ai-or-die-ui', 'card');
+    var heading = ctx.tag === 'text' ? 'Comment on selection' : 'Comment on &lt;' + escapeText(ctx.tag) + '&gt;';
+    var placeholder = ctx.tag === 'text'
+      ? 'Tell the agent what to change about this text…'
+      : 'Tell the agent what to change about this element…';
+    card.innerHTML =
+      '<div class="aod-heading">' + heading + '</div>' +
+      '<textarea placeholder="' + escapeText(placeholder) + '"></textarea>' +
+      '<div class="aod-hint">Enter to queue &middot; ' + (isMac() ? '⌘' : 'Ctrl') + '+Enter to send now &middot; Esc to cancel</div>' +
+      '<div class="aod-row"><button class="aod-cancel" type="button">Cancel</button><button class="aod-send" type="button">Queue</button></div>';
+    root.appendChild(card);
+
+    var left = Math.min(Math.max(12, rect.left), window.innerWidth - card.offsetWidth - 12);
+    var top = Math.min(Math.max(12, rect.bottom + 8), window.innerHeight - card.offsetHeight - 12);
+    card.style.left = left + 'px';
+    card.style.top = top + 'px';
+
+    var textarea = card.querySelector('textarea');
+    var cancelButton = card.querySelector('.aod-cancel');
+    var sendButton = card.querySelector('.aod-send');
+    if (!textarea || !cancelButton || !sendButton) return;
+
+    cancelButton.onclick = closeCard;
+    sendButton.onclick = function () {
+      var promptText = textarea.value.trim();
+      if (promptText) queueAnnotation(buildAnnotation(ctx, promptText));
+      closeCard();
+    };
+    textarea.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeCard();
+        return;
+      }
+      if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
+        event.preventDefault();
+        var sendNow = (event.ctrlKey || event.metaKey) && !!textarea.value.trim();
+        sendButton.click();
+        // postMessage delivery is ordered, so the queued annotation lands first.
+        if (sendNow) sendQueued();
+      }
+    });
+    setTimeout(function () { textarea.focus(); }, 0);
+  }
+
+  // ---- inbound host messages (agent-reply / presence / mode / scroll) -------
+
+  function handleHostMessage(event) {
+    var data = event && event.data;
+    if (!data || data.source !== HOST_SOURCE) return;
+    // Authenticate the sender: host messages come from our parent (the panel).
+    // When the SDK runs without a real parent, window.parent === window, so a
+    // self-sourced message is also accepted. Anything else is a spoof.
+    var expected = (window.parent && window.parent !== window) ? window.parent : window;
+    if (event.source && event.source !== expected) return;
+    if (data.sessionId && config.sessionId && data.sessionId !== config.sessionId) return;
+
+    if (data.type === 'set-annotation-mode') {
+      setAnnotationMode(data.payload && data.payload.enabled);
+    }
+    if (data.type === 'request-snapshot') {
+      // The panel owns the queue but wants the live DOM snapshot to attach to a
+      // Send. Reply with one so panel-Send carries the same context as the SDK's
+      // own Cmd/Ctrl+Enter send path.
+      post('artifact-snapshot', { domSnapshot: readDomSnapshot() });
+    }
+    if (data.type === 'restore-scroll') {
+      var p = data.payload || {};
+      window.scrollTo(Number(p.x) || 0, Number(p.y) || 0);
+    }
+    if (data.type === 'agent-reply') {
+      window.dispatchEvent(new CustomEvent('ai-or-die-artifact-agent-reply', { detail: data.payload || {} }));
+    }
+    if (data.type === 'presence') {
+      window.dispatchEvent(new CustomEvent('ai-or-die-artifact-presence', { detail: data.payload || {} }));
+    }
+  }
+
+  window.addEventListener('message', handleHostMessage);
+
+  // ---- scroll preservation ---------------------------------------------------
+
+  var scrollFrame = 0;
+  window.addEventListener('scroll', function () {
+    if (scrollFrame) return;
+    scrollFrame = window.requestAnimationFrame(function () {
+      scrollFrame = 0;
+      post('artifact-scroll', { x: window.scrollX, y: window.scrollY });
+    });
+  }, { passive: true });
+
+  // ---- pointer interactions --------------------------------------------------
+
+  document.addEventListener('mouseover', function (event) {
+    if (shouldIgnore(event.target)) return;
+    if (event.target === selected) return;
+    if (hovered && hovered !== selected) clearHighlight(hovered);
+    hovered = event.target;
+    highlightElement(hovered);
+  }, true);
+
+  document.addEventListener('mouseout', function () {
+    if (hovered && hovered !== selected) {
+      clearHighlight(hovered);
+      hovered = null;
+    }
+  }, true);
+
+  document.addEventListener('mouseup', function (event) {
+    if (shouldIgnore(event.target)) return;
+    var ctx = textSelectionContext(document.getSelection());
+    if (!ctx) return;
+    ignoreNextClick = true;
+    showAnnotationCard(ctx.element, { context: ctx, range: ctx.range });
+  }, true);
+
+  document.addEventListener('click', function (event) {
+    if (shouldIgnore(event.target)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (ignoreNextClick) {
+      ignoreNextClick = false;
+      return;
+    }
+    showAnnotationCard(event.target);
+  }, true);
+
+  // ---- legacy API (backward-compat) -----------------------------------------
+  // The previous SDK exposed window.lavish + prompt/queuePrompts/ask/request/
+  // warnLayout and posted the 'artifact-prompts' / 'artifact-layout-warnings'
+  // message types (still advertised by injectLavishSdk's config). Existing
+  // artifacts/tests rely on these to deliver feedback to /poll, so keep them
+  // working alongside the new annotation API. These post the OLD message types;
+  // the panel still handles both.
+
   function normalizePrompts(prompts) {
     if (Array.isArray(prompts)) return prompts;
     if (prompts == null) return [];
     return [String(prompts)];
   }
 
-  function queuePrompts(prompts, options) {
+  function legacyQueuePrompts(prompts, options) {
     options = options || {};
-    return post(config.promptsMessageType || 'artifact-prompts', {
+    post(config.promptsMessageType || 'artifact-prompts', {
       prompts: normalizePrompts(prompts),
       domSnapshot: Object.prototype.hasOwnProperty.call(options, 'domSnapshot')
         ? clone(options.domSnapshot)
@@ -82,52 +534,31 @@
     });
   }
 
-  function recordLayoutWarnings(warnings) {
-    return post(config.layoutWarningsMessageType || 'artifact-layout-warnings', {
+  function legacyRecordLayoutWarnings(warnings) {
+    post(config.layoutWarningsMessageType || 'artifact-layout-warnings', {
       layout_warnings: Array.isArray(warnings) ? clone(warnings) : [],
     });
   }
 
-  function handleMessage(event) {
-    var data = event && event.data;
-    if (!data || data.source !== 'ai-or-die-artifact-host') return;
-    if (data.sessionId && config.sessionId && data.sessionId !== config.sessionId) return;
-
-    var waiter = data.replyTo && pending[data.replyTo];
-    if (waiter) {
-      clearTimeout(waiter.timeout);
-      delete pending[data.replyTo];
-      if (data.error) waiter.reject(new Error(data.error));
-      else waiter.resolve(data.payload);
-    }
-
-    if (data.type === 'agent-reply') {
-      window.dispatchEvent(new CustomEvent('ai-or-die-artifact-agent-reply', {
-        detail: data.payload || {},
-      }));
-    }
-    if (data.type === 'presence') {
-      window.dispatchEvent(new CustomEvent('ai-or-die-artifact-presence', {
-        detail: data.payload || {},
-      }));
-    }
-  }
-
-  window.addEventListener('message', handleMessage);
+  // ---- public surface (parity with prior SDK so the panel + tests work) -----
 
   var api = {
     config: clone(config),
     post: post,
-    request: request,
-    prompt: queuePrompts,
-    queuePrompts: queuePrompts,
-    ask: queuePrompts,
-    warnLayout: recordLayoutWarnings,
-    recordLayoutWarnings: recordLayoutWarnings,
+    queue: function (ctx, promptText) { queueAnnotation(buildAnnotation(ctx || {}, promptText)); },
+    send: sendQueued,
+    setAnnotationMode: setAnnotationMode,
     snapshot: readDomSnapshot,
+    // Legacy aliases (post the old 'artifact-prompts' / 'artifact-layout-warnings').
+    prompt: legacyQueuePrompts,
+    queuePrompts: legacyQueuePrompts,
+    ask: legacyQueuePrompts,
+    warnLayout: legacyRecordLayoutWarnings,
+    recordLayoutWarnings: legacyRecordLayoutWarnings,
   };
-
   window.lavish = window.lavish || api;
   window.aiOrDieArtifact = api;
+
+  setAnnotationMode(annotationMode);
   post('artifact-ready', { domSnapshot: readDomSnapshot() });
 })();

--- a/src/public/artifact-panel.js
+++ b/src/public/artifact-panel.js
@@ -52,6 +52,7 @@
       this._sseSessionId = null;
       this._collapsed = false;   // session-show gate (switched-away / closed)
       this._minimized = false;   // window minimized to header bar
+      this._maximized = false;   // window expanded to fill the wrapper
       this._queue = [];          // queued annotations (the pills); panel-owned
       this._presence = 'waiting';
       this.onStateChange = null;
@@ -98,12 +99,14 @@
       const presence = el('span', { class: 'artifact-panel__presence', id: 'artifactPresence', text: '' });
       const spacer = el('span', { class: 'artifact-panel__spacer' });
       const reloadBtn = el('button', { class: 'artifact-panel__btn', title: 'Reload artifact', 'aria-label': 'Reload artifact', type: 'button', text: '↻' });
+      this._maxBtn = el('button', { class: 'artifact-panel__btn', title: 'Maximize', 'aria-label': 'Maximize panel', type: 'button', text: '⤢' });
       this._minBtn = el('button', { class: 'artifact-panel__btn', title: 'Minimize', 'aria-label': 'Minimize panel', type: 'button', text: '–' });
       const closeBtn = el('button', { class: 'artifact-panel__btn', title: 'Close panel', 'aria-label': 'Close panel', type: 'button', text: '×' });
       reloadBtn.addEventListener('click', () => this.reload());
+      this._maxBtn.addEventListener('click', () => this.toggleMaximize());
       this._minBtn.addEventListener('click', () => this.toggleMinimize());
       closeBtn.addEventListener('click', () => this.collapse());
-      this._header = el('div', { class: 'artifact-panel__header' }, [title, presence, spacer, reloadBtn, this._minBtn, closeBtn]);
+      this._header = el('div', { class: 'artifact-panel__header' }, [title, presence, spacer, reloadBtn, this._maxBtn, this._minBtn, closeBtn]);
       this._wireDrag(this._header);
 
       this._iframe = el('iframe', {
@@ -294,6 +297,8 @@
     // ---- minimize ---------------------------------------------------------
     toggleMinimize() {
       this._minimized = !this._minimized;
+      // Minimize and maximize are mutually exclusive.
+      if (this._minimized && this._maximized) { this._maximized = false; this._applyMaximized(); }
       this._applyMinimized();
       this._saveLayout();
       this._emitState();
@@ -301,11 +306,32 @@
     _applyMinimized() {
       this.el.classList.toggle('artifact-panel--minimized', this._minimized);
       if (this._body) this._body.hidden = this._minimized;
-      if (this._resizeHandle) this._resizeHandle.hidden = this._minimized;
+      if (this._resizeHandle) this._resizeHandle.hidden = this._minimized || this._maximized;
       if (this._minBtn) {
         this._minBtn.textContent = this._minimized ? '□' : '–';
         this._minBtn.setAttribute('title', this._minimized ? 'Restore' : 'Minimize');
         this._minBtn.setAttribute('aria-label', this._minimized ? 'Restore panel' : 'Minimize panel');
+      }
+    }
+
+    // ---- maximize ---------------------------------------------------------
+    // Expand the panel to fill the wrapper for a focused, lavish-style full view;
+    // toggle back to the prior size. The CSS class overrides the inline
+    // left/top/width/height with !important, so restoring just removes the class
+    // and the previous geometry reappears — no manual save/restore needed.
+    toggleMaximize() {
+      this._maximized = !this._maximized;
+      if (this._maximized && this._minimized) { this._minimized = false; this._applyMinimized(); }
+      this._applyMaximized();
+      this._emitState();
+    }
+    _applyMaximized() {
+      this.el.classList.toggle('artifact-panel--maximized', this._maximized);
+      if (this._resizeHandle) this._resizeHandle.hidden = this._maximized || this._minimized;
+      if (this._maxBtn) {
+        this._maxBtn.textContent = this._maximized ? '❐' : '⤢';
+        this._maxBtn.setAttribute('title', this._maximized ? 'Restore size' : 'Maximize');
+        this._maxBtn.setAttribute('aria-label', this._maximized ? 'Restore panel size' : 'Maximize panel');
       }
     }
 

--- a/src/public/artifact-panel.js
+++ b/src/public/artifact-panel.js
@@ -2,21 +2,27 @@
 
 // Per-tab artifact-review panel (Track A / ADR-0033). When the server broadcasts
 // `artifact_review_opened` for a tab (the in-session agent called artifact_open),
-// this panel renders the agent's HTML artifact in an iframe — served + SDK-injected
-// by ai-or-die at /api/artifact/:sessionId/view — and runs the human-in-the-loop
+// this panel renders the agent's artifact in an iframe — served + SDK-injected by
+// ai-or-die at /api/artifact/:sessionId/view — and runs the human-in-the-loop
 // review loop over the existing authed tunnel:
 //
-//   iframe SDK  --postMessage-->  panel  --authed POST-->  /api/artifact/:id/prompts
-//   /api/artifact/:id/events (SSE)  -->  panel  --postMessage-->  iframe SDK (agent-reply)
+//   iframe SDK  --postMessage-->  panel (queue + pills)  --Send--> POST /prompts
+//   /api/artifact/:id/events (SSE)  -->  panel  --postMessage-->  iframe SDK
 //
-// The browser never trusts the agent's token from the broadcast viewUrl; every URL
-// is (re)built with the client's own auth token (window.authManager). Modeled on
-// StickyNoteCard: self-builds DOM, self-mounts to .terminal-wrapper, one instance,
-// per-session state keyed by claude sessionId, shown only for the active tab.
+// The panel is a floating window: drag the header to move, drag the corner to
+// resize, minimize to the header bar. Position/size/minimized persist in
+// localStorage. The panel owns the annotation queue (rendered as removable pills);
+// the SDK only emits queue/send intents. The browser never trusts the agent's
+// token from the broadcast viewUrl; every URL is (re)built with the client's own
+// auth token (window.authManager).
 
 (function () {
   const SDK_SOURCE_IN = 'ai-or-die-artifact-sdk';   // messages FROM the iframe
   const HOST_SOURCE_OUT = 'ai-or-die-artifact-host'; // messages TO the iframe
+  const STORE_KEY = 'ai-or-die:artifact-panel:layout';
+
+  const MIN_W = 320;
+  const MIN_H = 240;
 
   function el(tag, attrs, children) {
     const node = document.createElement(tag);
@@ -31,59 +37,276 @@
     return node;
   }
 
+  function clampNumber(value, min, max) {
+    if (typeof value !== 'number' || !isFinite(value)) return min;
+    return Math.min(Math.max(value, min), max);
+  }
+
   class ArtifactPanel {
     constructor(app) {
       this.app = app;
-      // Per-session review state: sessionId -> { sessionId, viewUrl, file, ready }
+      // Per-session review state: sessionId -> { sessionId, viewUrl, file, ready, scroll }
       this.reviews = new Map();
       this.activeSessionId = null;
       this._sse = null;          // active EventSource (for the shown session)
       this._sseSessionId = null;
-      this._collapsed = false;
+      this._collapsed = false;   // session-show gate (switched-away / closed)
+      this._minimized = false;   // window minimized to header bar
+      this._queue = [];          // queued annotations (the pills); panel-owned
+      this._presence = 'waiting';
       this.onStateChange = null;
 
+      this._layout = this._loadLayout();
       this._buildDom();
+      this._applyLayout();
+      this._minimized = !!this._layout.minimized;
+      this._applyMinimized();
+
       this._onWindowMessage = (e) => this._handleIframeMessage(e);
       window.addEventListener('message', this._onWindowMessage);
+      // Re-clamp on viewport/wrapper resize so a shrinking window can't strand
+      // the panel header out of reach.
+      this._onWindowResize = () => { if (!this.el.hidden) this._clampToBounds(); };
+      window.addEventListener('resize', this._onWindowResize);
+    }
+
+    // ---- persisted layout -------------------------------------------------
+    _loadLayout() {
+      try {
+        const raw = window.localStorage.getItem(STORE_KEY);
+        const parsed = raw ? JSON.parse(raw) : null;
+        if (parsed && typeof parsed === 'object') return parsed;
+      } catch (_) { /* storage unavailable / corrupt */ }
+      return {};
+    }
+    _saveLayout() {
+      try {
+        window.localStorage.setItem(STORE_KEY, JSON.stringify({
+          left: this._layout.left,
+          top: this._layout.top,
+          width: this._layout.width,
+          height: this._layout.height,
+          minimized: this._minimized,
+        }));
+      } catch (_) { /* non-fatal */ }
     }
 
     _buildDom() {
-      this.el = el('div', { class: 'artifact-panel', id: 'artifactPanel', hidden: 'hidden' });
+      this.el = el('div', { class: 'artifact-panel', id: 'artifactPanel', hidden: 'hidden', role: 'dialog', 'aria-label': 'Artifact review' });
 
       const title = el('span', { class: 'artifact-panel__title', text: 'Artifact review' });
       const presence = el('span', { class: 'artifact-panel__presence', id: 'artifactPresence', text: '' });
       const spacer = el('span', { class: 'artifact-panel__spacer' });
-      const reloadBtn = el('button', { class: 'artifact-panel__btn', title: 'Reload artifact', type: 'button', text: '⟳' });
-      const closeBtn = el('button', { class: 'artifact-panel__btn', title: 'Close panel', type: 'button', text: '×' });
+      const reloadBtn = el('button', { class: 'artifact-panel__btn', title: 'Reload artifact', 'aria-label': 'Reload artifact', type: 'button', text: '↻' });
+      this._minBtn = el('button', { class: 'artifact-panel__btn', title: 'Minimize', 'aria-label': 'Minimize panel', type: 'button', text: '–' });
+      const closeBtn = el('button', { class: 'artifact-panel__btn', title: 'Close panel', 'aria-label': 'Close panel', type: 'button', text: '×' });
       reloadBtn.addEventListener('click', () => this.reload());
+      this._minBtn.addEventListener('click', () => this.toggleMinimize());
       closeBtn.addEventListener('click', () => this.collapse());
-      const header = el('div', { class: 'artifact-panel__header' }, [title, presence, spacer, reloadBtn, closeBtn]);
+      this._header = el('div', { class: 'artifact-panel__header' }, [title, presence, spacer, reloadBtn, this._minBtn, closeBtn]);
+      this._wireDrag(this._header);
 
       this._iframe = el('iframe', {
         class: 'artifact-panel__frame',
         id: 'artifactFrame',
         sandbox: 'allow-scripts allow-forms allow-same-origin',
         referrerpolicy: 'no-referrer',
+        title: 'Artifact preview',
       });
+      this._iframe.addEventListener('load', () => this._onIframeLoad());
+
+      // Queued-annotation pills + Send.
+      this._pills = el('div', { class: 'artifact-panel__pills', id: 'artifactPills' });
+      this._sendBtn = el('button', { class: 'artifact-panel__send', type: 'button', text: 'Send to agent' });
+      this._sendBtn.addEventListener('click', () => this._sendQueueWithSnapshot());
+      this._pillBar = el('div', { class: 'artifact-panel__pillbar', hidden: 'hidden' }, [this._pills, this._sendBtn]);
 
       this._chatLog = el('div', { class: 'artifact-panel__chat', id: 'artifactChat' });
       this._chatInput = el('input', {
         class: 'artifact-panel__input', id: 'artifactInput', type: 'text',
-        placeholder: 'Send a note to the agent…', autocomplete: 'off',
+        placeholder: 'Send a note to the agent…', autocomplete: 'off', 'aria-label': 'Note to the agent',
       });
-      const sendBtn = el('button', { class: 'artifact-panel__send', type: 'button', text: 'Send' });
-      sendBtn.addEventListener('click', () => this._submitNote());
+      const noteBtn = el('button', { class: 'artifact-panel__send artifact-panel__send--note', type: 'button', text: 'Send' });
+      noteBtn.addEventListener('click', () => this._submitNote());
       this._chatInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') this._submitNote(); });
-      const chatBar = el('div', { class: 'artifact-panel__chatbar' }, [this._chatInput, sendBtn]);
+      const chatBar = el('div', { class: 'artifact-panel__chatbar' }, [this._chatInput, noteBtn]);
 
-      this.el.appendChild(header);
-      this.el.appendChild(this._iframe);
-      this.el.appendChild(this._chatLog);
-      this.el.appendChild(chatBar);
+      this._resizeHandle = el('div', { class: 'artifact-panel__resize', 'aria-hidden': 'true' });
+      this._wireResize(this._resizeHandle);
+
+      this._body = el('div', { class: 'artifact-panel__body' }, [this._iframe, this._pillBar, this._chatLog, chatBar]);
+
+      this.el.appendChild(this._header);
+      this.el.appendChild(this._body);
+      this.el.appendChild(this._resizeHandle);
       this._refs = { presence };
 
       const wrapper = document.querySelector('.terminal-wrapper') || document.getElementById('terminalContainer') || document.body;
       if (wrapper) wrapper.appendChild(this.el);
+    }
+
+    // ---- floating-window geometry ----------------------------------------
+    _applyLayout() {
+      const L = this._layout;
+      if (typeof L.width === 'number') this.el.style.width = clampNumber(L.width, MIN_W, 4000) + 'px';
+      if (typeof L.height === 'number') this.el.style.height = clampNumber(L.height, MIN_H, 4000) + 'px';
+      // Position only when explicitly placed; otherwise the CSS default
+      // (anchored bottom-right) applies.
+      if (typeof L.left === 'number' && typeof L.top === 'number') {
+        this.el.style.left = L.left + 'px';
+        this.el.style.top = L.top + 'px';
+        this.el.style.right = 'auto';
+        this.el.style.bottom = 'auto';
+      }
+    }
+
+    // Keep the panel within the wrapper so a persisted off-screen position (e.g.
+    // saved on a larger window, or after the wrapper shrank) can't strand the
+    // header out of reach. No-op until a position has been set; clamps using the
+    // live panel size, then persists the corrected value. Safe to call when the
+    // panel is visible (a hidden panel measures 0x0, so we skip then).
+    _clampToBounds() {
+      const L = this._layout;
+      if (typeof L.left !== 'number' || typeof L.top !== 'number') return;
+      if (this.el.hidden) return;
+      const b = this._bounds();
+      const rect = this.el.getBoundingClientRect();
+      if (b.width <= 0 || b.height <= 0 || rect.width <= 0 || rect.height <= 0) return;
+      const left = clampNumber(L.left, 0, Math.max(0, b.width - rect.width));
+      const top = clampNumber(L.top, 0, Math.max(0, b.height - rect.height));
+      if (left !== L.left || top !== L.top) {
+        L.left = left;
+        L.top = top;
+        this._saveLayout();
+      }
+      this.el.style.left = left + 'px';
+      this.el.style.top = top + 'px';
+      this.el.style.right = 'auto';
+      this.el.style.bottom = 'auto';
+    }
+
+    _bounds() {
+      const wrapper = this.el.parentElement || document.body;
+      const wr = wrapper.getBoundingClientRect();
+      return { width: wr.width, height: wr.height };
+    }
+
+    _wireDrag(handle) {
+      let startX = 0, startY = 0, originLeft = 0, originTop = 0, dragging = false;
+      const onMove = (e) => {
+        if (!dragging) return;
+        const p = this._point(e);
+        const b = this._bounds();
+        const rect = this.el.getBoundingClientRect();
+        let left = clampNumber(originLeft + (p.x - startX), 0, Math.max(0, b.width - rect.width));
+        let top = clampNumber(originTop + (p.y - startY), 0, Math.max(0, b.height - rect.height));
+        this._layout.left = left;
+        this._layout.top = top;
+        this.el.style.left = left + 'px';
+        this.el.style.top = top + 'px';
+        this.el.style.right = 'auto';
+        this.el.style.bottom = 'auto';
+      };
+      const onUp = () => {
+        if (!dragging) return;
+        dragging = false;
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        this._dragCleanup = null;
+        this._saveLayout();
+      };
+      handle.addEventListener('mousedown', (e) => {
+        // Ignore drags that start on a header button.
+        if (e.target && e.target.closest && e.target.closest('.artifact-panel__btn')) return;
+        e.preventDefault();
+        const p = this._point(e);
+        const wrapper = this.el.parentElement || document.body;
+        const wr = wrapper.getBoundingClientRect();
+        const rect = this.el.getBoundingClientRect();
+        // Convert current rect to wrapper-relative left/top so the first drag
+        // doesn't jump when the panel was positioned via right/bottom CSS.
+        originLeft = rect.left - wr.left;
+        originTop = rect.top - wr.top;
+        startX = p.x;
+        startY = p.y;
+        dragging = true;
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+        // Let destroy() detach an in-progress drag (mouseup may never fire if
+        // the panel is torn down or the pointer leaves the window).
+        this._dragCleanup = () => {
+          document.removeEventListener('mousemove', onMove);
+          document.removeEventListener('mouseup', onUp);
+        };
+      });
+    }
+
+    _wireResize(handle) {
+      let startX = 0, startY = 0, originW = 0, originH = 0, resizing = false;
+      const onMove = (e) => {
+        if (!resizing) return;
+        const p = this._point(e);
+        const b = this._bounds();
+        const rect = this.el.getBoundingClientRect();
+        const wrapper = this.el.parentElement || document.body;
+        const wr = wrapper.getBoundingClientRect();
+        const maxW = Math.max(MIN_W, b.width - (rect.left - wr.left));
+        const maxH = Math.max(MIN_H, b.height - (rect.top - wr.top));
+        const width = clampNumber(originW + (p.x - startX), MIN_W, maxW);
+        const height = clampNumber(originH + (p.y - startY), MIN_H, maxH);
+        this._layout.width = width;
+        this._layout.height = height;
+        this.el.style.width = width + 'px';
+        this.el.style.height = height + 'px';
+      };
+      const onUp = () => {
+        if (!resizing) return;
+        resizing = false;
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        this._resizeCleanup = null;
+        this._saveLayout();
+      };
+      handle.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const p = this._point(e);
+        const rect = this.el.getBoundingClientRect();
+        originW = rect.width;
+        originH = rect.height;
+        startX = p.x;
+        startY = p.y;
+        resizing = true;
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+        this._resizeCleanup = () => {
+          document.removeEventListener('mousemove', onMove);
+          document.removeEventListener('mouseup', onUp);
+        };
+      });
+    }
+
+    _point(e) {
+      if (e.touches && e.touches[0]) return { x: e.touches[0].clientX, y: e.touches[0].clientY };
+      return { x: e.clientX, y: e.clientY };
+    }
+
+    // ---- minimize ---------------------------------------------------------
+    toggleMinimize() {
+      this._minimized = !this._minimized;
+      this._applyMinimized();
+      this._saveLayout();
+      this._emitState();
+    }
+    _applyMinimized() {
+      this.el.classList.toggle('artifact-panel--minimized', this._minimized);
+      if (this._body) this._body.hidden = this._minimized;
+      if (this._resizeHandle) this._resizeHandle.hidden = this._minimized;
+      if (this._minBtn) {
+        this._minBtn.textContent = this._minimized ? '□' : '–';
+        this._minBtn.setAttribute('title', this._minimized ? 'Restore' : 'Minimize');
+        this._minBtn.setAttribute('aria-label', this._minimized ? 'Restore panel' : 'Minimize panel');
+      }
     }
 
     // ---- token / url helpers (always the CLIENT's own token) --------------
@@ -108,6 +331,7 @@
         viewUrl: this._authUrl('/view', sessionId), // client-token URL, not the broadcast's
         file: message.file || null,
         ready: false,
+        scroll: { x: 0, y: 0 },
       });
       if (sessionId === this.activeSessionId) this._show(sessionId);
       this._emitState();
@@ -118,7 +342,7 @@
       if (!sessionId) return;
       this.reviews.delete(sessionId);
       if (sessionId === this._sseSessionId) this._teardownSse();
-      if (sessionId === this.activeSessionId) this._hide();
+      if (sessionId === this.activeSessionId) { this._clearQueue(); this._hide(); }
       this._emitState();
     }
 
@@ -129,13 +353,23 @@
       if (sessionId === this.activeSessionId) {
         this._appendChat('agent', text);
         this._postToIframe('agent-reply', { text });
+        // The agent responded, so it is no longer mid-turn: re-enable Send.
+        if (this._presence === 'working') this._setPresence('listening');
       }
     }
 
     notifyActiveSessionChanged(sessionId) {
       this.activeSessionId = sessionId ? String(sessionId) : null;
+      this._cancelPendingSnapshot();
+      this._clearQueue();
       if (this.activeSessionId && this.reviews.has(this.activeSessionId)) this._show(this.activeSessionId);
       else this._hide();
+    }
+
+    _cancelPendingSnapshot() {
+      if (this._snapshotTimer) { clearTimeout(this._snapshotTimer); this._snapshotTimer = null; }
+      this._snapshotPending = false;
+      this._snapshotSession = null;
     }
 
     // ---- show / hide -----------------------------------------------------
@@ -144,12 +378,16 @@
       if (!review) return;
       if (this._iframe.getAttribute('data-session') !== sessionId) {
         this._chatLog.innerHTML = '';
+        this._clearQueue();
         this._iframe.setAttribute('data-session', sessionId);
         this._iframe.src = review.viewUrl;
       }
       this._connectSse(sessionId);
       this._collapsed = false;
       this.el.hidden = false;
+      // Now that the panel is visible (and measurable), pull any off-screen
+      // persisted position back into the wrapper so the header stays grabbable.
+      this._clampToBounds();
     }
     _hide() {
       this.el.hidden = true;
@@ -173,19 +411,33 @@
     }
 
     // Server-driven auto live-reload: file changed under review. Only the active
-    // tab's iframe is cache-busted; the chat/feedback box is untouched.
+    // tab's iframe is cache-busted; the chat/queue box is untouched.
     reloadReview(message) {
       const sessionId = message && message.sessionId ? String(message.sessionId) : this.activeSessionId;
       if (!sessionId || sessionId !== this.activeSessionId || !this.reviews.has(sessionId)) return;
       this.reload();
     }
 
+    _onIframeLoad() {
+      const sessionId = this.activeSessionId;
+      if (!sessionId || !this.reviews.has(sessionId)) return;
+      const review = this.reviews.get(sessionId);
+      // Replay the pre-reload scroll position so hot reloads don't jump to top.
+      const scroll = (review && review.scroll) || { x: 0, y: 0 };
+      this._postToIframe('restore-scroll', { x: scroll.x, y: scroll.y });
+      this._postToIframe('set-annotation-mode', { enabled: true });
+    }
+
     // ---- iframe <-> server bridge ----------------------------------------
     _handleIframeMessage(event) {
       const data = event && event.data;
       if (!data || data.source !== SDK_SOURCE_IN) return;
+      // Authenticate the sender: only our own artifact iframe may drive the
+      // queue / network. A foreign window that knows the source string can't
+      // spoof annotations or trigger an authed POST. (lavish chrome pattern.)
+      if (!this._iframe || event.source !== this._iframe.contentWindow) return;
       const sessionId = data.sessionId ? String(data.sessionId) : this.activeSessionId;
-      if (!sessionId || !this.reviews.has(sessionId)) return;
+      if (!sessionId || !this.reviews.has(sessionId) || sessionId !== this.activeSessionId) return;
       const payload = data.payload || {};
 
       if (data.type === 'artifact-ready') {
@@ -193,11 +445,39 @@
         if (review) review.ready = true;
         return;
       }
+      if (data.type === 'artifact-annotation-queued') {
+        if (payload.annotation) this._enqueueAnnotation(payload.annotation);
+        return;
+      }
+      if (data.type === 'artifact-annotations-send') {
+        this._sendQueue(payload.domSnapshot);
+        return;
+      }
+      if (data.type === 'artifact-snapshot') {
+        // Reply to a panel-initiated snapshot request: flush the queue with it,
+        // but only if we still have a request pending for the CURRENT session.
+        if (this._snapshotPending) {
+          if (this._snapshotTimer) { clearTimeout(this._snapshotTimer); this._snapshotTimer = null; }
+          this._snapshotPending = false;
+          if (this._snapshotSession === this.activeSessionId) this._sendQueue(payload.domSnapshot);
+        }
+        return;
+      }
+      if (data.type === 'artifact-scroll') {
+        const review = this.reviews.get(sessionId);
+        if (review) review.scroll = { x: Number(payload.x) || 0, y: Number(payload.y) || 0 };
+        return;
+      }
+      // Legacy message types (backward-compat with the pre-annotation SDK and
+      // existing artifacts). 'artifact-prompts' POSTs immediately (the old
+      // contract had no queue); 'artifact-layout-warnings' forwards to the
+      // layout-warnings endpoint. The new annotation API is primary; these stay
+      // so older artifacts still deliver feedback to /poll.
       if (data.type === 'artifact-prompts') {
         const prompts = Array.isArray(payload.prompts) ? payload.prompts : [];
         if (prompts.length) {
           this._post('/prompts', sessionId, { prompts, domSnapshot: payload.domSnapshot });
-          prompts.forEach((p) => this._appendChat('you', typeof p === 'string' ? p : JSON.stringify(p)));
+          prompts.forEach((p) => this._appendChat('you', typeof p === 'string' ? p : (p && (p.prompt || p.text)) || JSON.stringify(p)));
         }
         return;
       }
@@ -220,7 +500,90 @@
         method: 'POST',
         headers: this._authHeaders(),
         body: JSON.stringify(body || {}),
-      }).catch(() => { /* surfaced via the agent's poll cadence; non-fatal in UI */ });
+      }).then(
+        (res) => !!(res && res.ok),
+        () => false
+      );
+    }
+
+    // ---- annotation queue + pills ----------------------------------------
+    _enqueueAnnotation(annotation) {
+      if (!annotation || typeof annotation !== 'object') return;
+      this._queue.push(annotation);
+      this._renderQueue();
+    }
+    _clearQueue() {
+      this._queue = [];
+      this._renderQueue();
+    }
+    _renderQueue() {
+      if (!this._pills) return;
+      this._pills.innerHTML = '';
+      this._queue.forEach((annotation, index) => {
+        const label = (annotation.prompt || annotation.text || annotation.selector || 'annotation').toString();
+        const pill = el('div', { class: 'artifact-panel__pill' });
+        const preview = el('span', { class: 'artifact-panel__pill-text', title: annotation.selector || '', text: label });
+        const remove = el('button', { class: 'artifact-panel__pill-x', type: 'button', 'aria-label': 'Remove queued annotation', text: '×' });
+        remove.addEventListener('click', () => { this._queue.splice(index, 1); this._renderQueue(); });
+        pill.appendChild(preview);
+        pill.appendChild(remove);
+        this._pills.appendChild(pill);
+      });
+      this._pillBar.hidden = this._queue.length === 0;
+      if (this._sendBtn) this._sendBtn.disabled = this._queue.length === 0 || this._presence === 'working';
+    }
+    // Panel "Send to agent": ask the iframe SDK for a live DOM snapshot, then
+    // flush the queue with it — so panel-Send carries the same context the SDK's
+    // own Cmd/Ctrl+Enter send does. Falls back to sending without a snapshot if
+    // the iframe doesn't reply promptly (sandboxed / not ready).
+    _sendQueueWithSnapshot() {
+      const sessionId = this.activeSessionId;
+      if (!sessionId || this._queue.length === 0) return;
+      if (this._snapshotPending) return; // a request is already in flight
+      this._snapshotPending = true;
+      this._snapshotSession = sessionId;
+      this._postToIframe('request-snapshot', {});
+      this._snapshotTimer = setTimeout(() => {
+        this._snapshotTimer = null;
+        if (!this._snapshotPending) return;
+        this._snapshotPending = false;
+        // Bail if the user switched sessions while we waited — don't flush a
+        // different session's queue.
+        if (this._snapshotSession !== this.activeSessionId) return;
+        this._sendQueue(); // no snapshot — it is optional metadata
+      }, 250);
+    }
+    _sendQueue(domSnapshot) {
+      const sessionId = this.activeSessionId;
+      if (!sessionId || !this.reviews.has(sessionId) || this._queue.length === 0) return;
+      const prompts = this._queue.slice();
+      // Optimistically clear so the pills reflect "sending"; restore them to the
+      // FRONT of the queue if the POST fails (network error or non-2xx) so the
+      // user's annotations are never silently lost and can be retried.
+      this._clearQueue();
+      prompts.forEach((p) => this._appendChat('you', (p && (p.prompt || p.text)) ? String(p.prompt || p.text) : JSON.stringify(p)));
+      if (this._presence === 'listening') this._setPresence('working');
+      let settle;
+      try {
+        settle = this._post('/prompts', sessionId, { prompts, domSnapshot: domSnapshot });
+      } catch (err) {
+        // A synchronous failure (e.g. JSON.stringify on a bad payload) must still
+        // clear the optimistic 'working' state and restore the queue.
+        settle = Promise.resolve(false);
+      }
+      settle.then((ok) => {
+        // Only touch presence/queue if this is still the SAME active session — a
+        // stale resolution after a tab switch must not mutate the new session.
+        if (sessionId !== this.activeSessionId) return;
+        // Clear the optimistic 'working' state once the round-trip settles so
+        // Send is never left permanently disabled (an agent-reply also clears it,
+        // but the POST may complete with no reply, or fail).
+        if (this._presence === 'working') this._setPresence('listening');
+        if (ok) return;
+        this._queue = prompts.concat(this._queue);
+        this._renderQueue();
+        this._appendChat('agent', 'Could not send your annotations. They were restored to the queue — press Send to retry.');
+      });
     }
 
     _submitNote() {
@@ -239,6 +602,19 @@
       this._chatLog.scrollTop = this._chatLog.scrollHeight;
     }
 
+    // ---- presence ---------------------------------------------------------
+    _setPresence(state) {
+      this._presence = (state === 'listening' || state === 'working') ? state : 'waiting';
+      if (this._refs && this._refs.presence) {
+        const label = this._presence === 'working' ? 'Working…'
+          : this._presence === 'listening' ? 'Listening'
+          : 'Waiting';
+        this._refs.presence.textContent = label;
+        this._refs.presence.setAttribute('data-state', this._presence);
+      }
+      if (this._sendBtn) this._sendBtn.disabled = this._queue.length === 0 || this._presence === 'working';
+    }
+
     // ---- SSE (agent replies + presence + end) ----------------------------
     _connectSse(sessionId) {
       if (this._sseSessionId === sessionId && this._sse) return;
@@ -252,14 +628,21 @@
       this._sseSessionId = sessionId;
       src.addEventListener('agent-reply', (e) => {
         const d = this._parse(e.data);
-        if (d && typeof d.text === 'string') { this._appendChat('agent', d.text); this._postToIframe('agent-reply', { text: d.text }); }
+        if (d && typeof d.text === 'string') {
+          this._appendChat('agent', d.text);
+          this._postToIframe('agent-reply', { text: d.text });
+          if (this._presence === 'working') this._setPresence('listening');
+        }
       });
       src.addEventListener('presence', (e) => {
         const d = this._parse(e.data);
-        if (d && d.presence && this._refs.presence) {
-          this._refs.presence.textContent = d.presence.connected ? '● live' : '';
-        }
-        this._postToIframe('presence', (d && d.presence) || {});
+        const presence = (d && d.presence) || {};
+        // SSE presence carries { connected, lastSeen, ... }. Map to a coarse
+        // agent state when available, else just reflect connectivity.
+        if (typeof presence.state === 'string') this._setPresence(presence.state);
+        else if (presence.connected) this._setPresence('listening');
+        else this._setPresence('waiting');
+        this._postToIframe('presence', presence);
       });
       src.addEventListener('ended', () => this.endReview({ sessionId }));
     }
@@ -272,13 +655,16 @@
 
     _emitState() {
       if (typeof this.onStateChange === 'function') {
-        this.onStateChange({ open: this.isOpenForActive(), collapsed: this._collapsed });
+        this.onStateChange({ open: this.isOpenForActive(), collapsed: this._collapsed, minimized: this._minimized });
       }
     }
 
     destroy() {
       window.removeEventListener('message', this._onWindowMessage);
+      if (this._onWindowResize) window.removeEventListener('resize', this._onWindowResize);
       this._teardownSse();
+      if (this._dragCleanup) { try { this._dragCleanup(); } catch (_) { /* ignore */ } this._dragCleanup = null; }
+      if (this._resizeCleanup) { try { this._resizeCleanup(); } catch (_) { /* ignore */ } this._resizeCleanup = null; }
       if (this.el && this.el.parentNode) this.el.parentNode.removeChild(this.el);
     }
   }

--- a/src/public/components/artifact-panel.css
+++ b/src/public/components/artifact-panel.css
@@ -32,6 +32,20 @@
   resize: none;
 }
 
+/* Maximized: fill the wrapper for a focused, full-area review. Overrides the
+   inline left/top/width/height set by drag/resize, so restoring (removing the
+   class) brings the prior geometry back with no manual save/restore. */
+.artifact-panel--maximized {
+  left: 8px !important;
+  top: 8px !important;
+  right: 8px !important;
+  bottom: 8px !important;
+  width: auto !important;
+  height: auto !important;
+  max-width: none !important;
+  max-height: none !important;
+}
+
 .artifact-panel__header {
   display: flex;
   align-items: center;

--- a/src/public/components/artifact-panel.css
+++ b/src/public/components/artifact-panel.css
@@ -1,5 +1,7 @@
-/* Artifact-review panel (Track A / ADR-0033). Per-tab overlay anchored bottom-right
-   of the terminal wrapper, mirroring the sticky-note card's placement language. */
+/* Artifact-review panel (Track A / ADR-0033). A floating window inside the
+   terminal wrapper: drag the header to move, drag the corner to resize, minimize
+   to the header bar. Position/size/minimized persist in localStorage. Default
+   placement is bottom-right (overridden once the user moves it). */
 .artifact-panel {
   position: absolute;
   right: 16px;
@@ -7,7 +9,9 @@
   width: 420px;
   max-width: calc(100% - 32px);
   height: 60%;
-  max-height: 70vh;
+  max-height: 80vh;
+  min-width: 320px;
+  min-height: 240px;
   display: flex;
   flex-direction: column;
   background: var(--panel-bg, #1b1d23);
@@ -21,6 +25,13 @@
 }
 .artifact-panel[hidden] { display: none; }
 
+/* Minimized: collapse to just the header bar. */
+.artifact-panel--minimized {
+  height: auto !important;
+  min-height: 0;
+  resize: none;
+}
+
 .artifact-panel__header {
   display: flex;
   align-items: center;
@@ -28,9 +39,18 @@
   padding: 8px 10px;
   background: var(--panel-header-bg, #232630);
   border-bottom: 1px solid var(--panel-border, #33363f);
+  cursor: move;
+  user-select: none;
+  flex: 0 0 auto;
 }
+.artifact-panel--minimized .artifact-panel__header { border-bottom: none; }
 .artifact-panel__title { font-weight: 600; }
-.artifact-panel__presence { color: #4ade80; font-size: 11px; }
+.artifact-panel__presence {
+  font-size: 11px;
+  color: var(--text-muted, #9aa0aa);
+}
+.artifact-panel__presence[data-state="listening"] { color: #4ade80; }
+.artifact-panel__presence[data-state="working"] { color: #fbbf24; }
 .artifact-panel__spacer { flex: 1; }
 .artifact-panel__btn {
   background: transparent;
@@ -43,13 +63,77 @@
   border-radius: 6px;
 }
 .artifact-panel__btn:hover { background: rgba(255, 255, 255, 0.08); }
+.artifact-panel__btn:focus-visible { outline: 2px solid var(--accent-default, #2563eb); outline-offset: 1px; }
+
+/* The body holds everything below the header; hidden when minimized. */
+.artifact-panel__body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.artifact-panel__body[hidden] { display: none; }
 
 .artifact-panel__frame {
   flex: 1;
   width: 100%;
   border: none;
   background: #fff;
+  min-height: 0;
 }
+
+/* Queued-annotation pills + Send. */
+.artifact-panel__pillbar {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  border-top: 1px solid var(--panel-border, #33363f);
+  background: var(--panel-bg, #1b1d23);
+}
+.artifact-panel__pillbar[hidden] { display: none; }
+.artifact-panel__pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  max-height: 84px;
+  overflow-y: auto;
+}
+.artifact-panel__pill {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  border: 1px solid var(--border-hover, #484f58);
+  border-radius: 999px;
+  background: var(--surface-elevated, #21262d);
+  color: var(--panel-fg, #e6e6e6);
+  padding: 4px 6px 4px 10px;
+  font-size: 12px;
+}
+.artifact-panel__pill-text {
+  display: block;
+  max-width: 180px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.artifact-panel__pill-x {
+  width: 18px;
+  height: 18px;
+  border: 0;
+  border-radius: 999px;
+  padding: 0;
+  background: var(--panel-border, #33363f);
+  color: var(--panel-fg, #e6e6e6);
+  line-height: 18px;
+  font-size: 13px;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+.artifact-panel__pill-x:hover { background: rgba(255, 255, 255, 0.16); }
 
 .artifact-panel__chat {
   max-height: 30%;
@@ -57,6 +141,7 @@
   padding: 6px 10px;
   border-top: 1px solid var(--panel-border, #33363f);
   background: var(--panel-bg, #1b1d23);
+  flex: 0 0 auto;
 }
 .artifact-panel__msg { margin: 3px 0; display: flex; gap: 6px; align-items: baseline; }
 .artifact-panel__role {
@@ -75,6 +160,7 @@
   gap: 6px;
   padding: 8px 10px;
   border-top: 1px solid var(--panel-border, #33363f);
+  flex: 0 0 auto;
 }
 .artifact-panel__input {
   flex: 1;
@@ -86,11 +172,29 @@
   font-size: 13px;
 }
 .artifact-panel__send {
-  background: var(--accent, #2563eb);
+  background: var(--accent-default, #2563eb);
   color: #fff;
   border: none;
   border-radius: 6px;
   padding: 6px 12px;
   cursor: pointer;
+  font-weight: 600;
+  white-space: nowrap;
 }
-.artifact-panel__send:hover { filter: brightness(1.1); }
+.artifact-panel__send:hover:not(:disabled) { filter: brightness(1.1); }
+.artifact-panel__send:disabled { opacity: 0.5; cursor: not-allowed; }
+.artifact-panel__send--note { font-weight: 500; }
+
+/* Resize handle, bottom-right corner. */
+.artifact-panel__resize {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 16px;
+  height: 16px;
+  cursor: nwse-resize;
+  z-index: 2;
+  background:
+    linear-gradient(135deg, transparent 0 50%, var(--border-hover, #484f58) 50% 60%, transparent 60% 70%, var(--border-hover, #484f58) 70% 80%, transparent 80%);
+}
+.artifact-panel__resize[hidden] { display: none; }

--- a/src/server.js
+++ b/src/server.js
@@ -139,6 +139,18 @@ class ClaudeCodeWebServer {
     let _baseFolder = process.cwd();
     try { _baseFolder = fs.realpathSync(_baseFolder); } catch (_) { /* keep cwd on failure */ }
     this.baseFolder = _baseFolder;
+    // Extra roots the ARTIFACT review routes (open/view only) may read, beyond
+    // baseFolder. Plan files live under ~/.claude/plans (outside the workspace),
+    // and an agent that can open them already has terminal/Read access to them —
+    // so the workspace sandbox would only block a legitimate review, not a real
+    // exfil path. General file-browser validatePath stays strict; this is
+    // artifact-scoped. Extend via AIORDIE_ARTIFACT_EXTRA_ROOTS (path-sep list).
+    this.artifactExtraRoots = (() => {
+      const roots = [path.join(os.homedir(), '.claude', 'plans')];
+      const extra = (process.env.AIORDIE_ARTIFACT_EXTRA_ROOTS || '').split(path.delimiter);
+      for (const r of extra) { if (r && r.trim()) roots.push(r.trim()); }
+      return roots.map((r) => { try { return fs.realpathSync(r); } catch (_) { return path.resolve(r); } });
+    })();
     // Session duration in hours (default to 5 hours from first message)
     this.sessionDurationHours = parseFloat(process.env.CLAUDE_SESSION_HOURS || options.sessionHours || 5);
     
@@ -723,6 +735,47 @@ class ClaudeCodeWebServer {
     return { valid: true, path: canonicalPath };
   }
 
+  /** True when targetPath (canonicalized) is within `root` (canonicalized). */
+  isPathWithinRoot(targetPath, root) {
+    try {
+      const resolvedTarget = this._canonicalizePathSync(targetPath);
+      const resolvedRoot = this._canonicalizePathSync(root);
+      const relative = path.relative(resolvedRoot, resolvedTarget);
+      return !relative.startsWith('..') && !path.isAbsolute(relative);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /**
+   * Path validator for the ARTIFACT review routes (open/view): allows baseFolder
+   * (like validatePath) OR any configured artifactExtraRoots (plan dir etc.), so
+   * a plan stored outside the workspace can be reviewed. Same symlink
+   * canonicalization as validatePath; the general file sandbox is unchanged.
+   */
+  validateArtifactPath(targetPath) {
+    const base = this.validatePath(targetPath);
+    if (base.valid) return base;
+    // baseFolder rejected it — retry against the extra roots using the same
+    // canonicalization validatePath applied.
+    if (!targetPath) return base;
+    let canonicalPath = path.resolve(targetPath);
+    try {
+      if (fs.existsSync(canonicalPath)) {
+        canonicalPath = fs.realpathSync(canonicalPath);
+      } else {
+        const parent = path.dirname(canonicalPath);
+        if (parent && parent !== canonicalPath && fs.existsSync(parent)) {
+          canonicalPath = path.join(fs.realpathSync(parent), path.basename(canonicalPath));
+        }
+      }
+    } catch (_) { /* keep lexical form */ }
+    for (const root of this.artifactExtraRoots || []) {
+      if (this.isPathWithinRoot(canonicalPath, root)) return { valid: true, path: canonicalPath };
+    }
+    return { valid: false, error: 'Access denied: Path is outside the allowed directory' };
+  }
+
   /**
    * Walk up from a file path looking for a `.git` entry (directory in a
    * regular repo, file in a worktree). Returns the absolute path of the
@@ -1202,7 +1255,7 @@ class ClaudeCodeWebServer {
     this.app.use('/api/control', createControlRouter(this._buildControlDeps()));
     this.app.use('/api/artifact', createArtifactReviewRouter({
       store: this.artifactReviews,
-      validatePath: (p) => this.validatePath(p),
+      validatePath: (p) => this.validateArtifactPath(p),
       mintAssetToken: (sid) => this._artifactAssetSigner.mint(sid),
       broadcastToSession: (sessionId, obj) => this.broadcastToSession(sessionId, obj),
       pollHoldMs: this.artifactPollHoldMs,

--- a/src/server.js
+++ b/src/server.js
@@ -4481,6 +4481,9 @@ class ClaudeCodeWebServer {
       AIORDIE_BASE_URL: `${this.useHttps ? 'https' : 'http'}://127.0.0.1:${this.port}`,
       AIORDIE_TOKEN: this.auth || 'noauth',
       AIORDIE_SESSION_ID: sessionId,
+      // Loopback self-signed cert: tell github-router's artifact client to relax
+      // TLS verification for this instance (it fails-closed for non-loopback).
+      AIORDIE_INSECURE_TLS: this.useHttps ? '1' : '0',
     };
   }
 

--- a/test/artifact-panel.test.js
+++ b/test/artifact-panel.test.js
@@ -93,22 +93,264 @@ describe('artifact-panel.js (DOM: iframe + SSE + postMessage bridge)', function 
     assert.equal(panel.el.hidden, true);
   });
 
-  it('forwards an iframe artifact-prompts message to POST /prompts', async function () {
+  it('queues an iframe annotation as a pill; Send POSTs the structured array to /prompts', async function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+
+    const annotation = {
+      uid: '3', selector: 'main > p:nth-of-type(2)', tag: 'p',
+      text: 'The footer is misaligned', prompt: 'make the header bigger', sourceLine: 12,
+    };
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotation-queued', sessionId: 'sid-1', payload: { annotation } },
+    }));
+    await Promise.resolve();
+
+    // Queued, not yet sent: a pill is rendered and nothing POSTed.
+    const pills = document.querySelectorAll('#artifactPills .artifact-panel__pill');
+    assert.equal(pills.length, 1, 'one pill rendered');
+    assert.ok(pills[0].textContent.includes('make the header bigger'));
+    assert.equal(posted.filter((p) => String(p.url).includes('/prompts')).length, 0, 'nothing POSTed on queue');
+
+    // Send requests a DOM snapshot from the iframe, then flushes on the reply.
+    document.querySelector('#artifactPanel .artifact-panel__send').click();
+    await Promise.resolve();
+    assert.equal(posted.filter((p) => String(p.url).includes('/prompts')).length, 0, 'waits for the snapshot reply');
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-snapshot', sessionId: 'sid-1', payload: { domSnapshot: { bodyText: 'live' } } },
+    }));
+    await Promise.resolve();
+
+    const call = posted.find((p) => String(p.url).includes('/prompts'));
+    assert.ok(call, 'POSTed to /prompts on Send');
+    assert.ok(String(call.url).includes('token=tok-123'));
+    const body = JSON.parse(call.opts.body);
+    assert.ok(Array.isArray(body.prompts) && body.prompts.length === 1, 'sends the structured annotation array');
+    assert.deepEqual(body.prompts[0], annotation);
+    assert.deepEqual(body.domSnapshot, { bodyText: 'live' }, 'panel Send carries the iframe snapshot');
+    assert.equal(document.querySelectorAll('#artifactPills .artifact-panel__pill').length, 0, 'queue cleared after send');
+  });
+
+  it('artifact-annotations-send from the iframe flushes the queue', async function () {
     const panel = new ArtifactPanel(app);
     panel.notifyActiveSessionChanged('sid-1');
     panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
 
     window.dispatchEvent(new window.MessageEvent('message', {
-      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-prompts', sessionId: 'sid-1', payload: { prompts: ['make the header bigger'] } },
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotation-queued', sessionId: 'sid-1', payload: { annotation: { prompt: 'fix spacing', selector: 'h1' } } },
+    }));
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotations-send', sessionId: 'sid-1', payload: { domSnapshot: { bodyText: 'snap' } } },
     }));
     await Promise.resolve();
 
     const call = posted.find((p) => String(p.url).includes('/prompts'));
     assert.ok(call, 'POSTed to /prompts');
-    assert.ok(String(call.url).includes('token=tok-123'));
     const body = JSON.parse(call.opts.body);
-    assert.deepEqual(body.prompts, ['make the header bigger']);
-    assert.ok(document.getElementById('artifactChat').textContent.includes('make the header bigger'));
+    assert.equal(body.prompts[0].prompt, 'fix spacing');
+    assert.deepEqual(body.domSnapshot, { bodyText: 'snap' });
+  });
+
+  it('a queued pill can be removed before sending', async function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotation-queued', sessionId: 'sid-1', payload: { annotation: { prompt: 'remove me', selector: 'div' } } },
+    }));
+    await Promise.resolve();
+    assert.equal(document.querySelectorAll('#artifactPills .artifact-panel__pill').length, 1);
+    document.querySelector('#artifactPills .artifact-panel__pill-x').click();
+    assert.equal(document.querySelectorAll('#artifactPills .artifact-panel__pill').length, 0, 'pill removed');
+    // Send with an empty queue does not POST.
+    document.querySelector('#artifactPanel .artifact-panel__send').click();
+    await Promise.resolve();
+    assert.equal(posted.filter((p) => String(p.url).includes('/prompts')).length, 0);
+  });
+
+  it('restores the queue to the front when the Send POST fails', async function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotation-queued', sessionId: 'sid-1', payload: { annotation: { prompt: 'will fail', selector: 'p' } } },
+    }));
+    await Promise.resolve();
+    assert.equal(document.querySelectorAll('#artifactPills .artifact-panel__pill').length, 1);
+
+    // Make the next POST fail (non-ok response).
+    const failFetch = (url, opts) => { posted.push({ url, opts }); return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) }); };
+    global.fetch = failFetch;
+    global.window.fetch = failFetch;
+
+    document.querySelector('#artifactPanel .artifact-panel__send').click();
+    // Drive the snapshot reply so the (failing) POST fires.
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-snapshot', sessionId: 'sid-1', payload: { domSnapshot: {} } },
+    }));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The annotation is restored to the queue so the user can retry.
+    assert.equal(document.querySelectorAll('#artifactPills .artifact-panel__pill').length, 1, 'failed batch restored to the queue');
+    assert.ok(document.getElementById('artifactPills').textContent.includes('will fail'));
+  });
+
+  it('panel Send falls back to sending without a snapshot if the iframe never replies', async function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotation-queued', sessionId: 'sid-1', payload: { annotation: { prompt: 'no snapshot', selector: 'p' } } },
+    }));
+    await Promise.resolve();
+
+    document.querySelector('#artifactPanel .artifact-panel__send').click();
+    // No artifact-snapshot reply is dispatched; the fallback timer (250ms) sends.
+    await new Promise((r) => setTimeout(r, 300));
+
+    const call = posted.find((p) => String(p.url).includes('/prompts'));
+    assert.ok(call, 'fallback POSTed without a snapshot');
+    const body = JSON.parse(call.opts.body);
+    assert.equal(body.prompts[0].prompt, 'no snapshot');
+    assert.ok(!('domSnapshot' in body) || body.domSnapshot === undefined, 'no snapshot attached on fallback');
+  });
+
+  it('re-enables Send after a successful send + agent reply (no permanent disable)', async function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+    // Agent is connected/listening, so a send transitions presence -> working.
+    panel._setPresence('listening');
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotation-queued', sessionId: 'sid-1', payload: { annotation: { prompt: 'do it', selector: 'p' } } },
+    }));
+    await Promise.resolve();
+
+    panel._sendQueue(); // direct send (skip the snapshot round-trip for determinism)
+    assert.equal(panel._presence, 'working', 'presence goes working on send');
+    // Mock fetch resolves ok:true; the .then() should clear working -> listening.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    assert.notEqual(panel._presence, 'working', 'presence cleared after POST settles');
+    assert.equal(panel._sendBtn.disabled, true, 'Send disabled only because queue is now empty, not because working');
+
+    // Queue another and confirm Send is enabled (not stuck disabled).
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotation-queued', sessionId: 'sid-1', payload: { annotation: { prompt: 'again', selector: 'p' } } },
+    }));
+    await Promise.resolve();
+    assert.equal(panel._sendBtn.disabled, false, 'Send re-enabled with a non-empty queue');
+  });
+
+  it('an agent reply clears a working presence so Send is usable again', function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+    panel._setPresence('working');
+    assert.equal(panel._presence, 'working');
+    panel.agentReply({ sessionId: 'sid-1', text: 'on it' });
+    assert.equal(panel._presence, 'listening', 'agent reply clears working');
+  });
+
+  it('a stale POST resolution from a switched-away session does not mutate the new session', async function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+    panel.open({ sessionId: 'sid-2', viewUrl: 'x' });
+
+    // Defer session-1's POST so it resolves AFTER we switch to session 2.
+    let resolvePost;
+    const deferred = new Promise((res) => { resolvePost = res; });
+    const slowFetch = (url, opts) => { posted.push({ url, opts }); return deferred; };
+    global.fetch = slowFetch;
+    global.window.fetch = slowFetch;
+
+    panel._setPresence('listening');
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotation-queued', sessionId: 'sid-1', payload: { annotation: { prompt: 'a1', selector: 'p' } } },
+    }));
+    await Promise.resolve();
+    panel._sendQueue(); // sid-1 send in flight, presence -> working
+    assert.equal(panel._presence, 'working');
+
+    // Switch to sid-2 and put it into 'working' independently.
+    panel.notifyActiveSessionChanged('sid-2');
+    panel._setPresence('working');
+
+    // Now resolve sid-1's POST. It must NOT touch sid-2's presence.
+    resolvePost({ ok: true, json: () => Promise.resolve({}) });
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    assert.equal(panel._presence, 'working', 'stale resolution left the active session untouched');
+  });
+
+  it('switching sessions cancels a pending snapshot request (no cross-session flush)', async function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+    panel.open({ sessionId: 'sid-2', viewUrl: 'x' });
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotation-queued', sessionId: 'sid-1', payload: { annotation: { prompt: 'q1', selector: 'p' } } },
+    }));
+    await Promise.resolve();
+    panel._sendQueueWithSnapshot(); // request-snapshot pending for sid-1
+    assert.equal(panel._snapshotPending, true);
+
+    panel.notifyActiveSessionChanged('sid-2'); // switch — must cancel the pending snapshot
+    assert.equal(panel._snapshotPending, false, 'pending snapshot cancelled on switch');
+
+    // A late snapshot reply (for the old session) must not POST anything.
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-snapshot', sessionId: 'sid-2', payload: { domSnapshot: {} } },
+    }));
+    await Promise.resolve();
+    assert.equal(posted.filter((p) => String(p.url).includes('/prompts')).length, 0, 'no cross-session flush');
+  });
+
+  it('legacy artifact-prompts message still POSTs to /prompts (backward-compat)', async function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-prompts', sessionId: 'sid-1', payload: { prompts: ['legacy note'], domSnapshot: { bodyText: 'old' } } },
+    }));
+    await Promise.resolve();
+    const call = posted.find((p) => String(p.url).includes('/prompts'));
+    assert.ok(call, 'legacy artifact-prompts POSTed to /prompts');
+    const body = JSON.parse(call.opts.body);
+    assert.deepEqual(body.prompts, ['legacy note']);
+    assert.deepEqual(body.domSnapshot, { bodyText: 'old' });
+    assert.ok(document.getElementById('artifactChat').textContent.includes('legacy note'));
+  });
+
+  it('legacy artifact-layout-warnings message forwards to /layout-warnings', async function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-layout-warnings', sessionId: 'sid-1', payload: { layout_warnings: [{ selector: '#root', severity: 'error' }] } },
+    }));
+    await Promise.resolve();
+    const call = posted.find((p) => String(p.url).includes('/layout-warnings'));
+    assert.ok(call, 'forwarded to /layout-warnings');
+    assert.deepEqual(JSON.parse(call.opts.body).layout_warnings, [{ selector: '#root', severity: 'error' }]);
   });
 
   it('ignores postMessages from a foreign source', async function () {
@@ -116,10 +358,24 @@ describe('artifact-panel.js (DOM: iframe + SSE + postMessage bridge)', function 
     panel.notifyActiveSessionChanged('sid-1');
     panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
     window.dispatchEvent(new window.MessageEvent('message', {
+      source: panel._iframe.contentWindow,
       data: { source: 'evil', type: 'artifact-prompts', sessionId: 'sid-1', payload: { prompts: ['x'] } },
     }));
     await Promise.resolve();
     assert.equal(posted.filter((p) => String(p.url).includes('/prompts')).length, 0);
+  });
+
+  it('ignores an SDK-shaped message from a window other than our iframe (source spoof)', async function () {
+    const panel = new ArtifactPanel(app);
+    panel.notifyActiveSessionChanged('sid-1');
+    panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+    // Correct data.source string, but event.source is NOT our iframe.
+    window.dispatchEvent(new window.MessageEvent('message', {
+      source: window, // a foreign window
+      data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotation-queued', sessionId: 'sid-1', payload: { annotation: { prompt: 'spoofed', selector: 'x' } } },
+    }));
+    await Promise.resolve();
+    assert.equal(document.querySelectorAll('#artifactPills .artifact-panel__pill').length, 0, 'spoofed annotation must not queue');
   });
 
   it('renders an SSE agent-reply into the chat log', function () {
@@ -175,5 +431,100 @@ describe('artifact-panel.js (DOM: iframe + SSE + postMessage bridge)', function 
     assert.equal(panel._iframe.src, before);
     panel.reloadReview({ sessionId: 'sid-1' }); // active: cache-busted
     assert.ok(panel._iframe.src.includes('_r='), 'iframe src should be cache-busted');
+  });
+
+  describe('floating-window chrome', function () {
+    function hasStorage() {
+      try { return !!(global.window && global.window.localStorage); } catch (_) { return false; }
+    }
+
+    it('minimize hides the body and persists; restore brings it back', function () {
+      if (!hasStorage()) { this.skip(); return; }
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+      assert.equal(panel._body.hidden, false);
+
+      panel.toggleMinimize();
+      assert.equal(panel._minimized, true);
+      assert.equal(panel._body.hidden, true);
+      assert.ok(panel.el.classList.contains('artifact-panel--minimized'));
+      const stored = JSON.parse(window.localStorage.getItem('ai-or-die:artifact-panel:layout'));
+      assert.equal(stored.minimized, true, 'minimized persisted to localStorage');
+
+      panel.toggleMinimize();
+      assert.equal(panel._minimized, false);
+      assert.equal(panel._body.hidden, false);
+    });
+
+    it('restores persisted position + size + minimized on construction', function () {
+      if (!hasStorage()) { this.skip(); return; }
+      window.localStorage.setItem('ai-or-die:artifact-panel:layout', JSON.stringify({
+        left: 40, top: 24, width: 500, height: 360, minimized: true,
+      }));
+      const panel = new ArtifactPanel(app);
+      assert.equal(panel.el.style.left, '40px');
+      assert.equal(panel.el.style.top, '24px');
+      assert.equal(panel.el.style.width, '500px');
+      assert.equal(panel.el.style.height, '360px');
+      assert.equal(panel._minimized, true, 'minimized restored');
+      assert.equal(panel._body.hidden, true);
+    });
+
+    it('clamps a persisted width below the minimum up to MIN_W', function () {
+      if (!hasStorage()) { this.skip(); return; }
+      window.localStorage.setItem('ai-or-die:artifact-panel:layout', JSON.stringify({ width: 100, height: 50 }));
+      const panel = new ArtifactPanel(app);
+      assert.equal(panel.el.style.width, '320px', 'width clamped to MIN_W');
+      assert.equal(panel.el.style.height, '240px', 'height clamped to MIN_H');
+    });
+
+    it('survives a corrupt localStorage payload', function () {
+      if (!hasStorage()) { this.skip(); return; }
+      window.localStorage.setItem('ai-or-die:artifact-panel:layout', '{not json');
+      assert.doesNotThrow(() => new ArtifactPanel(app));
+    });
+
+    it('clamps a persisted off-screen position back into the wrapper on show', function () {
+      if (!hasStorage()) { this.skip(); return; }
+      // A position saved when the window was larger (or after the wrapper shrank)
+      // would otherwise restore off-screen and strand the header.
+      window.localStorage.setItem('ai-or-die:artifact-panel:layout', JSON.stringify({
+        left: 5000, top: 5000, width: 420, height: 400,
+      }));
+      const panel = new ArtifactPanel(app);
+      // jsdom rects are 0x0; stub real sizes so _clampToBounds can compute.
+      const wrapper = panel.el.parentElement;
+      wrapper.getBoundingClientRect = () => ({ left: 0, top: 0, width: 800, height: 600, right: 800, bottom: 600 });
+      panel.el.getBoundingClientRect = () => ({ left: 0, top: 0, width: 420, height: 400, right: 420, bottom: 400 });
+
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' }); // triggers _show -> _clampToBounds
+
+      // left clamps to <= 800-420 = 380, top to <= 600-400 = 200.
+      assert.ok(panel._layout.left <= 380 && panel._layout.left >= 0, 'left clamped into wrapper, got ' + panel._layout.left);
+      assert.ok(panel._layout.top <= 200 && panel._layout.top >= 0, 'top clamped into wrapper, got ' + panel._layout.top);
+      assert.equal(panel.el.style.left, panel._layout.left + 'px');
+      // The corrected position is persisted.
+      const stored = JSON.parse(window.localStorage.getItem('ai-or-die:artifact-panel:layout'));
+      assert.equal(stored.left, panel._layout.left, 'clamped left persisted');
+    });
+
+    it('re-clamps on window resize', function () {
+      if (!hasStorage()) { this.skip(); return; }
+      window.localStorage.setItem('ai-or-die:artifact-panel:layout', JSON.stringify({
+        left: 300, top: 150, width: 420, height: 400,
+      }));
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+      const wrapper = panel.el.parentElement;
+      panel.el.getBoundingClientRect = () => ({ left: 0, top: 0, width: 420, height: 400, right: 420, bottom: 400 });
+      // Shrink the wrapper so the panel now hangs off the right/bottom edge.
+      wrapper.getBoundingClientRect = () => ({ left: 0, top: 0, width: 500, height: 450, right: 500, bottom: 450 });
+      window.dispatchEvent(new window.Event('resize'));
+      assert.ok(panel._layout.left <= 80, 'left re-clamped to <= 500-420 on resize, got ' + panel._layout.left);
+      assert.ok(panel._layout.top <= 50, 'top re-clamped to <= 450-400 on resize, got ' + panel._layout.top);
+    });
   });
 });

--- a/test/artifact-panel.test.js
+++ b/test/artifact-panel.test.js
@@ -457,6 +457,37 @@ describe('artifact-panel.js (DOM: iframe + SSE + postMessage bridge)', function 
       assert.equal(panel._body.hidden, false);
     });
 
+    it('maximize fills the wrapper and is mutually exclusive with minimize', function () {
+      if (!hasStorage()) { this.skip(); return; }
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+
+      // Maximize toggles the class + button affordance.
+      panel.toggleMaximize();
+      assert.equal(panel._maximized, true);
+      assert.ok(panel.el.classList.contains('artifact-panel--maximized'));
+      assert.equal(panel._maxBtn.getAttribute('aria-label'), 'Restore panel size');
+
+      // Minimizing while maximized clears maximized (mutually exclusive).
+      panel.toggleMinimize();
+      assert.equal(panel._minimized, true);
+      assert.equal(panel._maximized, false);
+      assert.ok(!panel.el.classList.contains('artifact-panel--maximized'));
+
+      // Maximizing while minimized clears minimized.
+      panel.toggleMaximize();
+      assert.equal(panel._maximized, true);
+      assert.equal(panel._minimized, false);
+      assert.equal(panel._body.hidden, false);
+
+      // Restore.
+      panel.toggleMaximize();
+      assert.equal(panel._maximized, false);
+      assert.ok(!panel.el.classList.contains('artifact-panel--maximized'));
+      assert.equal(panel._maxBtn.getAttribute('aria-label'), 'Maximize panel');
+    });
+
     it('restores persisted position + size + minimized on construction', function () {
       if (!hasStorage()) { this.skip(); return; }
       window.localStorage.setItem('ai-or-die:artifact-panel:layout', JSON.stringify({

--- a/test/artifact-sdk-client.test.js
+++ b/test/artifact-sdk-client.test.js
@@ -1,0 +1,179 @@
+'use strict';
+
+// jsdom unit test for the in-iframe annotation SDK (src/artifact-sdk-client.js).
+// The SDK is an IIFE served at /sdk.js that turns a click / text-selection into a
+// structured annotation and posts it to the parent (the panel) via postMessage.
+// We load it into a jsdom window, simulate a click + Queue, and assert the
+// structured annotation shape on the captured postMessage. Skips when jsdom is
+// not installed.
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+let JSDOM = null;
+try {
+  JSDOM = require('jsdom').JSDOM;
+} catch (_) {
+  /* skip below */
+}
+
+const SDK_SRC = path.join(__dirname, '..', 'src', 'artifact-sdk-client.js');
+
+describe('artifact-sdk-client.js (annotation payload shape)', function () {
+  if (!JSDOM) {
+    it('skipped — jsdom not installed', function () { this.skip(); });
+    return;
+  }
+
+  let dom;
+  let win;
+  let posted;
+
+  beforeEach(function () {
+    dom = new JSDOM(
+      '<!DOCTYPE html><html><head>' +
+      '<script>window.__AI_OR_DIE_ARTIFACT_REVIEW__={sessionId:"sid-9",key:"k9"};</script>' +
+      '</head><body>' +
+      '<main><p id="para" data-source-line="7">The footer is misaligned and too wide for the column.</p></main>' +
+      '</body></html>',
+      { url: 'http://localhost', runScripts: 'dangerously', pretendToBeVisual: true }
+    );
+    win = dom.window;
+
+    // Capture messages the SDK posts to the parent. In jsdom, parent === window
+    // for a top-level document, so intercept window.postMessage.
+    posted = [];
+    const origPost = win.postMessage.bind(win);
+    win.postMessage = function (message, targetOrigin) {
+      posted.push(message);
+      // Don't actually dispatch a MessageEvent — we only need the payload.
+      return undefined;
+    };
+    void origPost;
+
+    // getBoundingClientRect / getClientRects are stubbed by jsdom to zeros,
+    // which is fine — the card still positions and the payload is unaffected.
+
+    const code = fs.readFileSync(SDK_SRC, 'utf8');
+    const script = win.document.createElement('script');
+    script.textContent = code;
+    win.document.body.appendChild(script);
+  });
+
+  afterEach(function () {
+    try { win.close(); } catch (_) { /* ignore */ }
+  });
+
+  it('posts artifact-ready on load', function () {
+    const ready = posted.find((m) => m && m.type === 'artifact-ready');
+    assert.ok(ready, 'artifact-ready posted');
+    assert.equal(ready.source, 'ai-or-die-artifact-sdk');
+    assert.equal(ready.sessionId, 'sid-9');
+  });
+
+  it('clicking a block then Queue posts a structured annotation with sourceLine', function () {
+    const para = win.document.getElementById('para');
+
+    // Click the block — the SDK opens its shadow-DOM card.
+    para.dispatchEvent(new win.MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    const host = win.document.querySelector('[data-ai-or-die-ui="annotation-root"]');
+    assert.ok(host && host.shadowRoot, 'annotation shadow host created');
+    const card = host.shadowRoot.querySelector('.aod-annotation-card');
+    assert.ok(card, 'annotation card rendered');
+
+    const textarea = card.querySelector('textarea');
+    const queueBtn = card.querySelector('.aod-send');
+    assert.ok(textarea && queueBtn);
+
+    textarea.value = 'Widen the column and fix the footer';
+    queueBtn.click();
+
+    const queued = posted.find((m) => m && m.type === 'artifact-annotation-queued');
+    assert.ok(queued, 'artifact-annotation-queued posted');
+    assert.equal(queued.source, 'ai-or-die-artifact-sdk');
+    assert.equal(queued.sessionId, 'sid-9');
+
+    const a = queued.payload.annotation;
+    assert.ok(a, 'annotation present');
+    assert.equal(a.prompt, 'Widen the column and fix the footer');
+    assert.equal(a.tag, 'p');
+    assert.equal(a.selector, 'p#para', 'selector short-circuits at the id');
+    assert.equal(a.sourceLine, 7, 'sourceLine read from data-source-line');
+    assert.ok(typeof a.text === 'string' && a.text.length <= 240);
+    assert.ok(a.text.includes('footer is misaligned'));
+    assert.ok(!('target' in a), 'element annotation has no text-range target');
+  });
+
+  it('Queue with an empty comment posts nothing', function () {
+    const para = win.document.getElementById('para');
+    para.dispatchEvent(new win.MouseEvent('click', { bubbles: true, cancelable: true }));
+    const host = win.document.querySelector('[data-ai-or-die-ui="annotation-root"]');
+    const card = host.shadowRoot.querySelector('.aod-annotation-card');
+    card.querySelector('.aod-send').click(); // textarea is empty
+    assert.equal(posted.filter((m) => m && m.type === 'artifact-annotation-queued').length, 0);
+  });
+
+  it('does not annotate clicks on native interactive controls', function () {
+    const btn = win.document.createElement('button');
+    btn.textContent = 'Submit';
+    win.document.querySelector('main').appendChild(btn);
+    btn.dispatchEvent(new win.MouseEvent('click', { bubbles: true, cancelable: true }));
+    const host = win.document.querySelector('[data-ai-or-die-ui="annotation-root"]');
+    const card = host && host.shadowRoot && host.shadowRoot.querySelector('.aod-annotation-card');
+    assert.ok(!card, 'no card opened for a native control click');
+  });
+
+  it('a text selection yields a text-range target annotation', function () {
+    const para = win.document.getElementById('para');
+    const sel = win.document.getSelection();
+    const range = win.document.createRange();
+    range.selectNodeContents(para);
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    // mouseup over the selection opens the card (text-range path).
+    para.dispatchEvent(new win.MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+
+    const host = win.document.querySelector('[data-ai-or-die-ui="annotation-root"]');
+    const card = host && host.shadowRoot && host.shadowRoot.querySelector('.aod-annotation-card');
+    if (!card) { this.skip(); return; } // jsdom selection support is partial; skip if no card
+    const textarea = card.querySelector('textarea');
+    textarea.value = 'Reword this sentence';
+    card.querySelector('.aod-send').click();
+
+    const queued = posted.find((m) => m && m.type === 'artifact-annotation-queued');
+    assert.ok(queued, 'annotation queued');
+    const a = queued.payload.annotation;
+    assert.equal(a.tag, 'text');
+    assert.ok(a.target && a.target.type === 'text-range', 'carries a text-range target');
+    assert.ok(typeof a.target.commonAncestorSelector === 'string');
+    assert.ok(a.target.start && a.target.end, 'target has start/end boundaries');
+  });
+
+  it('exposes legacy aliases (window.lavish + queuePrompts/recordLayoutWarnings) posting the old message types', function () {
+    assert.ok(win.lavish, 'window.lavish present');
+    ['prompt', 'queuePrompts', 'ask', 'warnLayout', 'recordLayoutWarnings'].forEach((k) => {
+      assert.equal(typeof win.lavish[k], 'function', 'legacy alias ' + k);
+    });
+
+    win.lavish.queuePrompts(['make it bigger'], { domSnapshot: { bodyText: 'x' } });
+    const pm = posted.find((m) => m && m.type === 'artifact-prompts');
+    assert.ok(pm, 'queuePrompts posts artifact-prompts');
+    assert.deepEqual(pm.payload.prompts, ['make it bigger']);
+    assert.deepEqual(pm.payload.domSnapshot, { bodyText: 'x' });
+
+    win.lavish.recordLayoutWarnings([{ selector: '#a', severity: 'error' }]);
+    const lm = posted.find((m) => m && m.type === 'artifact-layout-warnings');
+    assert.ok(lm, 'recordLayoutWarnings posts artifact-layout-warnings');
+    assert.deepEqual(lm.payload.layout_warnings, [{ selector: '#a', severity: 'error' }]);
+  });
+
+  it('queuePrompts coerces a non-array prompt to a single-element array', function () {
+    win.lavish.queuePrompts('just a string', { domSnapshot: {} });
+    const pm = posted.find((m) => m && m.type === 'artifact-prompts');
+    assert.ok(pm);
+    assert.deepEqual(pm.payload.prompts, ['just a string']);
+  });
+});

--- a/test/control/artifact-extra-roots.test.js
+++ b/test/control/artifact-extra-roots.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+
+let ClaudeCodeWebServer;
+try {
+  ({ ClaudeCodeWebServer } = require('../../src/server'));
+} catch (_) {
+  /* optional native deps may be unavailable in some local test runs */
+}
+
+async function startWebServer(baseDir, options) {
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(baseDir);
+    const server = new ClaudeCodeWebServer(Object.assign({
+      port: 0,
+      sessionStoreOptions: { storageDir: path.join(baseDir, '.sessions') },
+    }, options || {}));
+    const httpServer = await server.start();
+    return { server, httpServer };
+  } finally {
+    process.chdir(originalCwd);
+  }
+}
+
+describe('validateArtifactPath (extra roots for out-of-workspace plans)', function () {
+  if (!ClaudeCodeWebServer) {
+    it.skip('ClaudeCodeWebServer unavailable in this environment', () => {});
+    return;
+  }
+
+  let baseDir, plansDir, prevExtra;
+
+  beforeEach(function () {
+    baseDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'aod-base-')));
+    plansDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'aod-plans-')));
+    prevExtra = process.env.AIORDIE_ARTIFACT_EXTRA_ROOTS;
+    process.env.AIORDIE_ARTIFACT_EXTRA_ROOTS = plansDir;
+  });
+
+  afterEach(function () {
+    if (prevExtra === undefined) delete process.env.AIORDIE_ARTIFACT_EXTRA_ROOTS;
+    else process.env.AIORDIE_ARTIFACT_EXTRA_ROOTS = prevExtra;
+    fs.rmSync(baseDir, { recursive: true, force: true });
+    fs.rmSync(plansDir, { recursive: true, force: true });
+  });
+
+  it('accepts a file in an extra root for artifacts but not the general sandbox', async function () {
+    const planFile = path.join(plansDir, 'plan.md');
+    fs.writeFileSync(planFile, '# plan');
+    const { server, httpServer } = await startWebServer(baseDir);
+    try {
+      const art = server.validateArtifactPath(planFile);
+      assert.equal(art.valid, true, 'artifact validator should accept an extra-root file');
+      const gen = server.validatePath(planFile);
+      assert.equal(gen.valid, false, 'general validatePath must stay strict (workspace only)');
+    } finally {
+      await new Promise((r) => httpServer.close(r));
+    }
+  });
+
+  it('still rejects a file outside both the workspace and the extra roots', async function () {
+    const outsideDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'aod-out-')));
+    const outsideFile = path.join(outsideDir, 'x.md');
+    fs.writeFileSync(outsideFile, 'x');
+    const { server, httpServer } = await startWebServer(baseDir);
+    try {
+      assert.equal(server.validateArtifactPath(outsideFile).valid, false);
+    } finally {
+      await new Promise((r) => httpServer.close(r));
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// keep http import referenced (lint parity with sibling tests)
+void http;

--- a/test/control/artifact-routes.test.js
+++ b/test/control/artifact-routes.test.js
@@ -164,6 +164,60 @@ describe('artifact review routes', function () {
     }
   });
 
+  it('markdown artifact view renders a shell (not raw markdown) with the SDK injected', async function () {
+    const mdFile = path.join(tmpDir, 'plan.md');
+    fs.writeFileSync(mdFile, '# My Plan\n\nFix the **footer** alignment.\n');
+    const { app } = buildApp({ baseDir: tmpDir });
+    const { server, port } = await listen(app);
+    try {
+      const opened = await postJson(port, '/api/artifact/md1/open', { file: mdFile });
+      assert.equal(opened.status, 200);
+
+      const r = await fetch(`http://127.0.0.1:${port}${opened.body.viewUrl}`);
+      const html = await r.text();
+      assert.equal(r.status, 200);
+      assert.match(r.headers.get('content-type') || '', /text\/html/);
+
+      // It is a rendered HTML shell, NOT the raw markdown bytes.
+      assert.match(html, /<!doctype html>/i);
+      assert.match(html, /md-artifact-root/);
+      // The renderer is loaded by ABSOLUTE path so the injected <base> can't
+      // redirect it through the asset route.
+      assert.match(html, /<script src="\/markdown-render\.js">/);
+      // Raw markdown must not be served unprocessed: the heading is carried as
+      // an escaped JSON string for the client renderer, not as a top-level
+      // markdown line in the document body.
+      assert.ok(!/^# My Plan$/m.test(html), 'raw markdown heading must not appear unprocessed');
+      assert.ok(html.includes('My Plan'), 'source is embedded for client rendering');
+
+      // The annotation SDK + config are injected on top of the shell.
+      assert.match(html, /data-ai-or-die-artifact-sdk/);
+      assert.match(html, /__AI_OR_DIE_ARTIFACT_REVIEW__/);
+      assert.match(html, /\/api\/artifact\/md1\/sdk\.js/);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('a non-markdown (.html) artifact keeps the raw passthrough path', async function () {
+    const { app } = buildApp({ baseDir: tmpDir });
+    const { server, port } = await listen(app);
+    try {
+      await postJson(port, '/api/artifact/h1/open', { file: artifactFile });
+      const r = await fetch(`http://127.0.0.1:${port}/api/artifact/h1/view`);
+      const html = await r.text();
+      assert.equal(r.status, 200);
+      // The original HTML body survives verbatim (only the SDK head injection is added).
+      assert.match(html, /<title>A<\/title>/);
+      assert.match(html, /<img src="img\.png">/);
+      // No markdown shell artifacts.
+      assert.ok(!html.includes('md-artifact-root'), 'html artifact must not be wrapped in the markdown shell');
+      assert.ok(!html.includes('/markdown-render.js'), 'html artifact must not load the markdown renderer');
+    } finally {
+      server.close();
+    }
+  });
+
   it('POST prompts then GET poll returns the feedback once', async function () {
     const { app, store } = buildApp({ baseDir: tmpDir });
     const { server, port } = await listen(app);


### PR DESCRIPTION
## What
Server + panel side of the Artifact review UX. Pairs with animeshkundu/github-router#78.

- **TLS/path**: emit `AIORDIE_INSECURE_TLS`; `validateArtifactPath` allows out-of-workspace plan files (`~/.claude/plans`, env-extensible) so the panel can open plans. General `validatePath` stays strict.
- **Render (fast consumption)**: `/view` renders a `.md`/`.markdown` artifact through the existing `markdown-render.js` (marked + DOMPurify) in a styled shell — never raw bytes (`markdownArtifactShell`). HTML artifacts keep the raw path. This is the *fallback*; the common path is already-HTML from the hook.
- **Annotate (point out errors)**: lavish-style SDK — hover-highlight, click-a-block or select-text → shadow-DOM popover → structured prompt `{selector, tag, text, prompt, sourceLine, target:text-range}`. Panel owns the queue (pills + Send); existing `/prompts` + `/poll` transport unchanged; legacy `artifact-prompts`/`layout-warnings` kept; `event.source` anti-spoof both directions.
- **Floating chrome (UX)**: drag to move, corner resize, minimize/restore, geometry persisted; off-screen positions clamped back into view; Send never left permanently disabled; session-scoped against cross-session mutation after a tab switch.

## Verification
- jsdom unit coverage (panel + SDK + routes); a **real-browser Playwright e2e** (`e2e/tests/55-artifact-panel-chrome.spec.js`, `ux-features` project) drives drag/resize/minimize/persistence/off-screen-clamp — stable across repeated runs.
- Full mocha suite 1691 passing / 0 failing; artifact tests green; existing artifact tests unbroken.

---
_CI note: bumped `longevity-smoke` Windows job timeout 12->18 min — that job (npm ci + playwright chromium install + 5-min headless soak) legitimately nears 12 min on Windows and intermittently canceled mid-soak; not caused by this change (the soak is headless, so the panel JS/CSS never run there)._
