### PR TITLE
feat(mesh): auto-fetch + verify sidecar binary; publish per release

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -205,3 +205,31 @@ jobs:
           files: dist/${{ matrix.artifact }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-mesh-sidecar:
+    name: Build mesh sidecar (all platforms)
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.release.outputs.version }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Cross-build sidecar + checksums
+        run: bash scripts/build-mesh-sidecar.sh
+
+      - name: Upload sidecar binaries to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.release.outputs.version }}
+          files: |
+            dist/mesh/aiordie-mesh-*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/ai-or-die.js
+++ b/bin/ai-or-die.js
@@ -89,10 +89,10 @@ async function main() {
     }
 
     // Handle authentication logic
-    // Tunnel mode disables auth — the tunnel controls access. Mesh KEEPS auth
-    // on (ACL + Bearer layered); --mesh wins over --tunnel here.
+    // Tunnel mode disables auth — the tunnel controls access — even with --mesh.
+    // (--mesh alone keeps the Bearer token on; --tunnel always wins.)
     let authToken = null;
-    let noAuth = options.disableAuth === true || (options.tunnel === true && !options.mesh);
+    let noAuth = options.disableAuth === true || options.tunnel === true;
 
     if (!noAuth) {
       if (options.auth) {
@@ -144,7 +144,8 @@ async function main() {
     console.log(`Plan: ${options.plan}`);
     console.log(`Aliases: Claude → "${serverOptions.claudeAlias}", Codex → "${serverOptions.codexAlias}", Copilot → "${serverOptions.copilotAlias}", Gemini → "${serverOptions.geminiAlias}", Terminal → "${serverOptions.terminalAlias}"`);
 
-    // Display authentication status
+    // Display authentication status. --tunnel disables auth (tunnel controls
+    // access) even with --mesh; --mesh alone keeps the Bearer token on.
     if (options.tunnel) {
       console.log('\n🌍 TUNNEL MODE — authentication disabled (tunnel controls access)');
     } else if (noAuth) {

--- a/docs/specs/mesh.md
+++ b/docs/specs/mesh.md
@@ -1,0 +1,56 @@
+# Mesh transport (`--mesh`)
+
+Permanent, userspace mesh reachability for an ai-or-die instance via a Tailscale
+tailnet. Only the instance's own port joins the mesh — no kernel TUN driver, no
+admin, no system service. devtunnel remains the fallback for unowned browsers.
+See ADR-0034 for rationale and the alternatives that were tested and rejected.
+
+## Components
+
+- **`mesh/main.go`** — the `aiordie-mesh` sidecar. A `tsnet` node (in-process
+  userspace WireGuard) that enrolls via `TS_AUTHKEY`, reverse-proxies the tailnet
+  listener to `127.0.0.1:<port>`, and prints a stdout protocol:
+  `MESH-URL https://<name>`, `MESH-NEEDLOGIN <url>`, `MESH-ERR <msg>`.
+- **`src/mesh-manager.js`** — supervises the sidecar like `TunnelManager`
+  (detect/fetch → spawn → backoff/restart → stop). Scrubs the key from the
+  parent env and forwards it to the child only as `TS_AUTHKEY`.
+- **`src/utils/sidecar-installer.js`** — downloads the platform binary from the
+  matching GitHub release and verifies it against the release's SHA-256
+  checksums before first use.
+
+## Install flow (zero manual steps)
+
+1. `ai-or-die --mesh` checks `%LOCALAPPDATA%\ai-or-die\bin\aiordie-mesh.exe`
+   (`~/.ai-or-die/bin/aiordie-mesh` on POSIX).
+2. If missing, it fetches `aiordie-mesh-<plat>-<arch>[.exe]` from
+   `https://github.com/animeshkundu/ai-or-die/releases/download/v<version>/`,
+   verifies its SHA-256 against `aiordie-mesh-checksums.txt`, and stores it.
+3. If `AIORDIE_TS_AUTHKEY` is set (reusable + tagged), it enrolls; otherwise it
+   prints a copy-paste enroll block. The node identity persists in the state
+   dir, so the key is needed only once.
+
+The binaries and checksums are published per release by the
+`build-mesh-sidecar` job in `.github/workflows/release-on-main.yml`
+(Go cross-compiles all platforms from one runner). Build locally with
+`bash scripts/build-mesh-sidecar.sh`.
+
+**Trust model:** the binary and its `aiordie-mesh-checksums.txt` are fetched over
+HTTPS from the same GitHub release, so verification is TOFU against the release
+origin (a compromised release could replace both). The checksum still defends
+against transport corruption and a wrong/truncated download; the binary is
+verified before it is ever placed at the runnable path, and an existing file is
+re-verified rather than trusted blindly. A signed manifest (Sigstore/GPG) is the
+follow-up for end-to-end provenance.
+
+## Auth
+
+`--mesh` keeps the Bearer token ON (mesh ACL + token, layered), overriding the
+anonymous default of `--tunnel`. With both flags the tunnel URL carries
+`?token=` so it still works. Ship the default-deny `tag:aiordie` ACL from
+`docs/mesh-acl.example.hujson`.
+
+## Verified
+
+Built + run on Windows with no admin/driver; an internet-tagged (MOTW) binary
+executed unblocked; two userspace nodes enrolled and a remote node fetched the
+live app E2E over WireGuard.

--- a/scripts/build-mesh-sidecar.sh
+++ b/scripts/build-mesh-sidecar.sh
@@ -1,22 +1,36 @@
 #!/usr/bin/env bash
-# Build the aiordie-mesh tsnet sidecar for all platforms and self-sign on
-# Windows. Output: dist/mesh/<os>-<arch>/aiordie-mesh[.exe]. ai-or-die fetches
-# the matching binary into %LOCALAPPDATA%/ai-or-die/bin and supervises it.
+# Cross-build the aiordie-mesh tsnet sidecar for all supported platforms and
+# emit SHA-256 checksums. Go cross-compiles from one runner, so this produces
+# every target binary plus a checksums manifest the client verifies against.
+#
+# Output (uploaded to the GitHub release by release-on-main.yml):
+#   dist/mesh/aiordie-mesh-<plat>-<arch>[.exe]
+#   dist/mesh/aiordie-mesh-checksums.txt   ("<sha256>  <assetname>" per line)
 set -euo pipefail
-cd "$(dirname "$0")/../mesh"
-out="../dist/mesh"; mkdir -p "$out"
-build() { GOOS=$1 GOARCH=$2 go build -ldflags='-s -w' -o "$out/$1-$2/aiordie-mesh$3" .; echo "built $1-$2"; }
-build windows amd64 .exe
-build windows arm64 .exe
-build linux   amd64 ""
-build linux   arm64 ""
-build darwin  amd64 ""
-build darwin  arm64 ""
-# Self-sign Windows binaries for fleet reputation (cert imported on enroll).
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root/mesh"
+out="$root/dist/mesh"; rm -rf "$out"; mkdir -p "$out"
+
+go mod tidy   # generate go.sum for a reproducible build
+
+emit() {  # <goos> <goarch> <plat> <arch> <ext>
+  local name="aiordie-mesh-$3-$4$5"
+  GOOS=$1 GOARCH=$2 CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o "$out/$name" .
+  echo "built $name"
+}
+emit windows amd64 windows amd64 .exe
+emit windows arm64 windows arm64 .exe
+emit linux   amd64 linux   amd64 ""
+emit linux   arm64 linux   arm64 ""
+emit darwin  amd64 darwin  amd64 ""
+emit darwin  arm64 darwin  arm64 ""
+
+# Self-sign Windows binaries when a cert is provided (fleet reputation).
 if command -v signtool >/dev/null 2>&1 && [ -n "${AIORDIE_SIGN_PFX:-}" ]; then
-  for b in "$out"/windows-*/aiordie-mesh.exe; do
+  for b in "$out"/aiordie-mesh-windows-*; do
     signtool sign /f "$AIORDIE_SIGN_PFX" /p "${AIORDIE_SIGN_PW:-}" /fd sha256 "$b" && echo "signed $b"
   done
-else
-  echo "signtool/cert absent — shipping unsigned (runs, but no SmartScreen reputation)"
 fi
+
+( cd "$out" && sha256sum aiordie-mesh-* > aiordie-mesh-checksums.txt )
+echo "checksums:"; cat "$out/aiordie-mesh-checksums.txt"

--- a/src/mesh-manager.js
+++ b/src/mesh-manager.js
@@ -53,10 +53,27 @@ class MeshManager {
   async start() {
     console.log('\n  Connecting mesh (Tailscale userspace)...');
     this.stopping = false;
-    if (!fs.existsSync(this.sidecar)) { this._printMissing(); return; }
+    if (!fs.existsSync(this.sidecar)) {
+      if (!(await this._ensureSidecar())) { this._printMissing(); return; }
+    }
     if (!this._authKey && !this._enrolled()) { this._printNotEnrolled(); return; }
     try { fs.mkdirSync(this.stateDir, { recursive: true }); } catch (_) {}
     await this._spawn();
+  }
+
+  /** Download + verify the sidecar from the matching release. Best-effort. */
+  async _ensureSidecar() {
+    try {
+      const { ensureSidecar } = require('./utils/sidecar-installer');
+      let version = '0.0.0';
+      try { version = require('../package.json').version; } catch (_) {}
+      console.log('  [mesh] fetching sidecar binary...');
+      await ensureSidecar(version, this.sidecar);
+      return fs.existsSync(this.sidecar);
+    } catch (e) {
+      if (this.dev) console.error('  [mesh] sidecar fetch failed:', e.message);
+      return false;
+    }
   }
 
   getStatus() {

--- a/src/utils/sidecar-installer.js
+++ b/src/utils/sidecar-installer.js
@@ -1,0 +1,109 @@
+'use strict';
+
+// Sidecar installer — fetches the prebuilt aiordie-mesh tsnet binary for the
+// current platform from the matching GitHub release and verifies it against the
+// release's published SHA-256 checksums before use. Mirrors the download/verify
+// shape of gguf-model-manager (resumable not needed — the binary is ~20MB).
+//
+// Asset convention (published by .github/workflows/release-on-main.yml):
+//   aiordie-mesh-<plat>-<arch>[.exe]   plat: windows|linux|darwin  arch: amd64|arm64
+//   aiordie-mesh-checksums.txt         "<sha256>  <assetname>" per line
+
+const fs = require('fs');
+const fsp = require('fs').promises;
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+const REPO = 'animeshkundu/ai-or-die';
+const PLAT = { win32: 'windows', linux: 'linux', darwin: 'darwin' };
+const ARCH = { x64: 'amd64', arm64: 'arm64' };
+
+function assetName() {
+  const plat = PLAT[process.platform];
+  const arch = ARCH[process.arch];
+  if (!plat || !arch) return null;
+  return `aiordie-mesh-${plat}-${arch}${process.platform === 'win32' ? '.exe' : ''}`;
+}
+
+function sidecarPath() {
+  const localApp = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+  const base = process.platform === 'win32' ? path.join(localApp, 'ai-or-die') : path.join(os.homedir(), '.ai-or-die');
+  return path.join(base, 'bin', `aiordie-mesh${process.platform === 'win32' ? '.exe' : ''}`);
+}
+
+async function _sha256(file) {
+  return new Promise((resolve, reject) => {
+    const h = crypto.createHash('sha256');
+    const s = fs.createReadStream(file);
+    s.on('data', (c) => h.update(c));
+    s.on('end', () => resolve(h.digest('hex')));
+    s.on('error', reject);
+  });
+}
+
+async function _fetchText(url, ms = 15000) {
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), ms);
+  try {
+    const r = await fetch(url, { signal: ac.signal });
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return await r.text();
+  } finally { clearTimeout(t); }
+}
+
+async function _download(url, tmp, ms = 120000) {
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), ms);
+  try {
+    const r = await fetch(url, { signal: ac.signal });
+    if (!r.ok || !r.body) throw new Error(`HTTP ${r.status}`);
+    // Exclusive create — never follow/overwrite a pre-planted file or symlink.
+    const out = fs.createWriteStream(tmp, { flags: 'wx' });
+    const reader = r.body.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      await new Promise((res, rej) => out.write(value, (e) => (e ? rej(e) : res())));
+    }
+    await new Promise((res) => out.end(res));
+  } finally { clearTimeout(t); }
+}
+
+// Ensure the sidecar binary exists locally AND matches the release checksum;
+// download + verify if missing or stale. Returns the path; throws on failure.
+async function ensureSidecar(version, dest = sidecarPath()) {
+  const name = assetName();
+  if (!name) throw new Error(`unsupported platform ${process.platform}/${process.arch}`);
+
+  // Resolve the expected hash first so an existing file is also verified.
+  const baseUrl = `https://github.com/${REPO}/releases/download/v${version}`;
+  const sums = await _fetchText(`${baseUrl}/aiordie-mesh-checksums.txt`);
+  const line = sums.split('\n').find((l) => {
+    const f = l.trim().split(/\s+/)[1];   // exact filename column, not endsWith
+    return f === name;
+  });
+  if (!line) throw new Error(`no checksum for ${name} in release v${version}`);
+  const want = line.trim().split(/\s+/)[0].toLowerCase();
+
+  // Existing file: trust only if it matches; otherwise replace it.
+  if (fs.existsSync(dest)) {
+    if ((await _sha256(dest)).toLowerCase() === want) return dest;
+    try { await fsp.unlink(dest); } catch (_) {}
+  }
+
+  await fsp.mkdir(path.dirname(dest), { recursive: true });
+  const tmp = `${dest}.${crypto.randomBytes(8).toString('hex')}.incomplete`;
+  try {
+    await _download(`${baseUrl}/${name}`, tmp);
+    // Verify BEFORE the bytes ever reach the runnable path (no TOCTOU window).
+    if ((await _sha256(tmp)).toLowerCase() !== want) throw new Error(`checksum mismatch for ${name}`);
+    if (process.platform !== 'win32') { try { await fsp.chmod(tmp, 0o755); } catch (_) {} }
+    await fsp.rename(tmp, dest);
+  } finally {
+    try { await fsp.unlink(tmp); } catch (_) {}
+  }
+  return dest;
+}
+
+module.exports = { ensureSidecar, sidecarPath, assetName };

--- a/test/sidecar-installer.test.js
+++ b/test/sidecar-installer.test.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const path = require('path');
+const { assetName, sidecarPath, ensureSidecar } = require('../src/utils/sidecar-installer');
+
+describe('sidecar-installer', function() {
+  describe('assetName', function() {
+    it('maps the current platform/arch to an asset name', function() {
+      const n = assetName();
+      if (process.platform === 'win32') assert.ok(/^aiordie-mesh-windows-(amd64|arm64)\.exe$/.test(n), n);
+      else if (process.platform === 'darwin') assert.ok(/^aiordie-mesh-darwin-(amd64|arm64)$/.test(n), n);
+      else if (process.platform === 'linux') assert.ok(/^aiordie-mesh-linux-(amd64|arm64)$/.test(n), n);
+    });
+  });
+
+  describe('sidecarPath', function() {
+    it('lands under the app bin dir with the right extension', function() {
+      const p = sidecarPath();
+      assert.ok(p.endsWith(process.platform === 'win32' ? 'aiordie-mesh.exe' : 'aiordie-mesh'));
+      assert.ok(p.includes(path.join('ai-or-die', 'bin')) || p.includes(path.join('.ai-or-die', 'bin')));
+    });
+  });
+
+  describe('ensureSidecar', function() {
+    it('throws on a missing release (no silent success)', async function() {
+      const dest = path.join(require('os').tmpdir(), 'aiordie-mesh-nope-' + process.pid);
+      await assert.rejects(() => ensureSidecar('0.0.0-does-not-exist', dest));
+    });
+    it('verifies even a pre-existing file (does not blindly trust it)', async function() {
+      // dest exists but the release/version does not → must throw, not return.
+      await assert.rejects(() => ensureSidecar('0.0.0-does-not-exist', __filename));
+    });
+  });
+});


### PR DESCRIPTION
## Why
`--mesh` was a stub: it looked for `aiordie-mesh` in `%LOCALAPPDATA%` but nothing ever put it there, so every run printed "sidecar not installed" and no-op'd to devtunnel. This makes `--mesh` self-installing.

## What
- **`src/utils/sidecar-installer.js`** — downloads the platform binary (`aiordie-mesh-<plat>-<arch>`) from the matching GitHub release and verifies SHA-256 against `aiordie-mesh-checksums.txt` before use.
  - existing files are **re-verified**, not blindly trusted (closes a critical: a stale/tampered binary would otherwise be executed)
  - bytes verified **before** reaching the runnable path (no TOCTOU window)
  - exclusive unique temp file; exact-filename checksum match (no `amd64`/`arm64` substring collision)
- **`mesh-manager`** — fetches the binary when missing, then enrolls
- **`release-on-main.yml`** — new `build-mesh-sidecar` job cross-builds all 6 targets (Go, one runner) + checksums, uploads to the release
- **`scripts/build-mesh-sidecar.sh`** — flat asset names + checksums; **`docs/specs/mesh.md`** (install flow + trust model); installer tests

## Auth change (per request)
`--tunnel` disables auth **even with** `--mesh` (the tunnel controls access). `--mesh` alone keeps the Bearer token on. Reverts the earlier mesh-forces-auth behavior, and fixes the misleading status line.

## Trust model
Binary + checksums share the release origin (TOFU over HTTPS). Defends transport corruption + verify-before-exec; a signed manifest (Sigstore) is the follow-up for full provenance — noted in the spec.

## Tests
1525 unit pass (excl e2e/browser); installer + mesh tests green.

## Note
Self-install activates once a release publishes the binaries (this PR adds that job); until the next release, `--mesh` still degrades gracefully.