### PR TITLE
feat(mesh): publish tagged tailnet peers + inject the app bearer

### DIFF
--- a/bin/ai-or-die.js
+++ b/bin/ai-or-die.js
@@ -216,6 +216,7 @@ async function main() {
       const mesh = new MeshManager({
         port,
         dev: options.dev,
+        authToken,
         onUrl: (meshUrl) => {
           const t = authToken ? `${meshUrl}?token=${authToken}` : meshUrl;
           console.log(`\n  \x1b[1m\x1b[32mMesh ready:\x1b[0m \x1b[1m\x1b[4m${t}\x1b[0m\n`);

--- a/mesh-sidecar.lock.json
+++ b/mesh-sidecar.lock.json
@@ -1,5 +1,5 @@
 {
   "version": "1.0.0",
-  "contentHash": "fb010e2cd6a930ef7eeac0de0adaf903cdb7252815650c38eac2d72f15da6e3d",
+  "contentHash": "dbf60b5215ebb0b0947edf8fa47906280dd1fea12ef7e1181918fecfe7d9bcc0",
   "assets": {}
 }

--- a/mesh/main.go
+++ b/mesh/main.go
@@ -17,6 +17,7 @@
 //   MESH-URL https://<name>      node is up, serving real TLS at the edge
 //   MESH-URL http://<name>       node is up, but TLS certs unavailable (degraded)
 //   MESH-NOCERT                  hint: enable HTTPS Certificates in the tailnet
+//   MESH-PEERS {"self":...,"peers":[...]} tagged fleet peers snapshot
 //   MESH-NEEDLOGIN <url>         no/!valid key — operator must enroll
 //   MESH-ERR <msg>               fatal
 package main
@@ -24,6 +25,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net"
@@ -31,16 +33,23 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
+	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tsnet"
 )
 
 // version is stamped at build time via -ldflags "-X main.version=<contentHash>".
 var version = "dev"
 
-const certWaitTimeout = 20 * time.Second
+const (
+	certWaitTimeout   = 20 * time.Second
+	meshPeersInterval = 20 * time.Second
+	meshPeersMaxPeers = 512
+	meshPeerTag       = "tag:aiordie"
+)
 
 func main() {
 	port := flag.String("port", "7777", "local ai-or-die port to expose (loopback)")
@@ -54,6 +63,8 @@ func main() {
 		fmt.Println(version)
 		return
 	}
+
+	proxyBearer := os.Getenv("AIORDIE_PROXY_BEARER")
 
 	// Resolve + validate the backend target. It MUST be loopback: the sidecar is
 	// a tailnet-facing reverse proxy, and pointing it off-host would expose an
@@ -80,6 +91,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if lc, err := s.LocalClient(); err == nil {
+		go emitMeshPeersLoop(context.Background(), lc)
+	}
+
 	name := *host
 	if st != nil && st.Self != nil && st.Self.DNSName != "" {
 		name = strings.TrimSuffix(st.Self.DNSName, ".")
@@ -91,7 +106,7 @@ func main() {
 	// so wss works regardless; this header is hygiene for any absolute-URL or
 	// redirect the app generates (no mixed content).
 	edgeProto := "http"
-	rp := newEdgeProxy(target, name, &edgeProto)
+	rp := newEdgeProxy(target, name, &edgeProto, proxyBearer)
 
 	// Decide the scheme BEFORE advertising. tsnet's ListenTLS returns a listener
 	// without provisioning the cert; the ACME work (and any failure) happens
@@ -163,6 +178,94 @@ func isLoopbackHost(h string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+type statusClient interface {
+	Status(context.Context) (*ipnstate.Status, error)
+}
+
+type meshPeersSnapshot struct {
+	Self  meshPeerSelf `json:"self"`
+	Peers []meshPeer   `json:"peers"`
+}
+
+type meshPeerSelf struct {
+	Hostname string `json:"hostname"`
+	DNSName  string `json:"dnsName"`
+}
+
+type meshPeer struct {
+	Hostname string `json:"hostname"`
+	DNSName  string `json:"dnsName"`
+	Online   bool   `json:"online"`
+}
+
+func emitMeshPeersLoop(ctx context.Context, lc statusClient) {
+	emitMeshPeers(ctx, lc)
+	ticker := time.NewTicker(meshPeersInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			emitMeshPeers(ctx, lc)
+		}
+	}
+}
+
+func emitMeshPeers(ctx context.Context, lc statusClient) {
+	status, err := lc.Status(ctx)
+	if err != nil || status == nil {
+		return
+	}
+	line := meshPeersFromStatus(status)
+	b, err := json.Marshal(line)
+	if err != nil {
+		return
+	}
+	fmt.Printf("MESH-PEERS %s\n", b)
+}
+
+func meshPeersFromStatus(status *ipnstate.Status) meshPeersSnapshot {
+	var self meshPeerSelf
+	if status.Self != nil {
+		self = meshPeerSelf{Hostname: status.Self.HostName, DNSName: normalizeDNSName(status.Self.DNSName)}
+	}
+
+	peers := make([]meshPeer, 0)
+	for _, ps := range status.Peer {
+		if ps == nil || !peerHasTag(ps, meshPeerTag) {
+			continue
+		}
+		peers = append(peers, meshPeer{Hostname: ps.HostName, DNSName: normalizeDNSName(ps.DNSName), Online: ps.Online})
+	}
+	sort.Slice(peers, func(i, j int) bool {
+		if peers[i].DNSName != peers[j].DNSName {
+			return peers[i].DNSName < peers[j].DNSName
+		}
+		return peers[i].Hostname < peers[j].Hostname
+	})
+	if len(peers) > meshPeersMaxPeers {
+		peers = peers[:meshPeersMaxPeers]
+	}
+	return meshPeersSnapshot{Self: self, Peers: peers}
+}
+
+func peerHasTag(ps *ipnstate.PeerStatus, tag string) bool {
+	if ps.Tags == nil {
+		return false
+	}
+	for i := 0; i < ps.Tags.Len(); i++ {
+		if ps.Tags.At(i) == tag {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeDNSName(s string) string {
+	return strings.ToLower(strings.TrimSuffix(s, "."))
+}
+
 // tryListenTLS returns a TLS listener on :443 only when a cert for `name` looks
 // obtainable; otherwise nil. It first checks the tailnet's advertised cert
 // domains, then proactively warms the cert with a bounded timeout so a failure
@@ -214,13 +317,22 @@ func redirectToHTTPS(name string) http.HandlerFunc {
 // X-Forwarded-Host so the app never emits mixed-content links. For an https
 // loopback backend (a future self-signed local listener) it skips verification —
 // the host is already validated as loopback, so this is not a trust boundary.
-func newEdgeProxy(target *url.URL, name string, proto *string) *httputil.ReverseProxy {
+func newEdgeProxy(target *url.URL, name string, proto *string, proxyBearer string) *httputil.ReverseProxy {
 	rp := httputil.NewSingleHostReverseProxy(target)
 	orig := rp.Director
 	rp.Director = func(r *http.Request) {
 		orig(r)
 		r.Header.Set("X-Forwarded-Proto", *proto)
 		r.Header.Set("X-Forwarded-Host", name)
+		// Authenticate tailnet->loopback traffic to the app's bearer middleware.
+		// Set REPLACES any client-supplied Authorization (no spoofing). When no
+		// token is configured, DELETE a client-supplied Authorization so a tailnet
+		// caller can never smuggle one through to the loopback app.
+		if proxyBearer != "" {
+			r.Header.Set("Authorization", "Bearer "+proxyBearer)
+		} else {
+			r.Header.Del("Authorization")
+		}
 	}
 	if target.Scheme == "https" {
 		rp.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}

--- a/mesh/main_test.go
+++ b/mesh/main_test.go
@@ -67,20 +67,21 @@ func TestIsLoopbackHost(t *testing.T) {
 }
 
 // End-to-end through the actual reverse proxy (no tailnet): a real loopback
-// backend must receive the X-Forwarded-Proto/Host the edge stamps, and the
-// pointer-captured proto must reflect the post-TLS decision.
-func TestEdgeProxyForwardsProtoAndHost(t *testing.T) {
-	var gotProto, gotHost, gotBody string
+// backend must receive the X-Forwarded-Proto/Host the edge stamps, the app
+// bearer, and the pointer-captured proto must reflect the post-TLS decision.
+func TestEdgeProxyForwardsProtoHostAndAuth(t *testing.T) {
+	var gotProto, gotHost, gotAuth, gotBody string
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotProto = r.Header.Get("X-Forwarded-Proto")
 		gotHost = r.Header.Get("X-Forwarded-Host")
+		gotAuth = r.Header.Get("Authorization")
 		io.WriteString(w, "backend-ok")
 	}))
 	defer backend.Close()
 
 	target, _ := url.Parse(backend.URL) // 127.0.0.1 loopback
 	proto := "http"                      // default before the TLS decision
-	rp := newEdgeProxy(target, "node.tailnet.ts.net", &proto)
+	rp := newEdgeProxy(target, "node.tailnet.ts.net", &proto, "app-token")
 	proto = "https" // edge decided real TLS AFTER constructing the proxy
 
 	front := httptest.NewServer(rp)
@@ -99,6 +100,9 @@ func TestEdgeProxyForwardsProtoAndHost(t *testing.T) {
 	}
 	if gotHost != "node.tailnet.ts.net" {
 		t.Errorf("backend saw X-Forwarded-Host=%q, want node.tailnet.ts.net", gotHost)
+	}
+	if gotAuth != "Bearer app-token" {
+		t.Errorf("backend saw Authorization=%q, want Bearer app-token", gotAuth)
 	}
 	if gotBody != "backend-ok" {
 		t.Errorf("proxy body=%q, want backend-ok", gotBody)

--- a/src/control/routes.js
+++ b/src/control/routes.js
@@ -187,6 +187,10 @@ function createControlRouter(deps) {
     }
   });
 
+  router.get('/mesh/peers', (req, res) => {
+    res.json({ peers: deps.getMeshPeers ? deps.getMeshPeers() : [] });
+  });
+
   // GET /snapshot — F15 atomic batch resync. Returns every session's derived
   // status PLUS the event cursor, captured atomically (cursor first, then
   // statuses), so after a gap/overflow the controller resyncs in ONE call and

--- a/src/mesh-manager.js
+++ b/src/mesh-manager.js
@@ -17,28 +17,32 @@ const STABILITY_THRESHOLD_MS = 60000;  // 60s up = reset retry budget
 const MIN_RESTART_DELAY_MS = 1000;
 const MAX_RESTART_DELAY_MS = 30000;
 const MAX_RETRIES = 10;
+const MESH_PEERS_JSON_MAX = 256 * 1024;
 
 class MeshManager {
   constructor(options = {}) {
     this.port = options.port || 7777;          // the ai-or-die port to expose
     this.dev = options.dev || false;
     this.onUrl = options.onUrl || (() => {});
-    // Consume the key once and scrub it everywhere it could leak.
+    this._proxyBearer = options.authToken || null;
+    // Consume the key once and scrub secrets everywhere they could leak.
     this._authKey = options.authKey || process.env.AIORDIE_TS_AUTHKEY || null;
     delete process.env.AIORDIE_TS_AUTHKEY;
+    delete process.env.AIORDIE_PROXY_BEARER;
     this._childEnv = { ...process.env };
     delete this._childEnv.AIORDIE_TS_AUTHKEY;
+    delete this._childEnv.AIORDIE_PROXY_BEARER;
 
     const localApp = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
-    const base = process.platform === 'win32'
+    this._appBase = process.platform === 'win32'
       ? path.join(localApp, 'ai-or-die')
       : path.join(os.homedir(), '.ai-or-die');
-    this.stateDir = options.stateDir || path.join(base, 'ts-state');
+    this.stateDir = options.stateDir || path.join(this._appBase, 'ts-state');
     // The sidecar binary is content-addressed: its path embeds the lock's
     // contentHash so a new build installs alongside the old one (no overwrite of
     // a running .exe). Derived from the installer's lock + path helpers.
     this._installer = options._installer || require('./utils/sidecar-installer');
-    this.sidecar = options.sidecar || this._sidecarPathFromLock(base);
+    this.sidecar = options.sidecar || this._sidecarPathFromLock(this._appBase);
     this.hostname = (options.hostname || `aiordie-${os.hostname()}`).toLowerCase().replace(/[^a-z0-9-]/g, '');
 
     this.proc = null;
@@ -53,6 +57,8 @@ class MeshManager {
     this._restartDelayTimer = null;
     this._restartDelayResolve = null;
     this._stabilityThresholdMs = options._stabilityThresholdMs || STABILITY_THRESHOLD_MS;
+    this._stdoutBuffer = '';
+    this.peers = null;
   }
 
   /** Never throws — degrades to localhost/devtunnel on any failure. */
@@ -93,11 +99,20 @@ class MeshManager {
   }
 
   getStatus() {
-    return { running: this.proc !== null && !this.stopping && !!this.dnsName, publicUrl: this.dnsName ? `${this.scheme || 'https'}://${this.dnsName}` : null };
+    return {
+      running: this.proc !== null && !this.stopping && !!this.dnsName,
+      publicUrl: this.dnsName ? `${this.scheme || 'https'}://${this.dnsName}` : null,
+      peers: this.peers ? this.peers.peers : [],
+    };
+  }
+
+  peersFilePath() {
+    return path.join(this._appBase, 'mesh', 'peers.json');
   }
 
   async stop() {
     this.stopping = true;
+    this._deletePeersFile();
     this._clearStabilityTimer();
     clearTimeout(this._restartDelayTimer);
     if (this._restartDelayResolve) { this._restartDelayResolve(); this._restartDelayResolve = null; }
@@ -117,34 +132,121 @@ class MeshManager {
   _spawn() {
     return new Promise((resolve) => {
       const args = ['--port', String(this.port), '--backend', this.backend, '--hostname', this.hostname, '--statedir', this.stateDir];
-      // Pass the key to the sidecar via TS_AUTHKEY (enroll only); it's already
-      // stripped from this process + base child env, so it reaches only this child.
-      const env = this._authKey ? { ...this._childEnv, TS_AUTHKEY: this._authKey } : this._childEnv;
+      // Pass secrets only to the sidecar child; both are stripped from this
+      // process + base child env before spawning.
+      const env = { ...this._childEnv };
+      if (this._authKey) env.TS_AUTHKEY = this._authKey;
+      if (this._proxyBearer) env.AIORDIE_PROXY_BEARER = this._proxyBearer;
+      this._stdoutBuffer = '';
       this.proc = spawn(this.sidecar, args, { stdio: ['ignore', 'pipe', 'pipe'], env });
       let done = false;
       const timer = setTimeout(() => { if (!done) { done = true; console.warn('  \x1b[33mMesh: no URL within 60s — check key/connectivity.\x1b[0m'); resolve(); } }, URL_TIMEOUT_MS);
       this.proc.stdout.on('data', (d) => {
-        const out = d.toString();
-        if (this.dev) process.stdout.write(`  [mesh] ${out}`);
-        if (/MESH-NOCERT/.test(out)) this._printNoCert();
-        const url = out.match(/MESH-URL (https?):\/\/(\S+)/);
-        if (url && !this.dnsName) {
-          this.scheme = url[1];
-          this.dnsName = url[2];
-          this._authKey = null;
-          this._startStabilityTimer();
-          this.onUrl(`${this.scheme}://${this.dnsName}`);
-          if (!done) { done = true; clearTimeout(timer); resolve(); }
-        }
-        if (/MESH-NEEDLOGIN/.test(out)) { this._printNotEnrolled(); if (!done) { done = true; clearTimeout(timer); resolve(); } }
+        if (this.dev) process.stdout.write(`  [mesh] ${d}`);
+        this._handleStdoutData(d, (line) => {
+          if (/^MESH-NOCERT\b/.test(line)) this._printNoCert();
+          const url = line.match(/^MESH-URL (https?):\/\/(\S+)/);
+          if (url && !this.dnsName) {
+            this.scheme = url[1];
+            this.dnsName = url[2];
+            this._authKey = null;
+            this._startStabilityTimer();
+            this.onUrl(`${this.scheme}://${this.dnsName}`);
+            if (!done) { done = true; clearTimeout(timer); resolve(); }
+          }
+          if (/^MESH-NEEDLOGIN\b/.test(line)) {
+            this._deletePeersFile();
+            this._printNotEnrolled();
+            if (!done) { done = true; clearTimeout(timer); resolve(); }
+          }
+        });
       });
       this.proc.stderr.on('data', (d) => { if (this.dev) process.stderr.write(`  [mesh] ${d}`); });
       this.proc.on('error', (e) => { console.error(`  \x1b[31mmesh sidecar failed: ${e.message}\x1b[0m`); this.proc = null; if (!done) { done = true; clearTimeout(timer); resolve(); } });
       this.proc.on('exit', (code) => {
-        this._clearStabilityTimer(); this.proc = null; this.dnsName = null;
+        this._clearStabilityTimer(); this.proc = null; this.dnsName = null; this._deletePeersFile();
         if (!this.stopping && code !== 0) this._restart();
       });
     });
+  }
+
+  _handleStdoutData(chunk, onLine) {
+    try {
+      this._stdoutBuffer += chunk.toString();
+      const lines = this._stdoutBuffer.split('\n');
+      this._stdoutBuffer = lines.pop() || '';
+      // Bound the carry-over: a newline-less run longer than any legitimate line
+      // (MESH-PEERS is capped well under this) is junk/log-spam — drop it so a
+      // misbehaving child can't grow the buffer without limit.
+      if (this._stdoutBuffer.length > MESH_PEERS_JSON_MAX) this._stdoutBuffer = '';
+      for (const rawLine of lines) {
+        const line = rawLine.replace(/\r$/, '');
+        this._handleStdoutLine(line);
+        if (onLine) onLine(line);
+      }
+    } catch (_) {}
+  }
+
+  _handleStdoutLine(line) {
+    try {
+      if (/^MESH-NEEDLOGIN\b/.test(line)) this._deletePeersFile();
+      const match = /^MESH-PEERS\s+(.+)$/.exec(line);
+      if (!match) return;
+      const raw = match[1];
+      if (Buffer.byteLength(raw, 'utf8') > MESH_PEERS_JSON_MAX) {
+        if (this.dev) console.debug('  [mesh] ignoring oversized MESH-PEERS payload');
+        return;
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (_) {
+        return;
+      }
+      const normalized = this._validatePeersPayload(parsed);
+      if (!normalized) return;
+      this.peers = normalized;
+      this._writePeersFile(normalized);
+    } catch (_) {}
+  }
+
+  _validatePeersPayload(payload) {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+    const self = payload.self;
+    if (!self || typeof self !== 'object' || Array.isArray(self)) return null;
+    if (typeof self.hostname !== 'string' || typeof self.dnsName !== 'string') return null;
+    if (!Array.isArray(payload.peers)) return null;
+    const peers = [];
+    for (const p of payload.peers) {
+      if (!p || typeof p !== 'object' || Array.isArray(p)) continue;
+      if (typeof p.hostname !== 'string' || typeof p.dnsName !== 'string' || typeof p.online !== 'boolean') continue;
+      peers.push({ hostname: p.hostname, dnsName: p.dnsName, online: p.online });
+    }
+    return { self: { hostname: self.hostname, dnsName: self.dnsName }, peers };
+  }
+
+  _writePeersFile(snapshot) {
+    const file = this.peersFilePath();
+    const dir = path.dirname(file);
+    const tmp = path.join(dir, `peers.json.${process.pid}.tmp`);
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(tmp, JSON.stringify({
+        version: 1,
+        updatedAt: Date.now(),
+        self: snapshot.self,
+        peers: snapshot.peers,
+      }), { mode: 0o600 });
+      fs.chmodSync(tmp, 0o600);
+      fs.renameSync(tmp, file);
+    } catch (_) {
+      try { fs.rmSync(tmp, { force: true }); } catch (_) {}
+    }
+  }
+
+  _deletePeersFile() {
+    this.peers = null;
+    try { fs.rmSync(this.peersFilePath(), { force: true }); } catch (_) {}
   }
 
   _printMissing(err) {

--- a/src/server.js
+++ b/src/server.js
@@ -4105,6 +4105,7 @@ class ClaudeCodeWebServer {
     return {
       sessions: this.claudeSessions,
       eventBus: this.controlEventBus,
+      getMeshPeers: () => this.meshManager ? this.meshManager.getStatus().peers : [],
       getStatusSignal: (id) => this._controlStatusSignal(id),
       readTail: async (id, lines) => this._controlReadTail(id, lines),
       createSession: async (opts) => this._controlCreateSession(opts),

--- a/test/control/routes.test.js
+++ b/test/control/routes.test.js
@@ -3,6 +3,8 @@
 const assert = require('assert');
 const http = require('http');
 const express = require('express');
+const testApi = global.describe ? { describe: global.describe, it: global.it } : require('node:test');
+const { describe, it } = testApi;
 const { createControlRouter, parseCursor, encodeCursor } = require('../../src/control/routes');
 const { ControlEventBus } = require('../../src/control/event-bus');
 
@@ -83,6 +85,27 @@ describe('control/routes /api/control', function () {
       assert.equal(s2.lifecycle, 'exited');
     } finally {
       server.close();
+    }
+  });
+
+  it('GET /mesh/peers returns injected mesh peers and defaults to empty', async function () {
+    const peer = { hostname: 'p1', dnsName: 'p1.tail', online: true };
+    const { server, port } = await listen(buildServer(fakeDeps({ getMeshPeers: () => [peer] })));
+    try {
+      const { status, body } = await getJson(port, '/api/control/mesh/peers');
+      assert.equal(status, 200);
+      assert.deepEqual(body, { peers: [peer] });
+    } finally {
+      server.close();
+    }
+
+    const fallback = await listen(buildServer(fakeDeps()));
+    try {
+      const { status, body } = await getJson(fallback.port, '/api/control/mesh/peers');
+      assert.equal(status, 200);
+      assert.deepEqual(body, { peers: [] });
+    } finally {
+      fallback.server.close();
     }
   });
 

--- a/test/mesh-manager.test.js
+++ b/test/mesh-manager.test.js
@@ -1,6 +1,9 @@
 const assert = require('assert');
+const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const testApi = global.describe ? { describe: global.describe, it: global.it } : require('node:test');
+const { describe, it } = testApi;
 const { MeshManager } = require('../src/mesh-manager');
 
 describe('MeshManager', function() {
@@ -45,19 +48,90 @@ describe('MeshManager', function() {
       assert.strictEqual(process.env.AIORDIE_TS_AUTHKEY, undefined);
       assert.strictEqual(m._childEnv.AIORDIE_TS_AUTHKEY, undefined);
     });
+
+    it('captures the app bearer for the sidecar and scrubs inherited env', function() {
+      process.env.AIORDIE_PROXY_BEARER = 'env-token';
+      const m = new MeshManager({ authToken: 'app-token' });
+      assert.strictEqual(m._proxyBearer, 'app-token');
+      assert.strictEqual(process.env.AIORDIE_PROXY_BEARER, undefined);
+      assert.strictEqual(m._childEnv.AIORDIE_PROXY_BEARER, undefined);
+    });
   });
 
   describe('getStatus', function() {
     it('not running until a name binds', function() {
-      assert.deepStrictEqual(new MeshManager().getStatus(), { running: false, publicUrl: null });
+      assert.deepStrictEqual(new MeshManager().getStatus(), { running: false, publicUrl: null, peers: [] });
     });
     it('reports https url once up', function() {
       const m = new MeshManager(); m.proc = {}; m.dnsName = 'h.tail.ts.net'; m.scheme = 'https';
-      assert.deepStrictEqual(m.getStatus(), { running: true, publicUrl: 'https://h.tail.ts.net' });
+      assert.deepStrictEqual(m.getStatus(), { running: true, publicUrl: 'https://h.tail.ts.net', peers: [] });
     });
     it('reports the http url when the edge degraded (no certs)', function() {
       const m = new MeshManager(); m.proc = {}; m.dnsName = 'h.tail.ts.net'; m.scheme = 'http';
-      assert.deepStrictEqual(m.getStatus(), { running: true, publicUrl: 'http://h.tail.ts.net' });
+      assert.deepStrictEqual(m.getStatus(), { running: true, publicUrl: 'http://h.tail.ts.net', peers: [] });
+    });
+    it('includes cached mesh peers', function() {
+      const m = new MeshManager();
+      m.peers = { self: { hostname: 'self', dnsName: 'self.tail' }, peers: [{ hostname: 'p', dnsName: 'p.tail', online: true }] };
+      assert.deepStrictEqual(m.getStatus().peers, [{ hostname: 'p', dnsName: 'p.tail', online: true }]);
+    });
+  });
+
+  describe('peer discovery cache', function() {
+    function tempManager() {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-manager-'));
+      const m = new MeshManager({ stateDir: path.join(dir, 'ts-state'), sidecar: path.join(dir, 'aiordie-mesh') });
+      m._appBase = dir;
+      return { m, dir };
+    }
+
+    it('parses MESH-PEERS, caches peers, and writes peers.json atomically', function() {
+      const { m, dir } = tempManager();
+      try {
+        const line = 'MESH-PEERS {"self":{"hostname":"self","dnsName":"self.tail"},"peers":[{"hostname":"p1","dnsName":"p1.tail","online":true},{"hostname":"bad","dnsName":"bad.tail","online":"yes"}]}\n';
+        m._handleStdoutData(Buffer.from(line));
+        assert.deepStrictEqual(m.peers, {
+          self: { hostname: 'self', dnsName: 'self.tail' },
+          peers: [{ hostname: 'p1', dnsName: 'p1.tail', online: true }],
+        });
+        const file = m.peersFilePath();
+        const written = JSON.parse(fs.readFileSync(file, 'utf8'));
+        assert.strictEqual(written.version, 1);
+        assert.strictEqual(typeof written.updatedAt, 'number');
+        assert.deepStrictEqual(written.self, m.peers.self);
+        assert.deepStrictEqual(written.peers, m.peers.peers);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps the last-good peers cache on malformed or oversized MESH-PEERS', function() {
+      const { m, dir } = tempManager();
+      try {
+        m._handleStdoutData(Buffer.from('MESH-PEERS {"self":{"hostname":"self","dnsName":"self.tail"},"peers":[]}\n'));
+        const lastGood = m.peers;
+        m._handleStdoutData(Buffer.from('MESH-PEERS {not json}\n'));
+        assert.strictEqual(m.peers, lastGood);
+        m._handleStdoutData(Buffer.from('MESH-PEERS {"self":{"hostname":"self"},"peers":[]}\n'));
+        assert.strictEqual(m.peers, lastGood);
+        m._handleStdoutData(Buffer.from(`MESH-PEERS ${'x'.repeat(256 * 1024 + 1)}\n`));
+        assert.strictEqual(m.peers, lastGood);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('deletes peers.json and clears memory on mesh shutdown markers', function() {
+      const { m, dir } = tempManager();
+      try {
+        m._handleStdoutData(Buffer.from('MESH-PEERS {"self":{"hostname":"self","dnsName":"self.tail"},"peers":[]}\n'));
+        assert.ok(fs.existsSync(m.peersFilePath()));
+        m._handleStdoutData(Buffer.from('MESH-NEEDLOGIN https://login.tailscale.com/admin/settings/keys\n'), () => {});
+        assert.strictEqual(m.peers, null);
+        assert.strictEqual(fs.existsSync(m.peersFilePath()), false);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## What

Two additions to the `--mesh` sidecar that let an external orchestrator (github-router's `--fleet`) drive instances over the tailnet with **zero per-instance config** — no copying random per-launch tokens around.

## Changes

- **Sidecar bearer injection** (`mesh/main.go`): the sidecar reads the app's bearer from `AIORDIE_PROXY_BEARER` (passed by `MeshManager`, scrubbed from the parent env like `TS_AUTHKEY`) and injects `Authorization: Bearer <token>` on **every** proxied tailnet→loopback request. So an ACL-gated mesh caller authenticates to the app, while a **direct loopback caller still needs the token** (loopback stays protected — no local priv-esc, no non-mesh bypass). Injection is unconditional on the sidecar path and **replaces** any client-supplied `Authorization`; when no token is configured it **strips** an incoming one so a tailnet caller can't smuggle one through. The `tag:aiordie` ACL is the access gate.
- **Peer publishing**: the sidecar emits a one-line `MESH-PEERS <json>` snapshot of `tag:aiordie` peers (bounded to 512, deterministic order). `MeshManager` parses it with a **bounded, line-buffered** reader that keeps the **last-good cache on malformed/oversized input**, caches it, and **atomically** writes a mode-0600 `<app-dir>/mesh/peers.json` (deleted on `stop` / sidecar exit / `MESH-NEEDLOGIN` so a stale list is never served). New `GET /api/control/mesh/peers` exposes the cache.

## Failure modes considered & tested

- Partial / oversized / malformed stdout lines → ignored, last-good cache preserved (line-buffer also bounded against newline-less spam).
- Atomic file write (temp + rename, mode 0600); peers.json deleted when the mesh goes down.
- Smuggled `Authorization` header from a tailnet caller → replaced/stripped.
- Empty peer set → emitted as `[]` (Go slice initialized, not nil) so the consumer updates to zero rather than going stale.

## Tests

- 42 node tests (`mesh-manager` peer parse / atomic write / last-good / lifecycle; control route).
- Go `TestEdgeProxyForwardsProtoHostAndAuth` asserts the loopback backend receives the injected `Bearer`.
- Go build defers to the `mesh-sidecar` CI job (no local toolchain); the `ipnstate.PeerStatus.Tags`/`Online`/`DNSName` usage was verified against the tailscale **v1.80.0** source (uses tailscale's own `Tags.Len()` idiom).

Pairs with github-router PR (file-based fleet discovery that reads this `peers.json`).