### PR TITLE
feat(mesh): userspace egress proxy + trustable stable-path sidecar

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -55,7 +55,7 @@ jobs:
           # Expected asset names are the fixed platform matrix (NOT the committed
           # lock, whose hashes may be empty in-repo), plus the checksums file.
           mapfile -t WANT < <(node -e "console.log(require('./scripts/mesh-lock.js').ASSET_NAMES.join('\n'))")
-          WANT+=("aiordie-mesh-checksums.txt")
+          WANT+=("ai-or-die-mesh-checksums.txt")
           if ! gh release view "$TAG" --json assets,isDraft > /tmp/rel.json 2>/dev/null; then
             echo "complete=false" >> "$GITHUB_OUTPUT"; echo "release $TAG absent — build required"; exit 0
           fi
@@ -91,11 +91,11 @@ jobs:
           # healthy published release; the brief tag-absent window is harmless
           # because npm publish is gated behind this job (needs: mesh-sidecar).
           gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
-          gh release create "$TAG" --draft --title "$TAG" --notes "aiordie-mesh sidecar ${{ steps.hash.outputs.hash }}"
-          gh release upload "$TAG" dist/mesh/aiordie-mesh-* --clobber
+          gh release create "$TAG" --draft --title "$TAG" --notes "ai-or-die-mesh sidecar ${{ steps.hash.outputs.hash }}"
+          gh release upload "$TAG" dist/mesh/ai-or-die-mesh-* --clobber
           # Verify every expected asset is present on the draft before finalizing.
           gh release view "$TAG" --json assets -q '.assets[].name' > /tmp/have.txt
-          for a in $(node -e "console.log(require('./scripts/mesh-lock.js').ASSET_NAMES.join(' '))") aiordie-mesh-checksums.txt; do
+          for a in $(node -e "console.log(require('./scripts/mesh-lock.js').ASSET_NAMES.join(' '))") ai-or-die-mesh-checksums.txt; do
             grep -qx "$a" /tmp/have.txt || { echo "::error::asset $a missing from draft $TAG"; exit 1; }
           done
           gh release edit "$TAG" --draft=false
@@ -214,8 +214,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="mesh-${{ needs.mesh-sidecar.outputs.hash }}"
-          gh release download "$TAG" --pattern aiordie-mesh-checksums.txt --dir /tmp --clobber
-          node scripts/mesh-lock.js --embed /tmp/aiordie-mesh-checksums.txt
+          gh release download "$TAG" --pattern ai-or-die-mesh-checksums.txt --dir /tmp --clobber
+          node scripts/mesh-lock.js --embed /tmp/ai-or-die-mesh-checksums.txt
           # Gate publish on a fully-valid lock: all 6 platform checksums present,
           # each a real sha256, and contentHash still current.
           node scripts/mesh-lock.js --assert-complete

--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,7 @@ test/
 tests/
 *.test.js
 *.spec.js
+*_test.go
 test-results/
 e2e/
 poc/

--- a/docs/adrs/0035-sidecar-versioning-and-mesh-tls.md
+++ b/docs/adrs/0035-sidecar-versioning-and-mesh-tls.md
@@ -41,7 +41,7 @@ verifies all six assets, then finalizes (atomic ready marker). `release` /
 `npm publish` `needs: mesh-sidecar`, and embeds the freshly-built checksums into
 the published lock — so npm never advertises a version whose sidecar is missing.
 
-**Versioned local path.** Installs land at `aiordie-mesh-<hash>[.exe]`, never
+**Versioned local path.** Installs land at `ai-or-die-mesh-<hash>[.exe]`, never
 overwriting a running binary (Windows `EPERM`).
 
 **Edge TLS, plaintext loopback backend.** The sidecar terminates real

--- a/docs/adrs/0036-mesh-egress-and-stable-path-sidecar.md
+++ b/docs/adrs/0036-mesh-egress-and-stable-path-sidecar.md
@@ -1,0 +1,82 @@
+# ADR-0036: Userspace mesh egress + trustable stable-path sidecar
+
+Date: 2026-07-01
+Status: Accepted
+
+## Context
+
+The mesh sidecar (ADR-0034/0035) makes an ai-or-die instance *reachable* on the tailnet, but a
+userspace `tsnet` node only serves **inbound** — it creates no host `tailscale0` interface and gives
+the host OS no outbound tailnet routing. So a *separate* same-box process (the github-router
+"conductor" that drives the fleet) cannot resolve MagicDNS or route to `.ts.net` peers: every mesh
+instance shows `UNREACHABLE` (NXDOMAIN / no route). Installing full Tailscale on the conductor was
+rejected (admin/driver friction — the whole reason `tsnet` was chosen).
+
+Two other defects surfaced with `--mesh`: the content-addressed binary filename forces re-trusting
+the unsigned sidecar per version on locked-down Windows (WDAC/AppLocker/SmartScreen), and an
+untagged enrollment produced a **silent** empty peer list with no diagnostic.
+
+A cross-lab review (gpt-5.5 / gemini-3.1-pro / Opus) added: undici `ProxyAgent`'s `token` option is
+Basic-only (a Bearer must ride the `headers` option, never a URI, or it leaks in socket errors); an
+egress credential does not belong in the discovery snapshot; the CONNECT allowlist must exact-match
+`DNSName` (no suffix / no IP literals); and the sidecar's existing bearer-injection is ambient
+authority bounded only by the tailnet ACL.
+
+## Decision
+
+**Userspace egress proxy.** The sidecar runs a loopback (`127.0.0.1:0`) HTTP CONNECT proxy backed by
+`tsnet.Server.Dial` (which resolves MagicDNS over WireGuard). It is gated by a random per-process
+`Proxy-Authorization: Bearer` token and an allowlist that permits CONNECT **only** to a
+`tag:aiordie`-tagged peer whose `DNSName` exactly matches `Status().Peer` on ports 443/7777 (IP
+literals rejected). The endpoint + token are announced on stdout (`MESH-EGRESS <url> <token>`) and
+persisted by the manager to a **separate 0600 file** `~/.ai-or-die/mesh/egress.json`
+(`{version,pid,updatedAt,url,token}`), rewritten each spawn (fresh port/pid — no stale-port hole);
+`peers.json` stays credential-free. github-router reads it, treats it stale on a dead pid / expired
+TTL, and routes mesh requests through an undici `ProxyAgent` with the token in the
+`Proxy-Authorization` header only. Origin-pinning + `redirect:"error"` are unchanged.
+
+**Trust: stable path + strip.** Rename `aiordie-mesh` → `ai-or-die-mesh`. The manager LAUNCHES a
+stable, hash-free path (`bin/ai-or-die-mesh[.exe]`) so a single-file WDAC/AppLocker rule matches the
+executed image across versions; the installer verifies the download's SHA-256 (vs the checksum in
+the signed npm package) and replaces the stable file in place. Because the stable file is free at
+process start (the prior ai-or-die and its sidecar have exited), no mid-process hot-swap is needed —
+the upgrade lands on the next launch. After the verify, the MOTW (`Zone.Identifier`) / macOS
+`com.apple.quarantine` mark is stripped so a re-download is not re-gated. Code signing is deferred.
+
+**Diagnostic.** When tailnet peers exist but none carry `tag:aiordie`, the sidecar emits
+`MESH-UNTAGGED <selfTagged> <total> <tagged>` and the manager prints a one-shot actionable hint.
+
+## Consequences
+
+- The no-admin conductor can drive the fleet over the tailnet. The egress runs on every `--mesh` box
+  (loopback-only, token-gated) but only the conductor consumes it.
+- Launching the stable path trades ADR-0035's zero-downtime install-alongside for WDAC single-file
+  rule compatibility; a `--mesh` upgrade now applies at the next process start (brief gap; the
+  MagicDNS name persists via `--statedir`). A directory allow-list (`bin\*`) also works and avoids
+  even that, where the environment permits it.
+- **Required precondition:** the tailnet ACL must deny instance→instance and allow the conductor →
+  `tag:aiordie` on the served ports (see `docs/mesh-acl.example.hujson`). The sidecar injects the app
+  bearer for any ACL-permitted caller (no per-caller identity check), so the ACL + the
+  loopback/token/allowlist are what bound the egress token's authority. A stronger
+  end-to-end-per-peer-bearer model (sidecar as pure L4) is a deferred hardening.
+- MOTW-strip removes SmartScreen/Gatekeeper prompts but does NOT satisfy an enforced-WDAC
+  unsigned-binary block — signing remains the durable fix. Extends ADR-0034/0035.
+
+## Residual risks (cross-lab reviewed, accepted/bounded)
+
+- **Stale-egress port squat (bounded).** The egress binds an ephemeral loopback port and publishes it
+  in `egress.json`; on an ungraceful sidecar death (kill -9/OOM) the file can outlive the port. A
+  local process could squat the freed port and, if a consumer routed to it, receive the Bearer token
+  + traffic. Bounded by: the consumer checks the pid is alive + a 120 s `updatedAt` TTL, and the
+  manager deletes `egress.json` on start (before respawn) and on stop/exit/NEEDLOGIN. The narrow
+  residual is pid-REUSE inside the TTL window. A Unix-domain-socket (0600, auto-revoked on death) is
+  the stronger future design; the token no-leak boundary already keeps the secret out of model/log
+  surfaces.
+- **Stable-path tamper (same-user).** Launching a hash-free path and stripping MOTW trades some
+  tamper-evidence: a local attacker who can WRITE `~/.ai-or-die/bin/` could plant a binary the next
+  launch runs. That attacker already has the user's privileges (game-over regardless), so this is
+  accepted for the no-admin/no-signing posture; signing is the durable fix. The installer still
+  SHA-verifies every download it fetches.
+- The CONNECT splice half-closes each write end on EOF (not a hard both-close) so request/response and
+  keep-alive survive; consumer-side `localhost` is rejected (numeric loopback only) to avoid a
+  rebinding of the proxy endpoint.

--- a/docs/specs/mesh.md
+++ b/docs/specs/mesh.md
@@ -7,7 +7,7 @@ See ADR-0034 for rationale and the alternatives that were tested and rejected.
 
 ## Components
 
-- **`mesh/main.go`** — the `aiordie-mesh` sidecar. A `tsnet` node (in-process
+- **`mesh/main.go`** — the `ai-or-die-mesh` sidecar. A `tsnet` node (in-process
   userspace WireGuard) that enrolls via `TS_AUTHKEY` and reverse-proxies the
   tailnet listener to the loopback backend (`--backend http://127.0.0.1:<port>`,
   validated loopback-only). When the tailnet has HTTPS certificates enabled it
@@ -30,10 +30,10 @@ See ADR-0034 for rationale and the alternatives that were tested and rejected.
 
 ## Install flow (zero manual steps)
 
-1. `ai-or-die --mesh` checks `%LOCALAPPDATA%\ai-or-die\bin\aiordie-mesh-<hash>.exe`
-   (`~/.ai-or-die/bin/aiordie-mesh-<hash>` on POSIX). The path is content-addressed,
+1. `ai-or-die --mesh` checks `%LOCALAPPDATA%\ai-or-die\bin\ai-or-die-mesh-<hash>.exe`
+   (`~/.ai-or-die/bin/ai-or-die-mesh-<hash>` on POSIX). The path is content-addressed,
    so a new build installs alongside the old one (never overwrites a running `.exe`).
-2. If missing, it fetches `aiordie-mesh-<plat>-<arch>[.exe]` from
+2. If missing, it fetches `ai-or-die-mesh-<plat>-<arch>[.exe]` from
    `https://github.com/animeshkundu/ai-or-die/releases/download/mesh-<contentHash>/`
    and verifies its SHA-256 against the checksum embedded in `mesh-sidecar.lock.json`.
 3. If `AIORDIE_TS_AUTHKEY` is set (reusable + tagged), it enrolls; otherwise it
@@ -112,8 +112,51 @@ anonymous default of `--tunnel`. With both flags the tunnel URL carries
 `?token=` so it still works. Ship the default-deny `tag:aiordie` ACL from
 `docs/mesh-acl.example.hujson`.
 
+## Egress (conductor → peers) — ADR-0036
+
+A userspace `tsnet` node serves **inbound** only; it does not put the host OS on
+the tailnet. So a same-box conductor process (github-router driving the fleet)
+cannot reach `.ts.net` peers directly. The sidecar therefore runs a **loopback
+HTTP CONNECT proxy** (`127.0.0.1:0`) backed by `tsnet.Server.Dial`:
+
+- **Gated:** every `CONNECT` needs `Proxy-Authorization: Bearer <token>` (a random
+  per-process token), and the target must be a `tag:aiordie` peer whose `DNSName`
+  EXACTLY matches `Status().Peer` on port 443 or 7777 — IP literals and
+  suffix-style spoofs are rejected. So a stray local process can neither use the
+  proxy nor turn it into a generic tailnet egress.
+- **Advertised:** `MESH-EGRESS http://127.0.0.1:<port> <token>` on stdout; the
+  manager persists it to `~/.ai-or-die/mesh/egress.json` (mode 0600,
+  `{version,pid,updatedAt,url,token}`), rewritten each spawn. This is a SEPARATE
+  file from `peers.json` (which stays credential-free); the consumer treats it
+  stale on a dead pid / expired TTL.
+- Runs on every `--mesh` box, but only a same-box conductor consumes it.
+
+The peer's OWN sidecar still injects the app bearer on the tailnet→loopback hop,
+so the conductor sends no `Authorization` on the wire. That injection is
+identity-blind, so the tailnet ACL (deny instance→instance; allow your conductor
+→ `tag:aiordie`) is a REQUIRED precondition — see `docs/mesh-acl.example.hujson`.
+
+## Trust: stable path + strip (ADR-0036)
+
+The manager LAUNCHES a stable, hash-free path (`bin/ai-or-die-mesh[.exe]`) so a
+single-file WDAC/AppLocker rule matches the executed image across versions; the
+installer verifies the download's SHA-256 (vs the signed-npm checksum) and
+replaces the stable file in place (the file is free at process start, so an
+upgrade lands on the next launch). After the verify it strips the Windows MOTW /
+macOS quarantine mark so a re-download is not re-gated. This does NOT satisfy an
+enforced-WDAC unsigned-binary block — signing stays the durable fix. A directory
+allow-list (`%LOCALAPPDATA%\ai-or-die\bin\*`) also works where permitted.
+
+## Untagged diagnostic
+
+When tailnet peers exist but none carry `tag:aiordie`, the sidecar emits
+`MESH-UNTAGGED <selfTagged> <total> <tagged>` and the manager prints a one-shot
+hint: fleet discovery stays empty until instances are tagged (enroll with a
+reusable+tagged key, or retag in the admin console).
+
 ## Verified
 
 Built + run on Windows with no admin/driver; an internet-tagged (MOTW) binary
 executed unblocked; two userspace nodes enrolled and a remote node fetched the
-live app E2E over WireGuard.
+live app E2E over WireGuard. The egress proxy's auth gating, exact-DNSName
+allowlist, and CONNECT tunnel are unit-tested (`mesh/egress_test.go`).

--- a/mesh-sidecar.lock.json
+++ b/mesh-sidecar.lock.json
@@ -1,5 +1,5 @@
 {
   "version": "1.0.0",
-  "contentHash": "dbf60b5215ebb0b0947edf8fa47906280dd1fea12ef7e1181918fecfe7d9bcc0",
+  "contentHash": "15ca95fdba8ba0d81c2e49f8f9707d2fb124f51ee3982dea3a87d11b140ab279",
   "assets": {}
 }

--- a/mesh/egress_test.go
+++ b/mesh/egress_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/types/key"
+	"tailscale.com/types/views"
+)
+
+type fakeStatus struct{ st *ipnstate.Status }
+
+func (f fakeStatus) Status(context.Context) (*ipnstate.Status, error) { return f.st, nil }
+
+func mockStatus(peers ...*ipnstate.PeerStatus) *ipnstate.Status {
+	m := map[key.NodePublic]*ipnstate.PeerStatus{}
+	for _, p := range peers {
+		m[key.NewNode().Public()] = p
+	}
+	return &ipnstate.Status{Peer: m}
+}
+
+func taggedPeer(dns, tag string) *ipnstate.PeerStatus {
+	t := views.SliceOf([]string{tag})
+	return &ipnstate.PeerStatus{HostName: "h", DNSName: dns, Tags: &t, Online: true}
+}
+
+func untaggedPeer(dns string) *ipnstate.PeerStatus {
+	return &ipnstate.PeerStatus{HostName: "h", DNSName: dns, Online: true}
+}
+
+func TestEgressTargetAllowed(t *testing.T) {
+	lc := fakeStatus{mockStatus(
+		taggedPeer("peer.tail.ts.net.", "tag:aiordie"), // trailing dot, normalized away
+		untaggedPeer("phone.tail.ts.net"),
+	)}
+	cases := []struct {
+		host, port string
+		want       bool
+		why        string
+	}{
+		{"peer.tail.ts.net", "443", true, "tagged peer on 443"},
+		{"peer.tail.ts.net", "7777", true, "tagged peer on 7777"},
+		{"PEER.TAIL.TS.NET", "443", true, "case-insensitive DNSName match"},
+		{"peer.tail.ts.net", "8080", false, "port not in {443,7777}"},
+		{"peer.tail.ts.net", "22", false, "ssh port rejected"},
+		{"phone.tail.ts.net", "443", false, "untagged peer rejected"},
+		{"unknown.tail.ts.net", "443", false, "unknown host rejected"},
+		{"peer.tail.ts.net.evil.com", "443", false, "suffix-style spoof rejected"},
+		{"100.64.1.2", "443", false, "IP literal rejected"},
+		{"", "443", false, "empty host rejected"},
+	}
+	for _, c := range cases {
+		if got := egressTargetAllowed(lc, c.host, c.port); got != c.want {
+			t.Errorf("egressTargetAllowed(%q,%q)=%v want %v (%s)", c.host, c.port, got, c.want, c.why)
+		}
+	}
+}
+
+// echoDial returns a real TCP connection to a shared in-process echo server, so a
+// full CONNECT tunnel (incl. half-close via CloseWrite) can be exercised without
+// a tailnet.
+var (
+	echoOnce sync.Once
+	echoAddr string
+)
+
+func echoDial(context.Context, string, string) (net.Conn, error) {
+	echoOnce.Do(func() {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return
+		}
+		echoAddr = ln.Addr().String()
+		go func() {
+			for {
+				c, err := ln.Accept()
+				if err != nil {
+					return
+				}
+				go func(c net.Conn) { _, _ = io.Copy(c, c); _ = c.Close() }(c)
+			}
+		}()
+	})
+	if echoAddr == "" {
+		return nil, io.ErrClosedPipe
+	}
+	return net.Dial("tcp", echoAddr)
+}
+
+func failDial(context.Context, string, string) (net.Conn, error) {
+	return nil, io.EOF
+}
+
+func serveEgress(t *testing.T, dial dialFunc, token string) (addr string, done func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lc := fakeStatus{mockStatus(taggedPeer("peer.tail.ts.net", "tag:aiordie"))}
+	srv := &http.Server{Handler: egressHandler(dial, lc, token)}
+	go func() { _ = srv.Serve(ln) }()
+	return ln.Addr().String(), func() { _ = srv.Close(); _ = ln.Close() }
+}
+
+func rawConnect(t *testing.T, proxyAddr, target, authz string) (*bufio.Reader, net.Conn) {
+	t.Helper()
+	c, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = c.SetDeadline(time.Now().Add(3 * time.Second))
+	req := "CONNECT " + target + " HTTP/1.1\r\nHost: " + target + "\r\n"
+	if authz != "" {
+		req += "Proxy-Authorization: " + authz + "\r\n"
+	}
+	req += "\r\n"
+	if _, err := c.Write([]byte(req)); err != nil {
+		t.Fatal(err)
+	}
+	return bufio.NewReader(c), c
+}
+
+func statusLine(t *testing.T, br *bufio.Reader) string {
+	t.Helper()
+	line, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	return line
+}
+
+func TestEgressHandlerRejectsNonConnect(t *testing.T) {
+	addr, done := serveEgress(t, echoDial, "secret")
+	defer done()
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	_ = c.SetDeadline(time.Now().Add(3 * time.Second))
+	_, _ = c.Write([]byte("GET / HTTP/1.1\r\nHost: x\r\n\r\n"))
+	line, _ := bufio.NewReader(c).ReadString('\n')
+	if !strings.Contains(line, "405") {
+		t.Fatalf("want 405 for GET, got %q", line)
+	}
+}
+
+func TestEgressHandlerRequiresToken(t *testing.T) {
+	addr, done := serveEgress(t, echoDial, "secret")
+	defer done()
+
+	br, c := rawConnect(t, addr, "peer.tail.ts.net:443", "")
+	if line := statusLine(t, br); !strings.Contains(line, "407") {
+		t.Fatalf("want 407 without token, got %q", line)
+	}
+	c.Close()
+
+	br, c = rawConnect(t, addr, "peer.tail.ts.net:443", "Bearer nope")
+	if line := statusLine(t, br); !strings.Contains(line, "407") {
+		t.Fatalf("want 407 with wrong token, got %q", line)
+	}
+	c.Close()
+}
+
+func TestEgressHandlerRejectsForbiddenTarget(t *testing.T) {
+	addr, done := serveEgress(t, echoDial, "secret")
+	defer done()
+	br, c := rawConnect(t, addr, "evil.example.com:443", "Bearer secret")
+	defer c.Close()
+	if line := statusLine(t, br); !strings.Contains(line, "403") {
+		t.Fatalf("want 403 for forbidden target, got %q", line)
+	}
+}
+
+func TestEgressHandlerTunnelsAllowedTarget(t *testing.T) {
+	addr, done := serveEgress(t, echoDial, "secret")
+	defer done()
+	br, c := rawConnect(t, addr, "peer.tail.ts.net:443", "Bearer secret")
+	defer c.Close()
+	if line := statusLine(t, br); !strings.Contains(line, "200") {
+		t.Fatalf("want 200 Connection Established, got %q", line)
+	}
+	// Consume the blank line terminating the CONNECT response headers.
+	for {
+		l, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read header terminator: %v", err)
+		}
+		if strings.TrimSpace(l) == "" {
+			break
+		}
+	}
+	if _, err := c.Write([]byte("ping")); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(br, buf); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("tunnel echo mismatch: %q", buf)
+	}
+}
+
+func TestEgressHandlerBadGatewayOnDialFailure(t *testing.T) {
+	addr, done := serveEgress(t, failDial, "secret")
+	defer done()
+	br, c := rawConnect(t, addr, "peer.tail.ts.net:443", "Bearer secret")
+	defer c.Close()
+	if line := statusLine(t, br); !strings.Contains(line, "502") {
+		t.Fatalf("want 502 on dial failure, got %q", line)
+	}
+}
+
+func TestPeerCounts(t *testing.T) {
+	st := mockStatus(
+		taggedPeer("a.ts.net", "tag:aiordie"),
+		untaggedPeer("b.ts.net"),
+		untaggedPeer("c.ts.net"),
+	)
+	total, tagged := peerCounts(st)
+	if total != 3 || tagged != 1 {
+		t.Fatalf("peerCounts=(%d,%d) want (3,1)", total, tagged)
+	}
+}

--- a/mesh/go.mod
+++ b/mesh/go.mod
@@ -1,4 +1,4 @@
-module aiordie-mesh
+module ai-or-die-mesh
 
 go 1.23
 

--- a/mesh/main.go
+++ b/mesh/main.go
@@ -1,4 +1,4 @@
-// Command aiordie-mesh is the userspace mesh sidecar for ai-or-die. It joins a
+// Command ai-or-die-mesh is the userspace mesh sidecar for ai-or-die. It joins a
 // Tailscale tailnet entirely in userspace via tsnet (no kernel TUN, no admin,
 // no system service) and reverse-proxies the tailnet listener to ai-or-die's
 // local HTTP/WebSocket port. Only this one port is exposed on the mesh; the
@@ -18,16 +18,24 @@
 //   MESH-URL http://<name>       node is up, but TLS certs unavailable (degraded)
 //   MESH-NOCERT                  hint: enable HTTPS Certificates in the tailnet
 //   MESH-PEERS {"self":...,"peers":[...]} tagged fleet peers snapshot
+//   MESH-EGRESS http://127.0.0.1:<port> <token>  loopback CONNECT proxy for a
+//                                same-box conductor to reach tagged tailnet peers
+//   MESH-UNTAGGED <selfTagged> <total> <tagged>  tailnet peers exist but none are
+//                                tagged tag:aiordie — discovery will stay empty
 //   MESH-NEEDLOGIN <url>         no/!valid key — operator must enroll
 //   MESH-ERR <msg>               fatal
 package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/subtle"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -35,6 +43,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"tailscale.com/ipn/ipnstate"
@@ -93,6 +102,10 @@ func main() {
 
 	if lc, err := s.LocalClient(); err == nil {
 		go emitMeshPeersLoop(context.Background(), lc)
+		// Loopback egress: lets a same-box conductor (github-router) reach tagged
+		// tailnet peers over WireGuard without the host OS joining the tailnet.
+		// Best-effort — a failure here never blocks serving.
+		startEgressProxy(s, lc)
 	}
 
 	name := *host
@@ -223,6 +236,29 @@ func emitMeshPeers(ctx context.Context, lc statusClient) {
 		return
 	}
 	fmt.Printf("MESH-PEERS %s\n", b)
+
+	// Diagnostic: tailnet peers exist but none are tagged tag:aiordie, so the
+	// snapshot above is empty and fleet discovery will surface nothing. Emit a
+	// machine-parseable line the manager turns into an actionable hint — the
+	// silent-empty-peers state is the exact failure this whole path guards against.
+	total, tagged := peerCounts(status)
+	if total > 0 && tagged == 0 {
+		selfTagged := status.Self != nil && peerHasTag(status.Self, meshPeerTag)
+		fmt.Printf("MESH-UNTAGGED %t %d %d\n", selfTagged, total, tagged)
+	}
+}
+
+func peerCounts(status *ipnstate.Status) (total, tagged int) {
+	for _, ps := range status.Peer {
+		if ps == nil {
+			continue
+		}
+		total++
+		if peerHasTag(ps, meshPeerTag) {
+			tagged++
+		}
+	}
+	return total, tagged
 }
 
 func meshPeersFromStatus(status *ipnstate.Status) meshPeersSnapshot {
@@ -338,4 +374,136 @@ func newEdgeProxy(target *url.URL, name string, proto *string, proxyBearer strin
 		rp.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	}
 	return rp
+}
+
+// startEgressProxy stands up a loopback HTTP CONNECT proxy so a same-box conductor
+// process (github-router) can reach TAGGED tailnet peers over the sidecar's
+// in-process WireGuard — the host OS never joins the tailnet. It is bound to
+// loopback, gated by a random per-process bearer, and restricted to tagged
+// .ts.net peers on the served ports, so a stray local process can neither turn it
+// into a generic tailnet egress nor learn the token off the wire. The endpoint +
+// token are announced via MESH-EGRESS for the manager to persist (0600).
+// Best-effort: any failure here never blocks serving.
+func startEgressProxy(s *tsnet.Server, lc statusClient) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return
+	}
+	token, err := randToken()
+	if err != nil {
+		_ = ln.Close()
+		return
+	}
+	fmt.Printf("MESH-EGRESS http://%s %s\n", ln.Addr().String(), token)
+	srv := &http.Server{Handler: egressHandler(s.Dial, lc, token)}
+	go func() { _ = srv.Serve(ln) }()
+}
+
+// dialFunc dials a tailnet address (tsnet.Server.Dial); injectable for tests.
+type dialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
+func egressHandler(dial dialFunc, lc statusClient, token string) http.Handler {
+	want := "Bearer " + token
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "only CONNECT is supported", http.StatusMethodNotAllowed)
+			return
+		}
+		// Constant-time bearer check on the proxy hop so a stray local process
+		// cannot use the tailnet egress without the per-process token.
+		got := r.Header.Get("Proxy-Authorization")
+		if subtle.ConstantTimeCompare([]byte(got), []byte(want)) != 1 {
+			w.Header().Set("Proxy-Authenticate", "Bearer")
+			http.Error(w, "proxy authorization required", http.StatusProxyAuthRequired)
+			return
+		}
+		host, port, err := net.SplitHostPort(r.Host)
+		if err != nil {
+			http.Error(w, "bad CONNECT target", http.StatusBadRequest)
+			return
+		}
+		if !egressTargetAllowed(lc, host, port) {
+			http.Error(w, "forbidden CONNECT target", http.StatusForbidden)
+			return
+		}
+		upstream, err := dial(r.Context(), "tcp", net.JoinHostPort(host, port))
+		if err != nil {
+			http.Error(w, "upstream dial failed", http.StatusBadGateway)
+			return
+		}
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			_ = upstream.Close()
+			http.Error(w, "hijack unsupported", http.StatusInternalServerError)
+			return
+		}
+		clientConn, _, err := hj.Hijack()
+		if err != nil {
+			_ = upstream.Close()
+			return
+		}
+		_, _ = clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+		// Splice both directions. Half-close each write end on its own EOF (so a
+		// one-way FIN — e.g. an HTTP/1.1 request with Connection: close — does not
+		// truncate the reply mid-flight), then fully close once BOTH directions
+		// have drained. net.Pipe and other non-TCP conns lack CloseWrite; the type
+		// assertion simply skips the half-close for them.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_, _ = io.Copy(upstream, clientConn)
+			if cw, ok := upstream.(interface{ CloseWrite() error }); ok {
+				_ = cw.CloseWrite()
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = io.Copy(clientConn, upstream)
+			if cw, ok := clientConn.(interface{ CloseWrite() error }); ok {
+				_ = cw.CloseWrite()
+			}
+		}()
+		wg.Wait()
+		_ = clientConn.Close()
+		_ = upstream.Close()
+	})
+}
+
+// egressTargetAllowed permits CONNECT only to a TAGGED same-tailnet .ts.net peer
+// (exact DNSName match, never a suffix) on a served port, and rejects IP-literal
+// targets — so the loopback proxy can never be turned into a generic tailnet
+// egress, preserving the ACL's instance-isolation posture.
+func egressTargetAllowed(lc statusClient, host, port string) bool {
+	if port != "443" && port != "7777" {
+		return false
+	}
+	if net.ParseIP(host) != nil {
+		return false // no raw IPs — only MagicDNS names bound to a known tagged peer
+	}
+	want := normalizeDNSName(host)
+	if want == "" {
+		return false
+	}
+	status, err := lc.Status(context.Background())
+	if err != nil || status == nil {
+		return false
+	}
+	for _, ps := range status.Peer {
+		if ps == nil || !peerHasTag(ps, meshPeerTag) {
+			continue
+		}
+		if normalizeDNSName(ps.DNSName) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func randToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-or-die",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-or-die",
-      "version": "0.1.90",
+      "version": "0.1.91",
       "license": "MIT",
       "dependencies": {
         "@lydell/node-pty": "1.2.0-beta.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-or-die",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "description": "Universal AI coding terminal — Claude, Copilot, Gemini & more in your browser",
   "main": "src/server.js",
   "bin": {

--- a/scripts/build-mesh-sidecar.sh
+++ b/scripts/build-mesh-sidecar.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-# Cross-build the aiordie-mesh tsnet sidecar for all supported platforms and
+# Cross-build the ai-or-die-mesh tsnet sidecar for all supported platforms and
 # emit SHA-256 checksums. Go cross-compiles from one runner, so this produces
 # every target binary plus a checksums manifest the client verifies against.
 #
 # Output (uploaded to the GitHub release by release-on-main.yml):
-#   dist/mesh/aiordie-mesh-<plat>-<arch>[.exe]
-#   dist/mesh/aiordie-mesh-checksums.txt   ("<sha256>  <assetname>" per line)
+#   dist/mesh/ai-or-die-mesh-<plat>-<arch>[.exe]
+#   dist/mesh/ai-or-die-mesh-checksums.txt   ("<sha256>  <assetname>" per line)
 set -euo pipefail
 root="$(cd "$(dirname "$0")/.." && pwd)"
 
 # Content hash (Go-free) identifies this sidecar build; stamp it into the binary
-# so `aiordie-mesh --version` is traceable and the release tag is mesh-<hash>.
+# so `ai-or-die-mesh --version` is traceable and the release tag is mesh-<hash>.
 version="$(node "$root/scripts/mesh-lock.js" --print-hash)"
 echo "mesh content hash: $version"
 
@@ -20,7 +20,7 @@ out="$root/dist/mesh"; rm -rf "$out"; mkdir -p "$out"
 go mod tidy   # generate go.sum for a reproducible build
 
 emit() {  # <goos> <goarch> <plat> <arch> <ext>
-  local name="aiordie-mesh-$3-$4$5"
+  local name="ai-or-die-mesh-$3-$4$5"
   GOOS=$1 GOARCH=$2 CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=$version" -o "$out/$name" .
   echo "built $name"
 }
@@ -33,13 +33,13 @@ emit darwin  arm64 darwin  arm64 ""
 
 # Self-sign Windows binaries when a cert is provided (fleet reputation).
 if command -v signtool >/dev/null 2>&1 && [ -n "${AIORDIE_SIGN_PFX:-}" ]; then
-  for b in "$out"/aiordie-mesh-windows-*; do
+  for b in "$out"/ai-or-die-mesh-windows-*; do
     signtool sign /f "$AIORDIE_SIGN_PFX" /p "${AIORDIE_SIGN_PW:-}" /fd sha256 "$b" && echo "signed $b"
   done
 fi
 
-( cd "$out" && sha256sum aiordie-mesh-* > aiordie-mesh-checksums.txt )
-echo "checksums:"; cat "$out/aiordie-mesh-checksums.txt"
+( cd "$out" && sha256sum ai-or-die-mesh-* > ai-or-die-mesh-checksums.txt )
+echo "checksums:"; cat "$out/ai-or-die-mesh-checksums.txt"
 
 # Finalize the lock with the freshly-built per-asset checksums (the installer
 # verifies downloads against these; they ship inside the npm tarball).

--- a/scripts/mesh-lock.js
+++ b/scripts/mesh-lock.js
@@ -35,12 +35,12 @@ const LOCK_PATH = path.join(ROOT, 'mesh-sidecar.lock.json');
 // The full platform matrix. MUST stay in lock-step with assetName() in
 // src/utils/sidecar-installer.js and the emit() calls in build-mesh-sidecar.sh.
 const ASSET_NAMES = [
-  'aiordie-mesh-windows-amd64.exe',
-  'aiordie-mesh-windows-arm64.exe',
-  'aiordie-mesh-linux-amd64',
-  'aiordie-mesh-linux-arm64',
-  'aiordie-mesh-darwin-amd64',
-  'aiordie-mesh-darwin-arm64',
+  'ai-or-die-mesh-windows-amd64.exe',
+  'ai-or-die-mesh-windows-arm64.exe',
+  'ai-or-die-mesh-linux-amd64',
+  'ai-or-die-mesh-linux-arm64',
+  'ai-or-die-mesh-darwin-amd64',
+  'ai-or-die-mesh-darwin-arm64',
 ];
 
 // Source files whose content defines the sidecar binary. A change to any of

--- a/src/mesh-manager.js
+++ b/src/mesh-manager.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // MeshManager — permanent reachability over a Tailscale tailnet via the
-// aiordie-mesh sidecar (tsnet in USERSPACE: no kernel TUN, no admin, no system
+// ai-or-die-mesh sidecar (tsnet in USERSPACE: no kernel TUN, no admin, no system
 // service). Only ai-or-die's own port joins the mesh; the rest of the machine
 // stays off it. Mirrors TunnelManager's lifecycle (detect → start → backoff →
 // stop) so bin/ai-or-die.js supervises it like the dev tunnel. Verified E2E:
@@ -11,6 +11,7 @@ const { spawn } = require('child_process');
 const os = require('os');
 const path = require('path');
 const fs = require('fs');
+const crypto = require('crypto');
 
 const URL_TIMEOUT_MS = 60000;          // enroll + name can take ~30s on first run
 const STABILITY_THRESHOLD_MS = 60000;  // 60s up = reset retry budget
@@ -38,11 +39,11 @@ class MeshManager {
       ? path.join(localApp, 'ai-or-die')
       : path.join(os.homedir(), '.ai-or-die');
     this.stateDir = options.stateDir || path.join(this._appBase, 'ts-state');
-    // The sidecar binary is content-addressed: its path embeds the lock's
-    // contentHash so a new build installs alongside the old one (no overwrite of
-    // a running .exe). Derived from the installer's lock + path helpers.
+    // The sidecar is LAUNCHED from a stable, hash-free path (ai-or-die-mesh[.exe])
+    // so a single-file WDAC/AppLocker allow-list rule matches the executed image
+    // across versions (ADR-0036). The installer verifies + replaces it in place.
     this._installer = options._installer || require('./utils/sidecar-installer');
-    this.sidecar = options.sidecar || this._sidecarPathFromLock(this._appBase);
+    this.sidecar = options.sidecar || this._stableSidecarPath(this._appBase);
     this.hostname = (options.hostname || `aiordie-${os.hostname()}`).toLowerCase().replace(/[^a-z0-9-]/g, '');
 
     this.proc = null;
@@ -59,12 +60,16 @@ class MeshManager {
     this._stabilityThresholdMs = options._stabilityThresholdMs || STABILITY_THRESHOLD_MS;
     this._stdoutBuffer = '';
     this.peers = null;
+    this._untaggedWarned = false;
   }
 
   /** Never throws — degrades to localhost/devtunnel on any failure. */
   async start() {
     console.log('\n  Connecting mesh (Tailscale userspace)...');
     this.stopping = false;
+    // Clear any egress.json left by a crashed/kill -9'd prior run BEFORE (re)spawn,
+    // so a consumer can't route to a freed loopback port a local process squatted.
+    this._deleteEgressFile();
     if (!fs.existsSync(this.sidecar)) {
       if (!(await this._ensureSidecar())) { this._printMissing(this._lastError); return; }
     }
@@ -73,13 +78,12 @@ class MeshManager {
     await this._spawn();
   }
 
-  /** Content-addressed sidecar path from the committed lock; safe fallback. */
-  _sidecarPathFromLock(base) {
+  /** Stable, hash-free sidecar path from the installer; safe fallback. */
+  _stableSidecarPath(base) {
     try {
-      const lock = this._installer.loadLock();
-      return this._installer.sidecarPath(lock.contentHash);
+      return this._installer.stableSidecarPath();
     } catch (_) {
-      const exe = process.platform === 'win32' ? 'aiordie-mesh.exe' : 'aiordie-mesh';
+      const exe = process.platform === 'win32' ? 'ai-or-die-mesh.exe' : 'ai-or-die-mesh';
       return path.join(base, 'bin', exe);
     }
   }
@@ -113,6 +117,7 @@ class MeshManager {
   async stop() {
     this.stopping = true;
     this._deletePeersFile();
+    this._deleteEgressFile();
     this._clearStabilityTimer();
     clearTimeout(this._restartDelayTimer);
     if (this._restartDelayResolve) { this._restartDelayResolve(); this._restartDelayResolve = null; }
@@ -156,6 +161,7 @@ class MeshManager {
           }
           if (/^MESH-NEEDLOGIN\b/.test(line)) {
             this._deletePeersFile();
+            this._deleteEgressFile();
             this._printNotEnrolled();
             if (!done) { done = true; clearTimeout(timer); resolve(); }
           }
@@ -164,7 +170,7 @@ class MeshManager {
       this.proc.stderr.on('data', (d) => { if (this.dev) process.stderr.write(`  [mesh] ${d}`); });
       this.proc.on('error', (e) => { console.error(`  \x1b[31mmesh sidecar failed: ${e.message}\x1b[0m`); this.proc = null; if (!done) { done = true; clearTimeout(timer); resolve(); } });
       this.proc.on('exit', (code) => {
-        this._clearStabilityTimer(); this.proc = null; this.dnsName = null; this._deletePeersFile();
+        this._clearStabilityTimer(); this.proc = null; this.dnsName = null; this._deletePeersFile(); this._deleteEgressFile();
         if (!this.stopping && code !== 0) this._restart();
       });
     });
@@ -189,7 +195,9 @@ class MeshManager {
 
   _handleStdoutLine(line) {
     try {
-      if (/^MESH-NEEDLOGIN\b/.test(line)) this._deletePeersFile();
+      if (/^MESH-NEEDLOGIN\b/.test(line)) { this._deletePeersFile(); this._deleteEgressFile(); return; }
+      if (/^MESH-EGRESS\b/.test(line)) { this._handleEgressLine(line); return; }
+      if (/^MESH-UNTAGGED\b/.test(line)) { this._handleUntaggedLine(line); return; }
       const match = /^MESH-PEERS\s+(.+)$/.exec(line);
       if (!match) return;
       const raw = match[1];
@@ -206,6 +214,8 @@ class MeshManager {
       const normalized = this._validatePeersPayload(parsed);
       if (!normalized) return;
       this.peers = normalized;
+      // Recovered: tagged peers are visible again, so re-arm the untagged warning.
+      if (normalized.peers.length > 0) this._untaggedWarned = false;
       this._writePeersFile(normalized);
     } catch (_) {}
   }
@@ -247,6 +257,70 @@ class MeshManager {
   _deletePeersFile() {
     this.peers = null;
     try { fs.rmSync(this.peersFilePath(), { force: true }); } catch (_) {}
+  }
+
+  egressFilePath() {
+    return path.join(this._appBase, 'mesh', 'egress.json');
+  }
+
+  // Parse `MESH-EGRESS <url> <token>` and persist the loopback CONNECT-proxy
+  // endpoint + local secret for a same-box conductor (github-router) to consume.
+  // Only a loopback http URL is ever accepted; the token is a local credential.
+  _handleEgressLine(line) {
+    const m = /^MESH-EGRESS\s+(\S+)\s+(\S+)\s*$/.exec(line);
+    if (!m) return;
+    const url = m[1];
+    const token = m[2];
+    let u;
+    try { u = new URL(url); } catch (_) { return; }
+    if (u.protocol !== 'http:') return;
+    const host = u.hostname.replace(/^\[/, '').replace(/\]$/, '');
+    // Only a numeric loopback literal — never `localhost`, whose resolution a
+    // consumer's DNS/hosts config could rebind off-host.
+    if (host !== '127.0.0.1' && host !== '::1') return;
+    if (!token || /\s/.test(token)) return;
+    this._writeEgressFile(url, token);
+  }
+
+  _writeEgressFile(url, token) {
+    const file = this.egressFilePath();
+    const dir = path.dirname(file);
+    // Random, exclusive-create tmp so a pre-planted symlink at a predictable path
+    // can't redirect the write (TOCTOU / symlink clobber).
+    const tmp = path.join(dir, `egress.json.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`);
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(tmp, JSON.stringify({
+        version: 1,
+        pid: this.proc ? this.proc.pid : process.pid,
+        updatedAt: Date.now(),
+        url,
+        token,
+      }), { mode: 0o600, flag: 'wx' });
+      fs.chmodSync(tmp, 0o600);
+      fs.renameSync(tmp, file);
+    } catch (_) {
+      try { fs.rmSync(tmp, { force: true }); } catch (_) {}
+    }
+  }
+
+  _deleteEgressFile() {
+    try { fs.rmSync(this.egressFilePath(), { force: true }); } catch (_) {}
+  }
+
+  // Actionable one-shot hint: tailnet peers exist but none carry tag:aiordie, so
+  // fleet discovery will surface nothing until they are tagged. The exact failure
+  // this whole path guards against — surfaced, not silent.
+  _handleUntaggedLine(line) {
+    if (this._untaggedWarned) return;
+    const m = /^MESH-UNTAGGED\s+(\S+)\s+(\d+)\s+(\d+)\s*$/.exec(line);
+    if (!m) return;
+    this._untaggedWarned = true;
+    const total = m[2];
+    console.log(`\n  \x1b[33mMesh: ${total} tailnet device(s) visible but \x1b[1m0 tagged tag:aiordie\x1b[0m\x1b[33m.\x1b[0m`);
+    console.log('    Fleet discovery stays EMPTY until instances carry the tag:');
+    console.log('    • enroll with a REUSABLE + TAGGED key (tag:aiordie), or retag each device in the admin console;');
+    console.log('    • ensure the ACL allows your conductor → tag:aiordie on the served ports (docs/mesh-acl.example.hujson).');
   }
 
   _printMissing(err) {

--- a/src/utils/sidecar-installer.js
+++ b/src/utils/sidecar-installer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Sidecar installer — fetches the prebuilt aiordie-mesh tsnet binary for the
+// Sidecar installer — fetches the prebuilt ai-or-die-mesh tsnet binary for the
 // current platform and verifies it against a SHA-256 that ships INSIDE this npm
 // package (mesh-sidecar.lock.json). Trust is therefore anchored by the signed
 // npm artifact, not by a checksums file fetched from the same mutable GitHub
@@ -12,7 +12,7 @@
 // CI only rebuilds when the source — and thus the hash — changes.
 //
 // Asset convention (published by .github/workflows/release-on-main.yml):
-//   aiordie-mesh-<plat>-<arch>[.exe]   plat: windows|linux|darwin  arch: amd64|arm64
+//   ai-or-die-mesh-<plat>-<arch>[.exe]   plat: windows|linux|darwin  arch: amd64|arm64
 
 const fs = require('fs');
 const fsp = require('fs').promises;
@@ -44,7 +44,7 @@ function assetName() {
   const plat = PLAT[process.platform];
   const arch = ARCH[process.arch];
   if (!plat || !arch) return null;
-  return `aiordie-mesh-${plat}-${arch}${process.platform === 'win32' ? '.exe' : ''}`;
+  return `ai-or-die-mesh-${plat}-${arch}${process.platform === 'win32' ? '.exe' : ''}`;
 }
 
 function baseDir() {
@@ -52,11 +52,32 @@ function baseDir() {
   return process.platform === 'win32' ? path.join(localApp, 'ai-or-die') : path.join(os.homedir(), '.ai-or-die');
 }
 
-// Versioned path: a new contentHash installs alongside the old one, so we never
-// rename over a binary that a running sidecar still has open (Windows EPERM).
-function sidecarPath(contentHash) {
+// Stable runnable path (NO content hash): the manager LAUNCHES this path, so a
+// single-file WDAC/AppLocker allow-list rule matches the executed image across
+// every version. This trades ADR-0035's install-alongside for that match; it is
+// safe because the stable file is free at process start (the prior ai-or-die and
+// its sidecar have exited), and the MOTW/quarantine mark is stripped after the
+// SHA-256 verify so a re-download is not re-gated. See ADR-0036.
+function stableSidecarPath() {
   const ext = process.platform === 'win32' ? '.exe' : '';
-  return path.join(baseDir(), 'bin', `aiordie-mesh-${contentHash}${ext}`);
+  return path.join(baseDir(), 'bin', `ai-or-die-mesh${ext}`);
+}
+
+// Best-effort provenance strip AFTER the SHA-256 verify: remove Windows
+// mark-of-the-web (Zone.Identifier ADS) / macOS Gatekeeper quarantine so the
+// freshly-verified binary is not re-gated by SmartScreen/Gatekeeper on each new
+// version. We verified the bytes against the checksum shipped in the signed npm
+// package, so this de-gates only a binary we already trust. Never throws.
+function stripProvenance(file) {
+  try {
+    if (process.platform === 'win32') {
+      fs.rmSync(`${file}:Zone.Identifier`, { force: true });
+    } else if (process.platform === 'darwin') {
+      try {
+        require('child_process').execFileSync('xattr', ['-d', 'com.apple.quarantine', file], { stdio: 'ignore' });
+      } catch (_) { /* xattr absent or attribute not set */ }
+    }
+  } catch (_) { /* best-effort */ }
 }
 
 // The release ref to fetch from. Defaults to mesh-<contentHash>; an explicit
@@ -127,11 +148,11 @@ async function ensureSidecar(dest, opts = {}) {
     throw new SidecarError('lock-unfinalized', `mesh-sidecar.lock.json has no checksum for ${name} (built without the mesh asset pipeline?)`);
   }
 
-  dest = dest || sidecarPath(lock.contentHash);
+  dest = dest || stableSidecarPath();
 
   // Existing file: trust only if it matches; otherwise replace it.
   if (fs.existsSync(dest)) {
-    if ((await _sha256(dest)).toLowerCase() === want) return dest;
+    if ((await _sha256(dest)).toLowerCase() === want) { stripProvenance(dest); return dest; }
     try { await fsp.unlink(dest); }
     catch (e) {
       if (e.code === 'EPERM' || e.code === 'EBUSY' || e.code === 'EACCES') {
@@ -157,7 +178,7 @@ async function ensureSidecar(dest, opts = {}) {
     } catch (e) {
       // Lost a race to a concurrent installer (or the file is locked). If the
       // destination is now present and valid, accept it; otherwise surface it.
-      if (fs.existsSync(dest) && (await _sha256(dest)).toLowerCase() === want) return dest;
+      if (fs.existsSync(dest) && (await _sha256(dest)).toLowerCase() === want) { stripProvenance(dest); return dest; }
       if (e.code === 'EPERM' || e.code === 'EBUSY' || e.code === 'EACCES') {
         throw new SidecarError('locked-binary', `cannot install sidecar at ${dest} (${e.code})`);
       }
@@ -166,7 +187,8 @@ async function ensureSidecar(dest, opts = {}) {
   } finally {
     try { await fsp.unlink(tmp); } catch (_) {}
   }
+  stripProvenance(dest);
   return dest;
 }
 
-module.exports = { ensureSidecar, sidecarPath, assetName, loadLock, SidecarError };
+module.exports = { ensureSidecar, stableSidecarPath, assetName, loadLock, SidecarError };

--- a/test/mesh-lock.test.js
+++ b/test/mesh-lock.test.js
@@ -16,8 +16,8 @@ function run(args) {
 describe('mesh-lock', function () {
   it('exposes the full 6-platform asset matrix', function () {
     assert.strictEqual(meshLock.ASSET_NAMES.length, 6);
-    assert.ok(meshLock.ASSET_NAMES.includes('aiordie-mesh-windows-amd64.exe'));
-    assert.ok(meshLock.ASSET_NAMES.includes('aiordie-mesh-darwin-arm64'));
+    assert.ok(meshLock.ASSET_NAMES.includes('ai-or-die-mesh-windows-amd64.exe'));
+    assert.ok(meshLock.ASSET_NAMES.includes('ai-or-die-mesh-darwin-arm64'));
   });
 
   it('computes a stable 64-hex content hash', function () {
@@ -44,13 +44,13 @@ describe('mesh-lock', function () {
   });
 
   it('parseChecksums reads "<sha>  <name>" lines', function () {
-    const parsed = meshLock.parseChecksums('abc123  aiordie-mesh-linux-amd64\nDEF456  aiordie-mesh-darwin-arm64\n\n');
-    assert.strictEqual(parsed['aiordie-mesh-linux-amd64'], 'abc123');
-    assert.strictEqual(parsed['aiordie-mesh-darwin-arm64'], 'def456');
+    const parsed = meshLock.parseChecksums('abc123  ai-or-die-mesh-linux-amd64\nDEF456  ai-or-die-mesh-darwin-arm64\n\n');
+    assert.strictEqual(parsed['ai-or-die-mesh-linux-amd64'], 'abc123');
+    assert.strictEqual(parsed['ai-or-die-mesh-darwin-arm64'], 'def456');
   });
 
   it('parseChecksums strips the binary-mode "*" prefix (Git Bash sha256sum)', function () {
-    const parsed = meshLock.parseChecksums('abc123 *aiordie-mesh-windows-amd64.exe\n');
-    assert.strictEqual(parsed['aiordie-mesh-windows-amd64.exe'], 'abc123');
+    const parsed = meshLock.parseChecksums('abc123 *ai-or-die-mesh-windows-amd64.exe\n');
+    assert.strictEqual(parsed['ai-or-die-mesh-windows-amd64.exe'], 'abc123');
   });
 });

--- a/test/mesh-manager.test.js
+++ b/test/mesh-manager.test.js
@@ -26,15 +26,17 @@ describe('MeshManager', function() {
 
     it('points sidecar + state under the app dir', function() {
       const m = new MeshManager();
-      assert.ok(/aiordie-mesh(-[0-9a-f]+)?(\.exe)?$/.test(m.sidecar), m.sidecar);
+      assert.ok(/ai-or-die-mesh(-[0-9a-f]+)?(\.exe)?$/.test(m.sidecar), m.sidecar);
       assert.ok(m.sidecar.includes(path.join('ai-or-die', 'bin')) || m.sidecar.includes(path.join('.ai-or-die', 'bin')));
       assert.ok(/ts-state$/.test(m.stateDir));
     });
 
-    it('content-addresses the sidecar path from the lock hash', function() {
+    it('launches a stable, hash-free sidecar path (single-file allow-list match)', function() {
       const m = new MeshManager();
-      // The committed lock has a 64-hex contentHash → the path embeds it.
-      assert.ok(/aiordie-mesh-[0-9a-f]{64}(\.exe)?$/.test(m.sidecar), m.sidecar);
+      // The manager LAUNCHES the stable path so a WDAC/AppLocker path rule matches
+      // the executed image across versions — no embedded content hash (ADR-0036).
+      assert.ok(/[/\\]ai-or-die-mesh(\.exe)?$/.test(m.sidecar), m.sidecar);
+      assert.ok(!/-[0-9a-f]{16,}/.test(path.basename(m.sidecar)), m.sidecar);
     });
 
     it('defaults the backend to plaintext loopback on the app port', function() {
@@ -80,7 +82,7 @@ describe('MeshManager', function() {
   describe('peer discovery cache', function() {
     function tempManager() {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-manager-'));
-      const m = new MeshManager({ stateDir: path.join(dir, 'ts-state'), sidecar: path.join(dir, 'aiordie-mesh') });
+      const m = new MeshManager({ stateDir: path.join(dir, 'ts-state'), sidecar: path.join(dir, 'ai-or-die-mesh') });
       m._appBase = dir;
       return { m, dir };
     }
@@ -132,6 +134,74 @@ describe('MeshManager', function() {
       } finally {
         fs.rmSync(dir, { recursive: true, force: true });
       }
+    });
+  });
+
+  describe('mesh egress file', function() {
+    function tempManager() {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-egress-'));
+      const m = new MeshManager({ stateDir: path.join(dir, 'ts-state'), sidecar: path.join(dir, 'ai-or-die-mesh') });
+      m._appBase = dir;
+      return { m, dir };
+    }
+
+    it('writes egress.json (0600, with pid) from a valid loopback MESH-EGRESS line', function() {
+      const { m, dir } = tempManager();
+      try {
+        m.proc = { pid: 4242 };
+        m._handleStdoutData(Buffer.from('MESH-EGRESS http://127.0.0.1:54321 deadbeefcafe\n'));
+        const file = m.egressFilePath();
+        assert.ok(fs.existsSync(file), 'egress.json must be written');
+        const written = JSON.parse(fs.readFileSync(file, 'utf8'));
+        assert.strictEqual(written.version, 1);
+        assert.strictEqual(written.pid, 4242);
+        assert.strictEqual(written.url, 'http://127.0.0.1:54321');
+        assert.strictEqual(written.token, 'deadbeefcafe');
+        assert.strictEqual(typeof written.updatedAt, 'number');
+        if (process.platform !== 'win32') {
+          assert.strictEqual(fs.statSync(file).mode & 0o777, 0o600, 'egress.json must be 0600');
+        }
+      } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+    });
+
+    it('rejects a non-http / non-loopback / localhost / token-less egress line', function() {
+      const { m, dir } = tempManager();
+      try {
+        m.proc = { pid: 1 };
+        for (const bad of [
+          'MESH-EGRESS https://127.0.0.1:5 tok',   // not http
+          'MESH-EGRESS http://10.0.0.5:5 tok',     // not loopback
+          'MESH-EGRESS http://localhost:5 tok',    // localhost — DNS-rebinding risk
+          'MESH-EGRESS http://127.0.0.1:5 ',       // no token (regex needs two fields)
+          'MESH-EGRESS notaurl tok',               // unparseable url
+        ]) {
+          m._handleStdoutData(Buffer.from(bad + '\n'));
+          assert.strictEqual(fs.existsSync(m.egressFilePath()), false, `must reject: ${bad}`);
+        }
+      } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+    });
+
+    it('deletes egress.json on a MESH-NEEDLOGIN marker', function() {
+      const { m, dir } = tempManager();
+      try {
+        m.proc = { pid: 7 };
+        m._handleStdoutData(Buffer.from('MESH-EGRESS http://127.0.0.1:9 tok9\n'));
+        assert.ok(fs.existsSync(m.egressFilePath()));
+        m._handleStdoutData(Buffer.from('MESH-NEEDLOGIN https://login.tailscale.com/admin/settings/keys\n'), () => {});
+        assert.strictEqual(fs.existsSync(m.egressFilePath()), false);
+      } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+    });
+
+    it('prints the MESH-UNTAGGED hint exactly once', function() {
+      const { m, dir } = tempManager();
+      const lines = []; const orig = console.log; console.log = (...a) => lines.push(a.join(' '));
+      try {
+        m._handleStdoutData(Buffer.from('MESH-UNTAGGED false 3 0\n'));
+        m._handleStdoutData(Buffer.from('MESH-UNTAGGED false 3 0\n')); // suppressed (one-shot)
+      } finally { console.log = orig; fs.rmSync(dir, { recursive: true, force: true }); }
+      const out = lines.join('\n');
+      assert.ok(/tag:aiordie/.test(out) && /discovery stays EMPTY/i.test(out), out);
+      assert.strictEqual((out.match(/tailnet device\(s\) visible/g) || []).length, 1, 'hint must print once');
     });
   });
 

--- a/test/sidecar-installer.test.js
+++ b/test/sidecar-installer.test.js
@@ -7,7 +7,7 @@ const path = require('path');
 const crypto = require('crypto');
 const installer = require('../src/utils/sidecar-installer');
 
-const { ensureSidecar, sidecarPath, assetName, SidecarError } = installer;
+const { ensureSidecar, stableSidecarPath, assetName, SidecarError } = installer;
 
 const sha256 = (buf) => crypto.createHash('sha256').update(buf).digest('hex');
 
@@ -43,7 +43,7 @@ describe('sidecar-installer', function () {
 
   beforeEach(function () {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aiordie-sidecar-'));
-    dest = path.join(tmpDir, `aiordie-mesh${process.platform === 'win32' ? '.exe' : ''}`);
+    dest = path.join(tmpDir, `ai-or-die-mesh${process.platform === 'win32' ? '.exe' : ''}`);
     origFetch = global.fetch;
   });
   afterEach(function () {
@@ -54,17 +54,17 @@ describe('sidecar-installer', function () {
   describe('assetName', function () {
     it('maps the current platform/arch to an asset name', function () {
       const n = assetName();
-      if (process.platform === 'win32') assert.ok(/^aiordie-mesh-windows-(amd64|arm64)\.exe$/.test(n), n);
-      else if (process.platform === 'darwin') assert.ok(/^aiordie-mesh-darwin-(amd64|arm64)$/.test(n), n);
-      else if (process.platform === 'linux') assert.ok(/^aiordie-mesh-linux-(amd64|arm64)$/.test(n), n);
+      if (process.platform === 'win32') assert.ok(/^ai-or-die-mesh-windows-(amd64|arm64)\.exe$/.test(n), n);
+      else if (process.platform === 'darwin') assert.ok(/^ai-or-die-mesh-darwin-(amd64|arm64)$/.test(n), n);
+      else if (process.platform === 'linux') assert.ok(/^ai-or-die-mesh-linux-(amd64|arm64)$/.test(n), n);
     });
   });
 
-  describe('sidecarPath', function () {
-    it('embeds the content hash so installs never collide / overwrite a running exe', function () {
-      const p = sidecarPath('abc123');
-      assert.ok(p.includes('abc123'), p);
-      assert.ok(/aiordie-mesh-abc123(\.exe)?$/.test(p), p);
+  describe('stableSidecarPath', function () {
+    it('is a stable hash-free path so a single-file allow-list rule matches the launched image', function () {
+      const p = stableSidecarPath();
+      assert.ok(/ai-or-die-mesh(\.exe)?$/.test(p), p);
+      assert.ok(!/-[0-9a-f]{6,}/.test(path.basename(p)), `must not embed a content hash: ${p}`);
       assert.ok(p.includes(path.join('ai-or-die', 'bin')) || p.includes(path.join('.ai-or-die', 'bin')), p);
     });
   });


### PR DESCRIPTION
## What & why

A userspace `tsnet` sidecar makes an instance *reachable* but does not put the host OS on the tailnet, so a same-box conductor process (github-router driving the fleet) cannot reach `.ts.net` peers — every mesh instance shows `UNREACHABLE`. This adds a loopback egress path the conductor can use, keeps the sidecar trustable across versions on locked-down Windows, and surfaces the previously-silent untagged-enrollment state.

Pairs with github-router PR (fleet: route mesh peers through the sidecar's loopback egress proxy) — the frozen contract is `~/.ai-or-die/mesh/egress.json`.

## Changes

- **Egress proxy** (`mesh/main.go`): a loopback HTTP CONNECT proxy backed by `tsnet.Server.Dial`. Gated by a random per-process Bearer (`Proxy-Authorization`), with an allowlist that permits CONNECT ONLY to a `tag:aiordie` peer whose `DNSName` exactly matches, on ports 443/7777 (IP-literals rejected). Endpoint + token published via `MESH-EGRESS`.
- **egress.json** (`src/mesh-manager.js`): the manager persists the endpoint+token to a 0600 `mesh/egress.json` (separate from `peers.json`), rewritten each spawn with the sidecar pid; deleted on stop/exit/NEEDLOGIN and on start (before respawn) so a freed port can't be squatted.
- **Trust** (`src/utils/sidecar-installer.js`): rename `aiordie-mesh` → `ai-or-die-mesh`; LAUNCH a stable, hash-free path so a single-file WDAC/AppLocker rule matches the executed image; strip MOTW / macOS quarantine after the SHA-256 verify. Signing deferred (see ADR-0036).
- **Diagnostic**: `MESH-UNTAGGED` when tailnet peers exist but none carry `tag:aiordie`; the manager prints a one-shot actionable hint.
- Docs: ADR-0036, mesh spec sections; release workflow asset names updated.

## Failure modes considered & tested

- CONNECT: non-CONNECT → 405; missing/wrong token → 407; forbidden target → 403; dial failure → 502; **half-close** — each write end is half-closed on its own EOF so a one-way FIN can't truncate the reply (was a hard both-close; fixed after review).
- Allowlist: wrong port, IP-literal, untagged peer, unknown host, suffix-style spoof, trailing-dot, case-insensitivity.
- Manager egress.json: valid write (0600 + pid), non-http/non-loopback/`localhost`/token-less rejected, delete-on-NEEDLOGIN, one-shot untagged hint.
- Race-checked (`go test -race`).

## Not yet done

The live over-the-tailnet drive (a real request over WireGuard to a peer) — proven by tests minus that hop; needs a published release + a fresh conductor launch.