### PR TITLE
fix(mesh): re-stamp egress.json so a live egress isn't rejected by the TTL

### DIFF
--- a/docs/adrs/0036-mesh-egress-and-stable-path-sidecar.md
+++ b/docs/adrs/0036-mesh-egress-and-stable-path-sidecar.md
@@ -30,7 +30,9 @@ authority bounded only by the tailnet ACL.
 `tag:aiordie`-tagged peer whose `DNSName` exactly matches `Status().Peer` on ports 443/7777 (IP
 literals rejected). The endpoint + token are announced on stdout (`MESH-EGRESS <url> <token>`) and
 persisted by the manager to a **separate 0600 file** `~/.ai-or-die/mesh/egress.json`
-(`{version,pid,updatedAt,url,token}`), rewritten each spawn (fresh port/pid — no stale-port hole);
+(`{version,pid,updatedAt,url,token}`), rewritten each spawn (fresh port/pid — no stale-port hole)
+and re-stamped every 30s while the sidecar lives (the write-once file would otherwise be rejected by
+the consumer's ~120s freshness TTL after ~2 min of uptime — a bug the live drive caught);
 `peers.json` stays credential-free. github-router reads it, treats it stale on a dead pid / expired
 TTL, and routes mesh requests through an undici `ProxyAgent` with the token in the
 `Proxy-Authorization` header only. Origin-pinning + `redirect:"error"` are unchanged.

--- a/docs/specs/mesh.md
+++ b/docs/specs/mesh.md
@@ -126,7 +126,9 @@ HTTP CONNECT proxy** (`127.0.0.1:0`) backed by `tsnet.Server.Dial`:
   proxy nor turn it into a generic tailnet egress.
 - **Advertised:** `MESH-EGRESS http://127.0.0.1:<port> <token>` on stdout; the
   manager persists it to `~/.ai-or-die/mesh/egress.json` (mode 0600,
-  `{version,pid,updatedAt,url,token}`), rewritten each spawn. This is a SEPARATE
+  `{version,pid,updatedAt,url,token}`), rewritten each spawn and re-stamped every
+  30s while the sidecar lives (so a consumer's freshness TTL never expires a live
+  egress). This is a SEPARATE
   file from `peers.json` (which stays credential-free); the consumer treats it
   stale on a dead pid / expired TTL.
 - Runs on every `--mesh` box, but only a same-box conductor consumes it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-or-die",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "description": "Universal AI coding terminal — Claude, Copilot, Gemini & more in your browser",
   "main": "src/server.js",
   "bin": {

--- a/src/mesh-manager.js
+++ b/src/mesh-manager.js
@@ -19,6 +19,10 @@ const MIN_RESTART_DELAY_MS = 1000;
 const MAX_RESTART_DELAY_MS = 30000;
 const MAX_RETRIES = 10;
 const MESH_PEERS_JSON_MAX = 256 * 1024;
+// The sidecar announces MESH-EGRESS once at spawn, but a consumer treats
+// egress.json stale past a short TTL (~120s). Re-stamp its updatedAt on this
+// cadence while the sidecar lives so a healthy egress never looks stale.
+const MESH_EGRESS_REFRESH_MS = 30000;
 
 class MeshManager {
   constructor(options = {}) {
@@ -61,6 +65,8 @@ class MeshManager {
     this._stdoutBuffer = '';
     this.peers = null;
     this._untaggedWarned = false;
+    this._egress = null;
+    this._egressRefreshTimer = null;
   }
 
   /** Never throws — degrades to localhost/devtunnel on any failure. */
@@ -279,7 +285,9 @@ class MeshManager {
     // consumer's DNS/hosts config could rebind off-host.
     if (host !== '127.0.0.1' && host !== '::1') return;
     if (!token || /\s/.test(token)) return;
+    this._egress = { url, token };
     this._writeEgressFile(url, token);
+    this._startEgressRefresh();
   }
 
   _writeEgressFile(url, token) {
@@ -304,7 +312,27 @@ class MeshManager {
     }
   }
 
+  // Keep egress.json's updatedAt fresh while the sidecar is alive. Without this a
+  // consumer's freshness TTL rejects the (write-once) egress after ~2 min of
+  // uptime and the mesh silently fails closed. Stops itself once the sidecar exits.
+  _startEgressRefresh() {
+    if (this._egressRefreshTimer) return;
+    this._egressRefreshTimer = setInterval(() => this._refreshEgressTick(), MESH_EGRESS_REFRESH_MS);
+    if (this._egressRefreshTimer.unref) this._egressRefreshTimer.unref();
+  }
+
+  _refreshEgressTick() {
+    if (this.proc && this._egress) this._writeEgressFile(this._egress.url, this._egress.token);
+    else this._stopEgressRefresh();
+  }
+
+  _stopEgressRefresh() {
+    if (this._egressRefreshTimer) { clearInterval(this._egressRefreshTimer); this._egressRefreshTimer = null; }
+  }
+
   _deleteEgressFile() {
+    this._egress = null;
+    this._stopEgressRefresh();
     try { fs.rmSync(this.egressFilePath(), { force: true }); } catch (_) {}
   }
 

--- a/test/mesh-manager.test.js
+++ b/test/mesh-manager.test.js
@@ -203,6 +203,47 @@ describe('MeshManager', function() {
       assert.ok(/tag:aiordie/.test(out) && /discovery stays EMPTY/i.test(out), out);
       assert.strictEqual((out.match(/tailnet device\(s\) visible/g) || []).length, 1, 'hint must print once');
     });
+
+    it('caches egress + starts a refresh timer, and clears both on shutdown', function() {
+      const { m, dir } = tempManager();
+      try {
+        m.proc = { pid: 55 };
+        m._handleStdoutData(Buffer.from('MESH-EGRESS http://127.0.0.1:5 tok5\n'));
+        assert.deepStrictEqual(m._egress, { url: 'http://127.0.0.1:5', token: 'tok5' });
+        assert.ok(m._egressRefreshTimer, 'refresh timer must be armed');
+        m._handleStdoutData(Buffer.from('MESH-NEEDLOGIN https://login.tailscale.com/admin/settings/keys\n'), () => {});
+        assert.strictEqual(m._egress, null);
+        assert.strictEqual(m._egressRefreshTimer, null, 'refresh timer must be cleared');
+      } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+    });
+
+    it('re-stamps a fresher updatedAt on a refresh tick while the sidecar is alive', function() {
+      const { m, dir } = tempManager();
+      try {
+        m.proc = { pid: 66 };
+        m._handleStdoutData(Buffer.from('MESH-EGRESS http://127.0.0.1:6 tok6\n'));
+        const first = JSON.parse(fs.readFileSync(m.egressFilePath(), 'utf8')).updatedAt;
+        // Force a distinct wall-clock, then tick the refresh directly.
+        const realNow = Date.now; let t = first + 1000; Date.now = () => t;
+        try { m._refreshEgressTick(); } finally { Date.now = realNow; }
+        const second = JSON.parse(fs.readFileSync(m.egressFilePath(), 'utf8'));
+        assert.ok(second.updatedAt > first, `updatedAt must advance (${first} -> ${second.updatedAt})`);
+        assert.strictEqual(second.url, 'http://127.0.0.1:6');
+        assert.strictEqual(second.token, 'tok6');
+      } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+    });
+
+    it('a refresh tick after the sidecar exits stops the timer (no dead re-stamp)', function() {
+      const { m, dir } = tempManager();
+      try {
+        m.proc = { pid: 77 };
+        m._handleStdoutData(Buffer.from('MESH-EGRESS http://127.0.0.1:7 tok7\n'));
+        assert.ok(m._egressRefreshTimer);
+        m.proc = null; // sidecar gone
+        m._refreshEgressTick();
+        assert.strictEqual(m._egressRefreshTimer, null, 'timer must stop once the sidecar is gone');
+      } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+    });
   });
 
   describe('diagnostics', function() {


### PR DESCRIPTION
## Bug (caught by the live over-the-tailnet drive)

The sidecar emits `MESH-EGRESS` **once at spawn**, so `mesh/egress.json`'s `updatedAt` was frozen at start time. The consumer (github-router `readMeshEgress`) treats the egress **stale past a ~120s freshness TTL**. Result: after ~2 minutes of sidecar uptime, every mesh drive failed closed with `MESH_UNCONFIGURED` — even though the sidecar process and its loopback CONNECT port were perfectly alive. Verified live: re-stamping `updatedAt` by hand immediately made `list_instances`/`list_sessions` reach the `.ts.net` peer.

## Fix

The manager caches the egress endpoint and **re-stamps `egress.json`'s `updatedAt` every 30s while the sidecar process is alive**, stopping the timer once the sidecar exits (so a dead sidecar is never kept artificially fresh — the consumer's pid-liveness + TTL still catch it). 30s ≪ 120s TTL leaves a 4× margin.

JS-only (`src/mesh-manager.js`) — the content-addressed sidecar binary is unchanged, so no new `mesh-<hash>` release is needed; only the npm package rebuilds.

## Failure modes tested

- caches egress + arms the refresh timer on a valid `MESH-EGRESS`; clears both on shutdown (`MESH-NEEDLOGIN`/exit).
- a refresh tick re-stamps a strictly-fresher `updatedAt` (same url/token) while the sidecar is alive.
- a refresh tick after the sidecar exits stops the timer (no dead re-stamp).

Pairs with the freshness contract on the github-router side (already merged: readMeshEgress pid-liveness + 120s TTL).