### PR TITLE
feat(mobile): transparent user-proxy mobile mode (Channel-1 decisions + Channel-2 input + Origin-pinned control plane)

### DIFF
--- a/docs/adrs/0038-mobile-mode-transparent-user-proxy.md
+++ b/docs/adrs/0038-mobile-mode-transparent-user-proxy.md
@@ -1,0 +1,44 @@
+# 0038 — Mobile Mode as a transparent "user proxy" (hook-intercepted decisions)
+
+## Status
+
+**Proposed** (2026-07-07). Core mechanism validated in `claude -p`; two interactive-mode unknowns remain before build (see Consequences → Open). Supersedes nothing; extends ADR-0037 (mobile input). Depends on ADR-0026 (Claude bind hook), ADR-0032 (control plane), ADR-0033 (artifact panel). Full plan: `docs/planning/mobile-mode.md`. UI spec: `docs/specs/mobile-mode-ui.md`.
+
+## Context
+
+ai-or-die's mobile web is a responsive collapse of a desktop terminal toolbar — the user hand-drives a raw xterm by touch (ADR-0037). We want a phone experience where the user treats the terminal as *read-only* and interacts through structured surfaces (conversation, decisions, input).
+
+The naive approach — **screen-scrape Claude's rendered prompt and inject `y\n`** — was reviewed by 3 cross-lab peers + 3 code audits and **rejected**: it races a moving PTY (a tap can answer the *wrong/stale* prompt), can mis-parse a wrapped/ANSI-mangled destructive command, and the JSONL carries no structured tool-approval (a pending `Bash` is indistinguishable from a running one). So a structured, *deterministic* interception is required.
+
+Key enabler: **`npx github-router claude` is always the launcher**, so github-router controls Claude Code's hooks.
+
+## Decision
+
+**ai-or-die + github-router act as a transparent "user proxy" around Claude.** Claude only ever sees its *native* channels (a tool result, or terminal stdin); it calls no panel API, spends no turn/token on panel lifecycle, and cannot tell a phone tap from a terminal keystroke. Surfaces pop **out-of-band** (hooks + sidecar render them) and human actions return via exactly two channels:
+
+1. **Channel 1 — hook-return (blocking, structured).** github-router installs a blocking `PreToolUse`/`PermissionRequest` decision hook for `Bash|Write|Edit|ExitPlanMode|AskUserQuestion`. It captures the exact structured `tool_input`, registers a decision with ai-or-die (`POST /api/control/sessions/:id/decision`), **long-polls** while the human answers on a rendered surface (reuse `ArtifactClient.awaitEvents` + the artifact SSE/`data-aod` panel), and returns `permissionDecision: allow|deny` (or the chosen option). The tool is *paused* until it returns — no race, no screen-scrape, no keystroke replay.
+2. **Channel 2 — idle-gated PTY injection.** Free-form input (composer, slash/mode) and non-blocking artifact comments are injected into stdin *as if typed*, gated on `detectTurnState → idle_at_prompt` (reuse `_pushArtifactFeedbackToAgent`), queued while busy; **interrupt is the one immediate injection**.
+
+The conversation *read* surface is a new durable turn-stream over the JSONL (`readNewTurns` is a lossy tailer — a new cursor+epoch layer is required, not a thin reuse). Delivered as a **PWA** (reuses the existing Playwright/WebKit CI; native deferred as a same-API re-skin). **Wait for the human by default** (high hook `timeout`); only hold when a human client is connected; on true absence **fail closed (deny)**, never auto-allow.
+
+## Consequences
+
+**Positive**
+- Deterministic + safe: the hook holds the exact command; no stale-prompt race, no mis-parsed approval, no `y\n` double-inject; plans render from structured `input.plan` in a *trusted* component (sidesteps the artifact-XSS/forged-approval path). Local inference is off the decision path entirely.
+- Transparent: Claude spends zero orchestration tokens; the same API contract backs a future native shell.
+- Mostly assembled: reuses github-router's hook-inject + allow/deny contract + `ArtifactClient`, and ai-or-die's `/await`+`/actions`+mobile panel + idle-gated PTY push.
+
+**Empirical results (Phase-0 spike, `claude -p` + scratch proxy; interactive PTY NOT driven):**
+- **Timeout fails OPEN** — a `PreToolUse` hook that overran its `timeout` was cancelled and the tool *still ran*. This confirms the design requirement: set `timeout` high (7200s was accepted) and **emit `deny` before the ceiling** — the host default is fail-open.
+- **`permissionDecision:"ask"` under `--dangerously-skip-permissions` did not surface a prompt** (tool didn't run, error result) — so "fall back to the terminal prompt" is unreliable under bypass; prefer explicit `deny`.
+- Multiple `PreToolUse` hooks **coexist, deny-wins, no deadlock**; a long `timeout` holds the tool cleanly (65s tested).
+- Exact `tool_input` fields: `ExitPlanMode` → `{plan, planFilePath, allowedPrompts?}` (field is **`plan`**, not `planText`); `AskUserQuestion` → `{questions:[{question, header, multiSelect, options:[{label, description}]}]}` (options are **`{label, description}`**, no `value`). JSONL is append-only; auto-compact writes a same-file `compact_boundary` + summary continuation (no rotation in the sample).
+
+**Open (must resolve in a true interactive-PTY spike before build):**
+- Does timeout still **fail open interactively** (it did in `-p`)? — critical; fail-open defeats the gate.
+- Do `ExitPlanMode`/`AskUserQuestion` fire an interceptable `PreToolUse`/`PermissionRequest` **event** in interactive mode (payload shapes proven; hook event routing not)?
+
+**Negative / risks**
+- Depends on Claude Code hook semantics (undocumented timeout ceiling; cross-repo github-router coupling).
+- New durable turn-stream layer + auth/Origin/CSRF hardening on the phone-facing routes are real work (not reuse).
+- Coverage gap: folder-trust and in-shell sub-prompts aren't hook-interceptable → raw-terminal fallback (rare).

--- a/docs/adrs/0038-mobile-mode-transparent-user-proxy.md
+++ b/docs/adrs/0038-mobile-mode-transparent-user-proxy.md
@@ -38,7 +38,10 @@ The conversation *read* surface is a new durable turn-stream over the JSONL (`re
 - **Timeout fails open interactively too (confirmed).** A `PreToolUse` hook killed at its `timeout` lets the tool run. ⇒ the blocking hook MUST run its own watchdog and **self-return `deny` before the host ceiling** (and deny immediately when no viewer is connected) — never let Claude's timeout end the wait, since that ends it in *allow*. A high `timeout` (7200 accepted) buys the human time; the hook owns the deadline.
 - **`ExitPlanMode` + `AskUserQuestion` each fire `PreToolUse` THEN `PermissionRequest`** with identical `tool_input` (`plan`; `questions[].{question,header,options[{label,description}],multiSelect}`). **Bind on `PreToolUse`** (earliest, before the decision UI).
 
-**Negative / risks**
+**Resolved (Origin/CSRF hardening, 2026-07-07):**
+- **The control plane is Origin-pinned to the server's OWN public origins**, not a shared suffix. A 3-lab adversarial review (codex + gemini ×2) found two Criticals in a first-cut allowlist — trusting a bare `*.ts.net`/`*.devtunnels.ms` suffix (any tenant can provision under those), and trusting the client `Host` header for same-origin (a DNS-rebinding bypass). Shipped fix (`src/server.js` `_isAllowedOrigin`): (i) exact-pin to `_trustedControlOrigins()` = the live `tunnelManager.publicUrl` + `meshManager.getStatus().publicUrl` (safe because the public host is unreachable until its URL is scraped, so "deny until known" has no real gap); (ii) never read the `Host` header; (iii) Origin-gate **every** control method — mutations AND reads — so cross-origin GET exfil (terminal output / history / pending decisions) is closed even under `--no-auth`; (iv) LAN access allows only the server's OWN interface addresses (`_ownLanHostnames()` via `os.networkInterfaces()`), not blanket RFC-1918 (which was a lateral keystroke-injection vector on shared Wi-Fi). No-Origin callers (the decision hook, curl, native apps) always pass; `AIORDIE_ALLOWED_ORIGINS` covers non-tunnel public deployments. Reviewed **GO-final**.
+
+
 - Depends on Claude Code hook semantics (undocumented timeout ceiling; cross-repo github-router coupling).
-- New durable turn-stream layer + auth/Origin/CSRF hardening on the phone-facing routes are real work (not reuse).
+- New durable turn-stream layer is real work (not reuse). Origin/CSRF hardening on the phone-facing routes + WS is **done** (see Resolved above).
 - Coverage gap: folder-trust and in-shell sub-prompts aren't hook-interceptable → raw-terminal fallback (rare).

--- a/docs/adrs/0038-mobile-mode-transparent-user-proxy.md
+++ b/docs/adrs/0038-mobile-mode-transparent-user-proxy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Proposed** (2026-07-07). Core mechanism validated in `claude -p`; two interactive-mode unknowns remain before build (see Consequences → Open). Supersedes nothing; extends ADR-0037 (mobile input). Depends on ADR-0026 (Claude bind hook), ADR-0032 (control plane), ADR-0033 (artifact panel). Full plan: `docs/planning/mobile-mode.md`. UI spec: `docs/specs/mobile-mode-ui.md`.
+**Proposed** (2026-07-07). Interactive-PTY gate **RESOLVED** (2026-07-07) — safe to build with a self-deadline, fail-closed hook (see Consequences → Resolved). Supersedes nothing; extends ADR-0037 (mobile input). Depends on ADR-0026 (Claude bind hook), ADR-0032 (control plane), ADR-0033 (artifact panel). Full plan: `docs/planning/mobile-mode.md`. UI spec: `docs/specs/mobile-mode-ui.md`.
 
 ## Context
 
@@ -34,9 +34,9 @@ The conversation *read* surface is a new durable turn-stream over the JSONL (`re
 - Multiple `PreToolUse` hooks **coexist, deny-wins, no deadlock**; a long `timeout` holds the tool cleanly (65s tested).
 - Exact `tool_input` fields: `ExitPlanMode` → `{plan, planFilePath, allowedPrompts?}` (field is **`plan`**, not `planText`); `AskUserQuestion` → `{questions:[{question, header, multiSelect, options:[{label, description}]}]}` (options are **`{label, description}`**, no `value`). JSONL is append-only; auto-compact writes a same-file `compact_boundary` + summary continuation (no rotation in the sample).
 
-**Open (must resolve in a true interactive-PTY spike before build):**
-- Does timeout still **fail open interactively** (it did in `-p`)? — critical; fail-open defeats the gate.
-- Do `ExitPlanMode`/`AskUserQuestion` fire an interceptable `PreToolUse`/`PermissionRequest` **event** in interactive mode (payload shapes proven; hook event routing not)?
+**Resolved (interactive-PTY spike, 2026-07-07):**
+- **Timeout fails open interactively too (confirmed).** A `PreToolUse` hook killed at its `timeout` lets the tool run. ⇒ the blocking hook MUST run its own watchdog and **self-return `deny` before the host ceiling** (and deny immediately when no viewer is connected) — never let Claude's timeout end the wait, since that ends it in *allow*. A high `timeout` (7200 accepted) buys the human time; the hook owns the deadline.
+- **`ExitPlanMode` + `AskUserQuestion` each fire `PreToolUse` THEN `PermissionRequest`** with identical `tool_input` (`plan`; `questions[].{question,header,options[{label,description}],multiSelect}`). **Bind on `PreToolUse`** (earliest, before the decision UI).
 
 **Negative / risks**
 - Depends on Claude Code hook semantics (undocumented timeout ceiling; cross-repo github-router coupling).

--- a/docs/planning/mobile-mode-mvp-go-no-go.html
+++ b/docs/planning/mobile-mode-mvp-go-no-go.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Mobile Mode MVP — Go / No-Go</title>
+<style>
+  :root {
+    --bg:#0f1115; --panel:#171a21; --panel2:#1b1f28; --fg:#e6e8ec; --muted:#9aa2ad;
+    --border:#2a2f3a; --accent:#4c8dff; --go:#37d67a; --warn:#f5a524; --stop:#ff5c5c;
+    --mono:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--fg);
+    font:15px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; }
+  .wrap { max-width:940px; margin:0 auto; padding:32px 24px 80px; }
+  h1 { font-size:26px; margin:0 0 4px; letter-spacing:-.02em; }
+  h2 { font-size:18px; margin:34px 0 12px; padding-bottom:6px; border-bottom:1px solid var(--border); }
+  h3 { font-size:15px; margin:18px 0 6px; color:var(--fg); }
+  p { margin:8px 0; }
+  .sub { color:var(--muted); margin:0 0 18px; }
+  .verdict { display:flex; align-items:center; gap:14px; background:var(--panel);
+    border:1px solid var(--border); border-left:4px solid var(--go); border-radius:10px; padding:16px 18px; margin:18px 0; }
+  .verdict .badge { font-weight:700; font-size:13px; letter-spacing:.08em; text-transform:uppercase;
+    color:#08240f; background:var(--go); padding:5px 12px; border-radius:999px; white-space:nowrap; }
+  .verdict .cond { color:var(--muted); font-size:13.5px; }
+  .grid { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+  @media (max-width:680px){ .grid{ grid-template-columns:1fr; } }
+  .card { background:var(--panel); border:1px solid var(--border); border-radius:10px; padding:14px 16px; }
+  .card h3 { margin-top:0; display:flex; align-items:center; gap:8px; }
+  .tick { color:var(--go); font-weight:700; }
+  table { width:100%; border-collapse:collapse; margin:6px 0 4px; font-size:13.5px; }
+  th,td { text-align:left; padding:7px 10px; border-bottom:1px solid var(--border); vertical-align:top; }
+  th { color:var(--muted); font-weight:600; font-size:12px; text-transform:uppercase; letter-spacing:.04em; }
+  td.n { color:var(--go); font-variant-numeric:tabular-nums; white-space:nowrap; }
+  code,.mono { font-family:var(--mono); font-size:12.5px; background:var(--panel2);
+    padding:1.5px 6px; border-radius:5px; color:#d7dde7; }
+  pre { background:var(--panel2); border:1px solid var(--border); border-radius:8px; padding:12px 14px;
+    overflow-x:auto; font-family:var(--mono); font-size:12.5px; line-height:1.5; color:#d7dde7; }
+  ul { margin:8px 0; padding-left:22px; } li { margin:5px 0; }
+  .pill { display:inline-block; font-size:11px; font-weight:600; padding:2px 8px; border-radius:999px;
+    background:var(--panel2); border:1px solid var(--border); color:var(--muted); }
+  .sev-crit { color:var(--stop); } .sev-imp { color:var(--warn); }
+  .caveat { border-left:3px solid var(--warn); background:var(--panel); border-radius:0 8px 8px 0;
+    padding:10px 14px; margin:10px 0; }
+  .caveat b { color:var(--warn); }
+  .muted { color:var(--muted); }
+  .foot { margin-top:30px; color:var(--muted); font-size:12.5px; }
+  a { color:var(--accent); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>Mobile Mode MVP — Go / No-Go</h1>
+  <p class="sub">Transparent user proxy for driving Claude Code from an iPhone / iPad · branch <code>main</code> (feature work) · 2026-07-07</p>
+
+  <div class="verdict">
+    <span class="badge">GO</span>
+    <div>
+      <div><b>Ship the MVP behind the <code>?mobileMode=1</code> opt-in.</b></div>
+      <div class="cond">Legacy mobile input stays the default. One human gate remains: your on-device parity pass over the mesh/tunnel (dimension fidelity can't be asserted from Windows — see below).</div>
+    </div>
+  </div>
+
+  <h2>What shipped — the four north-star surfaces</h2>
+  <p>The user treats the terminal as read-only and acts through structured surfaces. Claude only ever sees its <b>native</b> channels (a tool result, or terminal stdin) — it spends no turn/token on panels and can't tell a phone tap from a keystroke.</p>
+  <div class="grid">
+    <div class="card"><h3><span class="tick">✓</span> Conversation (read)</h3>
+      Durable turn-stream over the JSONL (stable ids, cursor+epoch, reset on compact/resume), collapsible tool-call/result cards. All content via <code>textContent</code>.</div>
+    <div class="card"><h3><span class="tick">✓</span> Decision cards — Channel 1</h3>
+      Blocking <code>PreToolUse</code> hook holds the tool; permission / plan / question sheets answer <span class="mono">allow/deny/choice</span> straight back to the hook. Fail-closed, wait-for-human, trusted rendering.</div>
+    <div class="card"><h3><span class="tick">✓</span> Input + interrupt — Channel 2</h3>
+      Composer injects to stdin only when <code>idle_at_prompt</code> (queued while busy); interrupt is the one immediate injection. Byte-exact, verified.</div>
+    <div class="card"><h3><span class="tick">✓</span> Trusted, transparent</h3>
+      Decision packets render from structured <code>tool_input</code> in a trusted component (no agent HTML) — sidesteps the artifact-XSS / forged-approval path. Artifact panel height cap also removed.</div>
+  </div>
+
+  <h2>Verification — what was actually run</h2>
+  <table>
+    <tr><th>Gate</th><th>Result</th><th>Detail</th></tr>
+    <tr><td>Full unit + control + e2e suite (<code>npm test</code>)</td><td class="n">1879 / 0</td><td>0 failing, exit 0 — full load profile</td></tr>
+    <tr><td>Mobile e2e (Playwright WebKit, portrait)</td><td class="n">12 / 12</td><td>iPhone 16 + iPad 11 · incl. 2 XSS-literal invariants, Channel-1 round-trip, byte-exact Channel-2</td></tr>
+    <tr><td>Desktop e2e (golden-path + functional-core)</td><td class="n">15 / 0</td><td>Origin gate does not disturb the main app's WS/HTTP</td></tr>
+    <tr><td>Decision-hook seam (real github-router binary ↔ live <code>/decision</code>)</td><td class="n">5 / 5</td><td>accept→allow, reject→deny, no-viewer→deny, viewer-timeout→deny (self-budget), plan→allow</td></tr>
+    <tr><td>Security — cross-lab adversarial review</td><td class="n">GO-final</td><td>3 labs (codex + gemini ×2); every finding closed &amp; re-verified</td></tr>
+  </table>
+
+  <h2>Security hardening — the control plane is a remote input API</h2>
+  <p>A 3-lab review treated the phone-facing control plane as a remote command-injection / exfil surface and found real holes in a first-cut Origin allowlist. All are closed and re-verified (7 dedicated origin tests):</p>
+  <table>
+    <tr><th>Finding</th><th>Sev</th><th>Resolution</th></tr>
+    <tr><td>Wildcard <code>*.ts.net</code>/<code>*.devtunnels.ms</code> suffix trust (any tenant can provision a host → cross-tenant RCE)</td><td class="sev-crit">Critical</td><td>Removed. Exact-pin to the server's OWN live origins (<code>tunnelManager.publicUrl</code> + <code>meshManager</code>), normalized by <code>_originKey</code></td></tr>
+    <tr><td>Host-header same-origin (DNS-rebinding bypass on default-port / tunnel)</td><td class="sev-crit">Critical</td><td>Removed. The client <code>Host</code> header is never read</td></tr>
+    <tr><td>Cross-origin GET read/exfil under <code>--no-auth</code></td><td class="sev-imp">Important</td><td>Every control method is Origin-gated (reads too); no-Origin + same-origin still pass</td></tr>
+    <tr><td>Blanket RFC-1918 trust (lateral keystroke-injection on shared Wi-Fi)</td><td class="sev-imp">Important</td><td>Replaced with the server's OWN interface addresses (<code>os.networkInterfaces()</code>)</td></tr>
+    <tr><td>POST-only gating (future PUT/DELETE unprotected)</td><td class="sev-imp">Important</td><td>Gate keyed on CSRF-unsafe method, not literal POST</td></tr>
+  </table>
+  <p class="muted">No-Origin callers (the decision hook, curl, native apps) always pass — Channel 1 is unaffected. Auth (Bearer/token) remains the primary gate; Origin is defense-in-depth.</p>
+
+  <h2>Where it might fail — honest caveats</h2>
+  <div class="caveat"><b>On-device dimensions (the open gate).</b> No iOS simulator exists on Windows; Playwright-WebKit verifies logic, not real-Safari layout. Final safe-area / keyboard / <code>dvh</code> polish converges on the <b>real iPhone over the mesh/tunnel</b> — your parity pass. Landscape UI (keyboard eats height) is a device-loop item; its logic is orientation-agnostic and covered on portrait.</div>
+  <div class="caveat"><b>Opt-in by design.</b> Mobile mode activates only via <code>?mobileMode=1</code> (or the <code>cc-mobile-mode</code> sessionStorage flag). Legacy touch-driving remains the default — a deliberate safe rollout, not a regression.</div>
+  <div class="caveat"><b>Non-tunnel public deploys.</b> With <code>--tunnel</code>/<code>--mesh</code> the origin auto-pins (no config). If you expose ai-or-die on a public host <i>without</i> them, set <code>AIORDIE_ALLOWED_ORIGINS=https://your-host</code>, or same-origin browser POSTs from that host are gated.</div>
+  <div class="caveat"><b>Startup window (self-healing).</b> A WS/POST in the sub-second gap after the tunnel routes but before Node scrapes its public URL is denied and recovers on the client's reconnect. You cannot reach the tunnel host before it exists, so there is no pre-tunnel exposure.</div>
+  <div class="caveat"><b>Coverage tail (by design).</b> Folder-trust prompts and a script's own in-shell <code>y/N</code> inside a <code>Bash</code> tool are not hook-interceptable → raw-terminal fallback (rare). Benign <code>MaxListeners</code>/<code>DEP0190</code> warnings in test output are pre-existing and non-blocking.</div>
+
+  <h2>Your on-device parity pass (the remaining gate)</h2>
+  <pre>1. Launch:  ai-or-die --tunnel        (or --mesh)
+2. iPhone:  open  https://&lt;tunnel-host&gt;.devtunnels.ms/?mobileMode=1
+3. Drive a Claude session and verify:
+   • conversation renders; tool cards collapse
+   • a Bash tool pops the permission sheet — exact command shown,
+     Deny is the default, Approve turns red on a destructive command
+   • Approve → runs;  Deny → cancelled
+   • ExitPlanMode pops the plan sheet; a question pops option cards
+   • composer injects only when idle; interrupt fires immediately</pre>
+
+  <h2>Commits (this delivery)</h2>
+  <pre>49f0dbd  test(e2e): deflake session_activity broadcasting (event-driven sync)
+aa810b5  test(mobile): deterministic sheet interaction via reduced-motion
+d21d448  docs(adr-0038): record shipped Origin-pinned control-plane hardening
+26adbda  feat(control): pin the control-plane Origin gate to the server's own origins
+c9970ff  feat(mobile): wire decision cards to Channel-1 (permission/plan/question)
+1628144  test(mobile): end-to-end decision-hook seam integration test
+  … plus turn-stream, /decision endpoint + store, mobile shell, artifact
+    height-cap; and in github-router: the internal-decision-hook + policy.</pre>
+
+  <p class="foot">Design + decision: <code>docs/adrs/0038-mobile-mode-transparent-user-proxy.md</code> · plan: <code>docs/planning/mobile-mode.md</code> · UI spec: <code>docs/specs/mobile-mode-ui.md</code> · reference mock: <code>src/public/mobile-proto.html</code>. Quality loop: plan → implement → self-check → 3-lab adversarial review → fix → re-verify → advisor. All findings closed; suite green.</p>
+
+</div>
+</body>
+</html>

--- a/docs/planning/mobile-mode.md
+++ b/docs/planning/mobile-mode.md
@@ -1,0 +1,65 @@
+# Mobile Mode — implementation plan (persisted)
+
+> Persisted 2026-07-07 from the approved planning session. Companion docs:
+> **ADR-0038** (`docs/adrs/0038-mobile-mode-transparent-user-proxy.md`) — the decision;
+> **UI spec** (`docs/specs/mobile-mode-ui.md`) — how/when the surfaces look & behave;
+> **Reference mock** (`src/public/mobile-proto.html`) — the clickable prototype.
+> Status: approved; **Phase 0 (de-risking) gates the build.** Empirical hook-spike results are recorded in ADR-0038 (timeout fails open under `-p`; two interactive unknowns remain).
+
+---
+
+## Context
+
+ai-or-die's mobile web hand-drives a raw terminal. **North-star:** the user treats the terminal as read-only and interacts through structured surfaces — a **conversation view**, an **input panel**, a **decision panel**, and the **artifact/plan panel** — and it all "just works" without the Claude instance ever orchestrating a panel or being able to tell a phone from a terminal user.
+
+**Unifying principle — the transparent user proxy.** `npx github-router claude` is *always* the launcher, so github-router (hooks) + ai-or-die (sidecar) sit around Claude and impersonate the terminal user. Claude only ever sees its **native channels** — a tool result, or terminal stdin. The panels are client-side renders of state the infra already holds; the human's action returns through two channels:
+
+- **Channel 1 — Hook-return (blocking, structured).** For decisions Claude is paused on (tool-permission, `ExitPlanMode`, `AskUserQuestion`). A `PreToolUse`/`PermissionRequest` hook holds the tool, the panel pops, the human answers, the hook returns `allow`/`deny`/the choice.
+- **Channel 2 — Idle-gated PTY injection ("typed as the user").** For the input panel + non-blocking artifact comments. Injected into stdin gated on `detectTurnState → idle_at_prompt` (reuse `_pushArtifactFeedbackToAgent`), queued while busy. **Interrupt (Ctrl-C/Esc) injects immediately.**
+
+This replaces the earlier screen-scrape + `y\n` design that a 3-lab peer review + 3 code audits rejected, and removes Claude from the panel lifecycle (no `artifact_open`/`await` MCP calls for the transparent path).
+
+## The four surfaces (how it pops, how it returns — all transparent)
+| Surface | Pops (out-of-band trigger) | Returns to Claude | Blocking? |
+|---|---|---|---|
+| Decision (tool-permission / plan / question) | `PreToolUse`/`PermissionRequest` hook with structured `tool_input` | Channel 1 — `allow`/`deny`/choice | Yes |
+| Artifact / plan panel | a hook detects a reviewable artifact and opens it via `ArtifactClient` (not Claude) | approve/reject → Ch.1; comments → Ch.2 | Optional |
+| Input panel | FAB tap / `waiting_input` | Channel 2 (interrupt immediate) | No |
+| Conversation view | live via SSE/`/events` | — read-only | No |
+
+## Architecture — decision round-trip (Channel 1)
+- **github-router**: new blocking `internal-decision-hook` (template = `internal-worker-guard` + `internal-artifact-open` + `ArtifactClient`), registered on `PreToolUse`/`PermissionRequest` for `Bash|Write|Edit|ExitPlanMode|AskUserQuestion` (generous `timeoutSec`, gated on `AIORDIE_SESSION_ID`).
+- **ai-or-die**: `POST /api/control/sessions/:id/decision` (register + long-poll) returns a structured `{choice,optionValue}` *directly to the hook*; render via artifact SSE/panel/`data-aod` with a **trusted** decision-packet component (not arbitrary agent HTML).
+- **Channel 2** reuses `{type:'input'}`/control `/message` + the `idle_at_prompt` gate + a queue.
+
+## Sharp risks (design + verify)
+1. **Wait for the human by default; fail closed, never open.** High host `timeout` (hours) so a present human answers in time. Guards: (i) only hold when a human client is connected — else apply a safe default (deny destructive), so unattended runs never wedge; (ii) on true absence, emit **`deny`** before the host ceiling. The current fallback silently **auto-allows** under `--dangerously-skip-permissions` — that becomes fail-closed. *(Phase-0: confirmed timeout fails open in `-p`; interactive unverified.)*
+2. `"allow"` doesn't override `ask`/`deny` rules — audit github-router's rule set.
+3. Exact `tool_input` field names — *resolved:* `ExitPlanMode.{plan, planFilePath, allowedPrompts?}`, `AskUserQuestion.questions[].{question, header, multiSelect, options[{label, description}]}`.
+4. Channel-2 injection strictly `idle_at_prompt`-gated + queued; interrupt is the only immediate injection; a pending Ch.1 decision preempts queued input.
+5. Auth/Origin/CSRF on the phone-facing routes + WS (none today; `?token=` widens leakage). Header bearer for mobile.
+6. Conversation READ view is a new stateful layer — `readNewTurns` is a lossy byte-tailer; need durable cursor+epoch, semantic items, dedup, reset-on-`/compact`·`/resume`.
+7. Coverage: folder-trust + in-shell sub-prompts not hook-interceptable → raw-terminal fallback (rare).
+
+## Phasing
+- **Phase 0 — De-risking (gates the build).** Hook spike (mostly done — see ADR-0038; **needs a true interactive-PTY follow-up** for timeout-fail-open + plan/question event routing) + a clickable UI prototype on the real iPhone (done: `src/public/mobile-proto.html`).
+- **MVP.** Channel-1 decision round-trip (tool-permission + plan + question) with fail-closed budget + trusted decision cards; Channel-2 input panel + immediate interrupt (idle-gated); conversation read view; Origin/CSRF hardening.
+- **Fast-follow.** Artifact/plan panel hook-popped + comment injection; single-FAB IA; async local-inference *enrichment* (never decisions).
+
+## Critical files
+- **github-router**: new `src/internal-decision-hook.ts` + `buildDecisionHookCommand` (`src/lib/orchestration/stop-gate-hook.ts`) + registration in `src/claude.ts`; reuse `worker-dispatch.ts` contract, `plan-html.ts`/`first-mate/decision-packet.ts`, `ArtifactClient`.
+- **ai-or-die**: `POST /decision` (`src/control/routes.js`/`src/artifact-review.js`); reuse artifact SSE/panel/`data-aod`; Channel-2 reuse `_pushArtifactFeedbackToAgent` + `detectTurnState`; Origin/CSRF in `src/server.js`; new turn-stream module + `GET /sessions/:id/messages` (`sticky-note-jsonl.js` `readNewTurns` = raw-line source only).
+- **Client** (gated on `body.is-mobile`/`detectMobile()`): decision cards, input panel, conversation view, mobile IA (`src/public/index.html` + `mobile-mode.css`); reuse `artifact-panel.js` SSE/`data-aod`, `key-encoder.js`, `session-manager.js`.
+
+## Verification
+- Playwright WebKit (real backend + PTY): decision card shows exact command → Approve→`allow`→runs; Reject→`deny`→cancelled; timeout → **fail-closed, never auto-allow**; phone+desktop → first-answer-wins; input injects only when idle; interrupt immediate; turns render with stable ids + collapsible tool cards.
+- Security: cross-origin POST to `/decision` rejected; WS foreign Origin rejected.
+- Turn stream: cursor epoch/reset on `/compact`; partial-JSONL replay; offline-past-window catch-up.
+- **iOS from Windows** (no simulator exists): real iPhone over mesh/tunnel (primary dimension loop) + real-device cloud (BrowserStack/LambdaTest) regression + Playwright WebKit (logic). Dimension strategy: demote the terminal; `viewport-fit=cover` + `env(safe-area-inset-*)` + `100dvh/svh` + `visualViewport` + `interactive-widget=resizes-content`.
+- Cross-lab re-review of the blocking-hook + timeout design before shipping.
+
+## Out of scope / deferred
+- Native iOS app (same API ⇒ future re-skin). Happy integration (`.docs/research/happy/`). Background push (installed-PWA web-push). Local inference as a synchronous structurer.
+
+## Tangential
+- **Artifact panel — remove the height cap** (`components/artifact-panel.css:12` `max-height:80vh`; phone `:305-306`; resize clamp `artifact-panel.js:211-212`) → grow to full viewport height, `_clampToBounds`-fitted, keep `MIN_W`/`MIN_H`.

--- a/docs/planning/structured-sdk-refounding-proposal.md
+++ b/docs/planning/structured-sdk-refounding-proposal.md
@@ -1,0 +1,62 @@
+# Strategic proposal: re-found execution on the Claude Agent SDK (structured control plane)
+
+> Status: **Proposal — awaiting decision** (2026-07-07). Supersedes the *decision plane* of ADR-0038 (the github-router hook + PTY-inject approach); keeps ADR-0038's surface/UX design. If accepted, becomes a new ADR that supersedes ADR-0038's mechanism.
+
+## TL;DR
+
+Swap ai-or-die's execution substrate from **node-pty running the Claude Code TUI** to the **Claude Agent SDK `query()` Streaming Input Mode with a `canUseTool` permission callback**. Structured becomes the **default**; the current pty/xterm becomes an opt-in `--tui` fallback. This retires the entire hook / screen-scrape / keystroke-inject plane (and eliminates the C1/I1/I2 race class by construction), and it re-founds ai-or-die's existing `/api/control` as the **unified control plane** of a first-class Claude Code web stack: **github-router (Copilot→Anthropic proxy + GitHub auth + tunnel) + Agent SDK engine + unified control plane + web portal**.
+
+## How we got here
+
+The mobile-mode effort built structured surfaces (conversation view, decision cards) over the terminal by intercepting decisions with a github-router hook and answering them by **injecting keystrokes into the PTY**. A 3-lab adversarial review confirmed a **Critical** in that mechanism (C1): the desktop answers out-of-band, so a phone tap can inject a keystroke into an already-advanced terminal and approve a command the user never saw. Raw injection is not a deterministic write. The user chose "structured card everywhere (default), `--tui` opt-out" and asked whether a structured agent mode (`--acp`/SDK) is the better foundation, and whether the result is really a unified control plane rather than a terminal wrapper.
+
+## What the research found (3 independent streams, convergent)
+
+1. **Claude Code capability (docs).** The **Agent SDK** `query()` Streaming Input Mode is the officially-documented interactive path: long-lived, multi-turn, free-form typing, `interrupt()`, `setPermissionMode()`, structured message stream. **`canUseTool(toolName, input, {toolUseID, suggestions, ...}) → {behavior:'allow', updatedInput, updatedPermissions?} | {behavior:'deny', message}`** is a structured permission callback that **pauses execution until resolved** — no terminal, no keystrokes. **ACP is a third-party wrapper over this same SDK** (no Anthropic `--acp`); skip it, use the SDK directly.
+2. **ai-or-die architecture.** The conversation view (`turn-stream.js`, `/messages`), the decision store, and all of `/api/control/*` are **already structured and pty-independent**. Only the *execution/permission/input* path is terminal-coupled. Swapping it is a **bounded add** (~400–800 lines: a new `ClaudeSdkBridge` + a `canUseTool`→decision-store bridge) with a clean single-seam `--tui` fallback at `getBridgeForAgent('claude')`.
+3. **claudecodeui (production proof).** `server/claude-sdk.js` uses **`canUseTool` in production** with a request-id/Promise-map → WebSocket round-trip → approve/deny cards. No pty, no injection, no `--permission-prompt-tool`, no MCP. It also proves: **refresh survival** (`chat.subscribe {sessionId, lastSeq}` replays a seq-ring **and returns pending permission requests**), a provider-agnostic `NormalizedMessage` schema, plan mode, "always allow" via `updatedPermissions`, and — decisively — that **`ANTHROPIC_BASE_URL` is forwarded to the SDK**, so a Copilot→Anthropic proxy (github-router) works unmodified.
+
+## Proposed decision
+
+Re-found the default execution path on the Agent SDK; keep pty as `--tui`.
+
+- **Engine:** `@anthropic-ai/claude-agent-sdk` `query()` Streaming Input Mode, in-process in ai-or-die, one long-lived session per tab (mirrors the current per-tab model).
+- **Permissions:** `canUseTool` → register a decision in the existing `decision-store` → the existing card renders on **every** surface (desktop + mobile) → first human answer resolves the promise with `{behavior}`. Deterministic; no PTY; **C1/I1/I2 cannot occur**. `suggestions`/`updatedPermissions` back "always allow"; `AskUserQuestion` routes through the same callback.
+- **Events:** normalize the SDK `SDKMessage` stream (assistant text deltas, `tool_use`/`tool_result`, `thinking`, `system/init`) into the structured event stream the cards + conversation view already consume.
+- **Model access / unified stack:** SDK → `ANTHROPIC_BASE_URL` = **github-router** proxy → Copilot. github-router stays as auth + proxy + tunnel. ai-or-die's `/api/control` is the **unified control plane** every surface (web, mobile, future native) speaks.
+- **Retire:** the github-router decision/permission/tool-ran hooks and the PTY keystroke-inject answer path (superseded by `canUseTool`).
+
+## Reuse vs. rebuild
+
+| Reuse as-is | Build / change |
+|---|---|
+| `turn-stream.js`, `/messages`, decision-store, decision cards, all `/api/control/*` | New `ClaudeSdkBridge` (SDK `query()` session runtime) |
+| Mobile-mode UI + surfaces, Origin hardening | `canUseTool` → decision-store bridge (pending-promise map keyed by `toolUseID`) |
+| Sessions/persistence, devtunnel, Tailscale mesh, keep-awake, Windows ops | SDKMessage → normalized-event translation |
+| github-router (now purely proxy + auth + tunnel) | Refresh-survival: `subscribe {sessionId, lastSeq}` + seq-ring + return-pending-permissions |
+| Desktop app shell, WS gateway | Desktop structured card rendering (today desktop is xterm-only) + `--tui` bridge seam |
+
+## Phasing
+
+- **Phase 0 — de-risk (must pass before build):** confirm the SDK routes through github-router via `ANTHROPIC_BASE_URL` (Copilot auth intact); confirm the SDK session still writes/enables the structured transcript the conversation view reads (or feed SDK messages directly); fetch `agent-sdk/typescript.md` for exact `SDKMessage`/`PermissionResult` field shapes.
+- **Phase 1 — MVP:** `ClaudeSdkBridge` + `canUseTool`→decision-store + normalized events → cards on desktop + mobile; free-form chat input; interrupt.
+- **Phase 2 — parity + durability:** refresh survival (subscribe + seq-ring + pending-permission replay), "always allow" (`updatedPermissions`), plan mode, `AskUserQuestion`.
+- **Phase 3 — `--tui` fallback + cleanup:** pty bridge behind `--tui`; delete the hook/inject plane; docs/ADRs.
+
+## Risks / open questions
+
+- **github-router ↔ SDK wiring (Phase-0 gate):** must confirm `ANTHROPIC_BASE_URL` + auth flow through github-router for the SDK exactly as for the CLI.
+- **Transcript source:** does an SDK session still populate `~/.claude/projects/*.jsonl` (so `turn-stream` is reused), or must we drive the conversation view from the in-process SDK stream? Either works; decides the events wiring.
+- **Permissive modes skip `canUseTool`:** in `auto`/`bypassPermissions`, `AskUserQuestion`/`ExitPlanMode` never reach the callback (SDK resolves earlier). If we want them under those modes, add a `PreToolUse` hook. Also: keep `default` mode as our default so cards actually fire; don't inherit a one-click "skip permissions" that silently bypasses the whole structured story.
+- **Claude-only:** structured approval is an Agent-SDK capability, not a cross-CLI pattern (fine — we're Claude-first).
+- **Feature deltas vs TUI:** the terminal's own permission menu + `/login` dialog go away (replaced by our cards = feature transfer); `AskUserQuestion` is unavailable inside subagents.
+
+## What happens to the in-flight mobile-mode PRs
+
+- **Carries forward:** decision-store, decision cards, `/api/control`, turn-stream, mobile UI, the Origin hardening, the artifact-panel height fix.
+- **Superseded / retired:** the github-router `PermissionRequest`/`PostToolUse`/decision hooks and the ai-or-die PTY keystroke-inject answer path (the uncommitted increment-2 work). Not wasted — it built the decision store + cards and mapped the exact requirements; the substrate was wrong.
+
+## Consequences
+
+- **Positive:** eliminates the injection-race class; deterministic structured permissions; refresh-durable; simpler (no hook/scrape/inject); re-founds `/api/control` as a real unified control plane; a coherent "first-class Claude Code web" stack; native + desktop clients can speak the same contract later.
+- **Negative:** a bounded but real new execution runtime; two execution paths to maintain (SDK default + pty `--tui`); Phase-0 unknowns must clear first; structured approval is Claude-specific.

--- a/docs/specs/mobile-mode-ui.md
+++ b/docs/specs/mobile-mode-ui.md
@@ -1,0 +1,128 @@
+# Mobile Mode — UI/UX Specification
+
+**Status:** Design reference, approved 2026-07-07 (pre-implementation; backend wiring gated by the Phase-0 de-risking spike).
+**Reference mock:** [`src/public/mobile-proto.html`](../../src/public/mobile-proto.html) — a self-contained, clickable, backend-free prototype of every surface below.
+**Related:** ADR-0038 (mobile-mode architecture — the *transparent user proxy*), ADR-0037 (mobile input two-mode + flicker), ADR-0026 (Claude bind hook), ADR-0032 (control plane), ADR-0033 (artifact panel), `docs/planning/mobile-mode.md` (full plan), `docs/specs/mobile-input.md`, `docs/specs/plan-viewer.md`, `docs/specs/notifications.md`.
+
+This spec captures **how** we want the mobile surfaces to look and behave, and **when** each one appears. It is the contract the production build implements; the mock is the visual source of truth.
+
+---
+
+## 1. Intent & the one rule
+
+**North-star:** on a phone, the user treats the terminal as *read-only* and interacts through **structured surfaces** — a conversation to read, and structured controls to act. The raw xterm is demoted to a rarely-opened "raw output" tab.
+
+**One vocabulary (do not scatter modal styles):**
+- **Bottom sheet** — input, short decisions, questions. Grip handle, backdrop scrim, `dvh`-sized, safe-area padded, drag-to-dismiss, pinned above the keyboard.
+- **Full-screen sheet** — long content (a plan, the raw terminal). Header with ✕, scroll body, sticky footer.
+- **Right-side panel** — on iPad, sheets dock as a right panel (two-pane: conversation left) so context is preserved.
+- **No center modals on phone** (out of thumb reach, fight the keyboard). Center modal is desktop-only.
+
+---
+
+## 2. WHEN — the trigger & return model (state machine)
+
+Every surface is **popped out-of-band** (the infra renders it; the Claude instance never calls a panel API) and every human action returns to Claude through exactly **two channels**. See ADR-0038 for the transparent-user-proxy architecture.
+
+| Surface | Pops when… (trigger) | Returns via | Blocking? |
+|---|---|---|---|
+| **Decision — tool permission** | a `PreToolUse` hook fires for `Bash`/`Write`/`Edit` (has the exact `tool_input`) | **Channel 1** — hook returns `allow`/`deny` | Yes (tool paused) |
+| **Decision — plan** | `ExitPlanMode` hook (`PermissionRequest`/`PreToolUse`) | Channel 1 — `allow`/`deny` (+ comments via Ch.2) | Yes |
+| **Decision — question** | `AskUserQuestion` hook (question + options) | Channel 1 — the chosen option | Yes |
+| **Artifact / plan review** | a hook detects a reviewable artifact (e.g. `PostToolUse`), opens it via `ArtifactClient` — *not* Claude calling `artifact_open` | approve/reject → Ch.1; free-form comments → Ch.2 | Optional |
+| **Input composer** | user taps the FAB, or a `waiting_input` event | **Channel 2** — idle-gated PTY injection (interrupt = immediate) | No |
+| **Conversation view** | live via SSE/control `/events` | — (read-only) | No |
+| **"Needs you" pill** | any pending blocking decision / `waiting_input` | — (affordance to open the pending surface) | No |
+
+**The two return channels:**
+- **Channel 1 — hook-return (structured, blocking):** the hook holds the tool, the human answers, the hook returns the decision. Claude sees a normal tool result.
+- **Channel 2 — idle-gated PTY injection ("typed as the user"):** free-form input + non-blocking comments are injected into Claude's stdin *only when `idle_at_prompt`* (never mid-turn), queued while busy. **Interrupt (Ctrl-C/Esc) is the one immediate injection.**
+
+**Precedence & concurrency:** one decision at a time; a pending blocking decision **preempts** queued input; if multiple stack, show a badge and resolve in order; **first client to answer wins** (phone or desktop), single resolution.
+
+**Timeout / absence (see ADR-0038 §risks):** a present human is simply **waited for** (high hook timeout). Only hold the tool when a human client is connected; on true absence, **fail closed (deny)** — never auto-allow.
+
+---
+
+## 3. HOW — per-surface visual + interaction spec
+
+### 3.1 Conversation view (primary read surface)
+- **Header:** slim — `◄ session-name · mode ⋮`. Overflow `⋮` holds session actions.
+- **Body:** scrollable message list: user messages; assistant text; **tool cards** that collapse to one line (`▸ Ran \`npm test\` ✓`, `▸ Edited auth.js +12/-3`) and **expand on tap** to show the full call/result. Thinking is a subtle collapsed block.
+- **Status line:** `Claude idle` / `working…` / `waiting for you`.
+- **Input bar:** persistent bottom bar (`Message…` + mic + send ⬆) that **expands into the composer sheet** on tap.
+- **"● needs you" pill** appears when a decision is pending.
+
+### 3.2 Decision — tool permission (bottom sheet, blocking) — *the safety-critical one*
+- Slides up over a **dimmed** conversation; grip handle.
+- `⚠ Claude wants to run` + the tool name.
+- **Exact command** in a monospace, scrollable box (never truncated; scroll if long). `cwd` line beneath.
+- **Fail-closed countdown** (`falls back in 45s`, animated) — makes the time-boxed hook legible.
+- **`Show raw`** link (one tap to the raw terminal).
+- Actions: **`[ Deny ]`** (safe default, left) **`[ Approve ]`** (right). For a **destructive** command, Approve is **red/destructive-styled and is not the default focus** — deliberate friction.
+
+### 3.3 Decision — plan approval (full-screen sheet)
+- Header `Plan — approve to start` + ✕.
+- Scrollable **rendered plan** (headings, checklist, diff blocks) — the full plan (not a 300-char preview), from the hook's structured `input.plan`, rendered in a **trusted** component.
+- Sticky footer: **`[ Reject ] [ Comment ] [ Approve ]`**. Comment routes as a Channel-2 note; Approve/Reject as Channel-1.
+
+### 3.4 Decision — question (bottom sheet)
+- The question text + **option cards**: radio (choose-one) or checkboxes + `Send` (multi-select). Options come structured from `AskUserQuestion`.
+
+### 3.5 Input composer (bottom sheet)
+- Multi-line textarea; a row of **structured controls**: slash `/`, mode toggle (plan/accept-edits), **Stop/interrupt**; mic + `Send`.
+- **Keyboard-aware:** stays pinned above the soft keyboard via the `visualViewport` sync; the conversation scrolls behind.
+
+### 3.6 Status / presence
+- `● Claude needs you` pill (tappable → opens the pending surface); subtle haptic + optional chime when a decision auto-surfaces.
+
+---
+
+## 4. Per-screen adaptation
+
+| Surface | Phone portrait | Phone landscape (keyboard eats height) | iPad | Desktop |
+|---|---|---|---|---|
+| Decision (tool/question) | bottom sheet | compact top banner + inline Approve/Deny | right-side panel | center modal (arrives via hook regardless of client) |
+| Plan / artifact | full-screen sheet | slim overlay, scroll | right-side panel (two-pane) | existing artifact panel / side |
+| Input composer | expanding bottom sheet | slim overlay above keyboard | docked bottom bar | terminal stays primary |
+| Conversation | full-screen base | base behind overlays | left pane | mobile mode off by default |
+
+---
+
+## 5. iOS dimension toolkit (what makes the layout robust)
+
+The **terminal** (fixed cols×rows, must re-fit on every keyboard/viewport change) is the worst dimension offender — demoting it is the structural fix. Primary surfaces are flow/flex HTML using:
+- `<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content">`.
+- `env(safe-area-inset-*)` on every edge (notch / Dynamic Island / home indicator), captured as CSS vars (`--safe-top/-right/-bottom/-left`).
+- `100dvh` / `100svh` for full-height containers — **never bare `100vh`** (it ignores the keyboard/toolbars on iOS).
+- The **`visualViewport` API** (resize/scroll listeners → a `--keyboard-bottom` var) so bottom sheets and the composer stay above the keyboard.
+- 44px min touch targets; system font stack; `prefers-reduced-motion` respected.
+
+Validation: real iPhone over the mesh/tunnel (primary loop) + real-device cloud (BrowserStack/LambdaTest) for regression — **there is no iOS simulator on Windows**. See `docs/specs/mobile-input-verification.md` for the manual device checklist.
+
+---
+
+## 6. Interaction & safety principles (cross-surface)
+
+- **Destructive friction:** red Approve, safe Deny default, Approve never the default focus; the exact command/args are **always shown** with one-tap `Show raw`. No inference/screen-scrape ever fabricates an approval target (ADR-0038).
+- **Auto-surface:** a pending decision slides up on its own + a presence pill + haptic; a visible **fail-closed countdown**.
+- **One at a time:** blocking decision preempts queued input; a badge if more stack.
+- **Reachability:** primary actions in the bottom third; sheets are thumb-driven.
+- **Accessibility:** 44px targets, dynamic type, VoiceOver labels, `role="dialog"`/`aria-modal`, focus trapping in sheets.
+
+---
+
+## 7. The reference mock
+
+`src/public/mobile-proto.html` — self-contained (inline CSS/JS, no backend, no external deps). To view: serve `src/public` on a port and open on the device (LAN or over a dev tunnel / mesh) — e.g. `http://<lan-ip>:<port>/mobile-proto.html`.
+
+A **dev trigger toolbar** (bottom, dismissible) exposes every state for on-device review:
+- Permission sheet · **destructive⇄safe command** toggle · Plan sheet · Question (radio + multi-select) · Composer sheet · **iPad/desktop layout** toggle.
+
+The mock is the **visual/interaction source of truth**; it is a design reference, not production. The production build wires these surfaces to the backend per `docs/planning/mobile-mode.md` and ADR-0038.
+
+---
+
+## 8. Not-yet-designed (open, to settle in the device loop)
+
+Empty / loading / error / offline states; reconnect + stale-decision UI; landscape refinements; iPad two-pane details; light theme; exact microcopy; haptic/sound choices; multi-session switcher (mobile drawer). These are deliberately deferred to on-device iteration and the MVP phase.

--- a/e2e/helpers/terminal-helpers.js
+++ b/e2e/helpers/terminal-helpers.js
@@ -278,6 +278,56 @@ async function waitForWsMessage(page, dir, type, timeoutMs = 5000) {
   return null;
 }
 
+/**
+ * Return the current capture cursor for frames recorded by setupPageCapture().
+ * @param {import('@playwright/test').Page} page
+ * @returns {number}
+ */
+function wsCursor(page) {
+  return (page._wsMessages || []).length;
+}
+
+/**
+ * Wait for a captured WebSocket frame after a known cursor.
+ * @param {import('@playwright/test').Page} page
+ * @param {number} startIndex
+ * @param {(message: object) => boolean} predicate
+ * @param {string} label
+ * @param {number} [timeoutMs=5000]
+ * @returns {Promise<object>}
+ */
+async function waitForWsFrameAfter(page, startIndex, predicate, label, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  let recent = [];
+  while (Date.now() < deadline) {
+    const messages = (page._wsMessages || []).slice(startIndex);
+    const found = messages.find(predicate);
+    if (found) return found;
+    recent = messages.slice(-5);
+    await page.waitForTimeout(50);
+  }
+  throw new Error(`Timed out waiting for ${label}. Recent WS frames: ${JSON.stringify(recent)}`);
+}
+
+/**
+ * Wait for an exact terminal-input frame after a known capture cursor.
+ * @param {import('@playwright/test').Page} page
+ * @param {number} startIndex
+ * @param {string} expectedData
+ * @param {string} label
+ * @param {number} [timeoutMs=5000]
+ * @returns {Promise<object>}
+ */
+async function waitForSentInput(page, startIndex, expectedData, label, timeoutMs = 5000) {
+  return waitForWsFrameAfter(
+    page,
+    startIndex,
+    (m) => m.dir === 'sent' && m.type === 'input' && m.data === expectedData,
+    `${label} input ${JSON.stringify(expectedData)}`,
+    timeoutMs
+  );
+}
+
 module.exports = {
   waitForAppReady,
   waitForTerminalCanvas,
@@ -291,5 +341,8 @@ module.exports = {
   attachFailureArtifacts,
   waitForWebSocket,
   waitForWsMessage,
+  waitForWsFrameAfter,
+  waitForSentInput,
+  wsCursor,
   joinSessionAndStartTerminal,
 };

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -205,10 +205,10 @@ module.exports = defineConfig({
       timeout: 120000,
     },
     // iOS mobile-input / flicker suite on WebKit (approximates Edge-on-iOS).
-    // Specs 77-79. Service workers allowed so the PWA/offline paths can run.
+    // Specs 77-80. Service workers allowed so the PWA/offline paths can run.
     {
       name: 'ios-iphone16',
-      testMatch: /7[7-9]-.*\.spec\.js/,
+      testMatch: /(?:7[7-9]-.*|80-mobile-mode-shell)\.spec\.js/,
       use: { ...iPhone16, serviceWorkers: 'allow' },
     },
     {
@@ -218,7 +218,7 @@ module.exports = defineConfig({
     },
     {
       name: 'ios-ipad11',
-      testMatch: /7[7-9]-.*\.spec\.js/,
+      testMatch: /(?:7[7-9]-.*|80-mobile-mode-shell)\.spec\.js/,
       use: { ...iPad11, serviceWorkers: 'allow' },
     },
     {

--- a/e2e/tests/80-mobile-mode-shell.spec.js
+++ b/e2e/tests/80-mobile-mode-shell.spec.js
@@ -1,0 +1,132 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const { createServer } = require('../helpers/server-factory');
+const {
+  setupPageCapture,
+  attachFailureArtifacts,
+  waitForAppReady,
+  waitForWebSocket,
+  waitForSentInput,
+  wsCursor,
+} = require('../helpers/terminal-helpers');
+
+let server, url;
+
+test.use({ permissions: [] });
+
+test.beforeAll(async () => {
+  ({ server, url } = await createServer());
+});
+
+test.afterAll(async () => {
+  if (server) await server.close();
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  await page.evaluate(() => {
+    if (window.MobileMode) window.MobileMode.closeSurface();
+  }).catch(() => {});
+  await attachFailureArtifacts(page, testInfo);
+});
+
+async function startMobileMode(page) {
+  setupPageCapture(page);
+  await page.goto(url + '?mobileMode=1');
+  await waitForAppReady(page, 20000);
+  await waitForWebSocket(page, 20000);
+  await page.waitForFunction(() => {
+    return !!(window.app && window.app.isMobile)
+      && document.body.classList.contains('is-mobile')
+      && document.body.classList.contains('mobile-mode-active')
+      && !!(window.MobileMode && window.MobileMode.getController && window.MobileMode.getController());
+  }, null, { timeout: 20000 });
+}
+
+test.describe('Mobile mode client shell', () => {
+  test('activates on the iPhone/iPad mobile projects when explicitly opted in', async ({ page }) => {
+    await startMobileMode(page);
+
+    const state = await page.evaluate(() => ({
+      appIsMobile: !!(window.app && window.app.isMobile),
+      bodyIsMobile: document.body.classList.contains('is-mobile'),
+      mobileModeActive: document.body.classList.contains('mobile-mode-active'),
+      hasController: !!(window.MobileMode && window.MobileMode.getController && window.MobileMode.getController()),
+    }));
+
+    expect(state).toEqual({
+      appIsMobile: true,
+      bodyIsMobile: true,
+      mobileModeActive: true,
+      hasController: true,
+    });
+    await expect(page.locator('[data-testid="mobile-mode-shell"]')).toBeVisible();
+    await expect(page.locator('[data-testid="mobile-compose-fab"]')).toBeVisible();
+  });
+
+  test('composer sends exact Channel-2 bytes for message+Enter and immediate interrupt', async ({ page }) => {
+    await startMobileMode(page);
+
+    await page.locator('[data-testid="mobile-compose-fab"]').click();
+    await expect(page.locator('[data-testid="mobile-composer-sheet"]')).toHaveClass(/active/);
+    await page.locator('[data-testid="mobile-composer-text"]').fill('hello mobile mode');
+
+    const sendStart = wsCursor(page);
+    await page.locator('[data-testid="mobile-send-composer"]').click();
+    const sent = await waitForSentInput(page, sendStart, 'hello mobile mode\r', 'mobile composer send');
+    expect(sent.data).toBe('hello mobile mode\r');
+
+    await page.locator('[data-testid="mobile-compose-fab"]').click();
+    await expect(page.locator('[data-testid="mobile-composer-sheet"]')).toHaveClass(/active/);
+
+    const stopStart = wsCursor(page);
+    await page.locator('[data-testid="mobile-stop-button"]').click();
+    const interrupted = await waitForSentInput(page, stopStart, '\x03', 'mobile composer interrupt');
+    expect(interrupted.data).toBe('\x03');
+  });
+
+  test('opens and closes reusable mobile sheets', async ({ page }) => {
+    await startMobileMode(page);
+
+    await page.evaluate(() => window.MobileMode.openSurface('question'));
+    const sheet = page.locator('[data-testid="mobile-question-sheet"]');
+    await expect(sheet).toHaveClass(/active/);
+    await expect(sheet).toHaveAttribute('aria-hidden', 'false');
+
+    await sheet.locator('[data-close-surface]').first().click();
+    await expect(sheet).not.toHaveClass(/active/);
+    await expect(sheet).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('destructive permission data gives Approve the danger styling', async ({ page }) => {
+    await startMobileMode(page);
+
+    await page.evaluate(() => {
+      window.MobileMode.setDecisionStub('permission', {
+        kind: 'permission',
+        command: 'npm test -- --watch=false',
+        cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die',
+        destructive: false,
+        risk: 'Read-only-ish test command',
+      });
+      window.MobileMode.openSurface('permission');
+    });
+
+    const approve = page.locator('[data-testid="mobile-approve-permission"]');
+    await expect(approve).toHaveClass(/primary/);
+    await expect(approve).not.toHaveClass(/danger/);
+
+    await page.evaluate(() => {
+      window.MobileMode.setDecisionStub('permission', {
+        kind: 'permission',
+        command: 'rm -rf build/',
+        destructive: true,
+        risk: 'Destructive filesystem operation',
+      });
+    });
+
+    await expect(approve).toHaveClass(/danger/);
+    await expect(approve).not.toHaveClass(/primary/);
+    const destructiveAttr = await approve.getAttribute('data-destructive');
+    expect(destructiveAttr).toBe('true');
+  });
+});

--- a/e2e/tests/80-mobile-mode-shell.spec.js
+++ b/e2e/tests/80-mobile-mode-shell.spec.js
@@ -33,6 +33,11 @@ test.afterEach(async ({ page }, testInfo) => {
 
 async function startMobileMode(page) {
   setupPageCapture(page);
+  // Deterministic interaction: honor the CSS prefers-reduced-motion block so sheet
+  // slide transitions collapse to ~instant. Without it, Playwright's actionability
+  // "stable" check can fight the 260ms open/close animation under full-suite CPU
+  // load (janky frames) and time out clicking a sheet control (iPad-landscape flake).
+  await page.emulateMedia({ reducedMotion: 'reduce' });
   await page.goto(url + '?mobileMode=1');
   await waitForAppReady(page, 20000);
   await waitForWebSocket(page, 20000);

--- a/e2e/tests/80-mobile-mode-shell.spec.js
+++ b/e2e/tests/80-mobile-mode-shell.spec.js
@@ -42,6 +42,11 @@ async function startMobileMode(page) {
       && document.body.classList.contains('mobile-mode-active')
       && !!(window.MobileMode && window.MobileMode.getController && window.MobileMode.getController());
   }, null, { timeout: 20000 });
+  await page.waitForFunction(() => {
+    const controller = window.MobileMode && window.MobileMode.getController && window.MobileMode.getController();
+    const sessionId = window.app && window.app.currentClaudeSessionId;
+    return !!(controller && sessionId && controller.currentSessionId === String(sessionId));
+  }, null, { timeout: 20000 });
 }
 
 async function createBoundTranscriptSession(name) {
@@ -62,6 +67,41 @@ async function createBoundTranscriptSession(name) {
 function appendJsonl(file, records) {
   const text = records.map((record) => JSON.stringify(record)).join('\n') + '\n';
   fs.appendFileSync(file, text, 'utf8');
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForMobileSession(page, sessionId) {
+  await page.waitForFunction((sid) => {
+    return window.app && window.app.currentClaudeSessionId === sid
+      && window.MobileMode && window.MobileMode.getController
+      && window.MobileMode.getController().currentSessionId === sid;
+  }, sessionId, { timeout: 20000 });
+}
+
+async function postControlDecision(sessionId, body) {
+  const response = await fetch(url + '/api/control/sessions/' + encodeURIComponent(sessionId) + '/decision', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error('decision create failed: HTTP ' + response.status + ' ' + await response.text());
+  return response.json();
+}
+
+async function awaitDecisionAnswer(decisionId) {
+  const response = await fetch(url + '/api/control/decisions/' + encodeURIComponent(decisionId) + '/await?timeoutMs=10000');
+  if (!response.ok) throw new Error('decision await failed: HTTP ' + response.status + ' ' + await response.text());
+  return response.json();
+}
+
+function waitForDecisionAnswerRequest(page, decisionId) {
+  return page.waitForRequest((request) => {
+    return request.method() === 'POST'
+      && request.url().includes('/api/control/decisions/' + encodeURIComponent(decisionId) + '/answer');
+  }, { timeout: 20000 });
 }
 
 test.describe('Mobile mode client shell', () => {
@@ -150,6 +190,72 @@ test.describe('Mobile mode client shell', () => {
     await expect(approve).not.toHaveClass(/primary/);
     const destructiveAttr = await approve.getAttribute('data-destructive');
     expect(destructiveAttr).toBe('true');
+  });
+
+  test('answers real Channel-1 mobile decisions without executing command HTML', async ({ page }) => {
+    server.claudeSessions.clear();
+    server._stickyJsonl.clear();
+
+    const xssCommand = 'rm -rf build && <img src=x onerror="window.__xssd=1">';
+    const { sessionId } = await createBoundTranscriptSession('Mobile Channel-1 decisions');
+    const firstEventsRequest = page.waitForRequest((request) => request.url().includes('/api/control/events?'), { timeout: 20000 });
+    await startMobileMode(page);
+    await firstEventsRequest;
+    await waitForMobileSession(page, sessionId);
+
+    const toolDecision = await postControlDecision(sessionId, {
+      kind: 'tool_approval',
+      tool: 'Bash',
+      command: xssCommand,
+      cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die',
+    });
+    const toolDecisionId = toolDecision.decisionId;
+
+    const permissionSheet = page.locator('[data-testid="mobile-permission-sheet"]');
+    await expect(permissionSheet).toHaveClass(/active/);
+    await expect(permissionSheet).toHaveAttribute('aria-hidden', 'false');
+    await expect(permissionSheet).toHaveAttribute('data-decision-id', toolDecisionId);
+    await expect(page.locator('[data-mobile-needs-pill]')).toHaveCSS('opacity', '1');
+    await expect(permissionSheet.locator('[data-mobile-permission-command]')).toHaveText(xssCommand);
+    await expect(permissionSheet.locator('[data-mobile-permission-cwd]')).toHaveText('C:\\Users\\anikundu\\Software\\ai-or-die');
+    await expect(permissionSheet.locator('img[src="x"]')).toHaveCount(0);
+    await expect(await page.evaluate(() => window.__xssd)).toBeUndefined();
+
+    const approve = page.locator('[data-testid="mobile-approve-permission"]');
+    await expect(approve).toHaveClass(/danger/);
+    await expect(approve).not.toHaveClass(/primary/);
+    await expect(approve).toHaveAttribute('data-destructive', 'true');
+
+    const toolAwait = awaitDecisionAnswer(toolDecisionId);
+    await delay(20);
+    const toolAnswerRequest = waitForDecisionAnswerRequest(page, toolDecisionId);
+    await approve.click();
+    const toolRequest = await toolAnswerRequest;
+    expect(toolRequest.postDataJSON()).toEqual({ choice: 'accept' });
+    await expect(permissionSheet).not.toHaveClass(/active/);
+    await expect(await toolAwait).toEqual({ answered: true, choice: 'accept' });
+
+    const planText = '### Plan\n- [ ] Reject this mobile-mode plan\n- [ ] Keep Channel-1 first-answer-wins';
+    const planDecision = await postControlDecision(sessionId, {
+      kind: 'plan_approval',
+      plan: planText,
+    });
+    const planDecisionId = planDecision.decisionId;
+
+    const planSheet = page.locator('[data-testid="mobile-plan-sheet"]');
+    await expect(planSheet).toHaveClass(/active/);
+    await expect(planSheet).toHaveAttribute('aria-hidden', 'false');
+    await expect(planSheet).toHaveAttribute('data-decision-id', planDecisionId);
+    await expect(planSheet.locator('[data-mobile-plan-doc]')).toContainText('Reject this mobile-mode plan');
+
+    const planAwait = awaitDecisionAnswer(planDecisionId);
+    await delay(20);
+    const planAnswerRequest = waitForDecisionAnswerRequest(page, planDecisionId);
+    await planSheet.locator('[data-mobile-reject-plan]').click();
+    const planRequest = await planAnswerRequest;
+    expect(planRequest.postDataJSON()).toEqual({ choice: 'reject' });
+    await expect(await planAwait).toEqual({ answered: true, choice: 'reject' });
+    await expect(planSheet).not.toHaveClass(/active/);
   });
 
   test('renders the real turn stream tool card without executing tool-result HTML', async ({ page }) => {

--- a/e2e/tests/80-mobile-mode-shell.spec.js
+++ b/e2e/tests/80-mobile-mode-shell.spec.js
@@ -1,4 +1,6 @@
 // @ts-check
+const fs = require('fs');
+const path = require('path');
 const { test, expect } = require('@playwright/test');
 const { createServer } = require('../helpers/server-factory');
 const {
@@ -40,6 +42,26 @@ async function startMobileMode(page) {
       && document.body.classList.contains('mobile-mode-active')
       && !!(window.MobileMode && window.MobileMode.getController && window.MobileMode.getController());
   }, null, { timeout: 20000 });
+}
+
+async function createBoundTranscriptSession(name) {
+  const response = await fetch(url + '/api/sessions/create', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name })
+  });
+  if (!response.ok) throw new Error('session create failed: HTTP ' + response.status);
+  const data = await response.json();
+  const sessionId = data.sessionId;
+  const transcriptPath = path.join(server._testTempDir, sessionId + '.jsonl');
+  fs.writeFileSync(transcriptPath, '', 'utf8');
+  server._stickyJsonl.set(sessionId, { file: transcriptPath });
+  return { sessionId, transcriptPath };
+}
+
+function appendJsonl(file, records) {
+  const text = records.map((record) => JSON.stringify(record)).join('\n') + '\n';
+  fs.appendFileSync(file, text, 'utf8');
 }
 
 test.describe('Mobile mode client shell', () => {
@@ -128,5 +150,84 @@ test.describe('Mobile mode client shell', () => {
     await expect(approve).not.toHaveClass(/primary/);
     const destructiveAttr = await approve.getAttribute('data-destructive');
     expect(destructiveAttr).toBe('true');
+  });
+
+  test('renders the real turn stream tool card without executing tool-result HTML', async ({ page }) => {
+    server.claudeSessions.clear();
+    server._stickyJsonl.clear();
+
+    const xss = '<img src=x onerror="window.__xss=1">';
+    const { sessionId, transcriptPath } = await createBoundTranscriptSession('Mobile real stream');
+    appendJsonl(transcriptPath, [
+      {
+        type: 'user',
+        uuid: 'mobile-user-1',
+        timestamp: '2026-07-07T00:00:00.000Z',
+        message: { role: 'user', content: 'Please run the mobile stream smoke test.' },
+      },
+      {
+        type: 'assistant',
+        uuid: 'mobile-assistant-1',
+        timestamp: '2026-07-07T00:00:01.000Z',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'I will run the smoke test now.' },
+            { type: 'tool_use', id: 'tool-mobile-1', name: 'Bash', input: { command: 'npm test -- --runInBand', cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die' } },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        uuid: 'mobile-tool-result-1',
+        timestamp: '2026-07-07T00:00:02.000Z',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tool-mobile-1', content: xss, is_error: false }] },
+      },
+      {
+        type: 'assistant',
+        uuid: 'mobile-assistant-2',
+        timestamp: '2026-07-07T00:00:03.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'The smoke test finished safely.' }] },
+      },
+    ]);
+
+    const firstEventsRequest = page.waitForRequest((request) => request.url().includes('/api/control/events?'), { timeout: 20000 });
+    await startMobileMode(page);
+    await firstEventsRequest;
+
+    await page.waitForFunction((sid) => {
+      return window.app && window.app.currentClaudeSessionId === sid
+        && window.MobileMode && window.MobileMode.getController
+        && window.MobileMode.getController().currentSessionId === sid;
+    }, sessionId, { timeout: 20000 });
+
+    await expect(page.locator('.message-row.user .bubble')).toContainText('Please run the mobile stream smoke test.');
+    await expect(page.locator('.message-row.assistant .bubble').first()).toContainText('I will run the smoke test now.');
+    await expect(page.locator('.message-row.assistant .bubble').last()).toContainText('The smoke test finished safely.');
+
+    const toolCards = page.locator('[data-mobile-message-stack] .tool-card');
+    await expect(toolCards).toHaveCount(1);
+    await expect(toolCards.first().locator('.tool-summary')).toContainText('npm test -- --runInBand');
+    await toolCards.first().locator('.tool-summary').click();
+    await expect(toolCards.first()).toHaveClass(/expanded/);
+    await expect(toolCards.first().locator('.tool-details')).toContainText('npm test -- --runInBand');
+    await expect(toolCards.first().locator('pre')).toContainText(xss);
+    await expect(toolCards.first().locator('img[src="x"]')).toHaveCount(0);
+    await expect(await page.evaluate(() => window.__xss)).toBeUndefined();
+
+    const nextEventsRequest = page.waitForRequest((request) => request.url().includes('/api/control/events?'), { timeout: 20000 });
+    server.controlEventBus.append(sessionId, 'became_busy');
+    await expect(page.locator('[data-mobile-status-text]')).toHaveText('working…');
+    await nextEventsRequest;
+
+    const idleEventsRequest = page.waitForRequest((request) => request.url().includes('/api/control/events?'), { timeout: 20000 });
+    server.controlEventBus.append(sessionId, 'waiting_input');
+    await expect(page.locator('[data-mobile-status-text]')).toHaveText('needs you');
+    await expect(page.locator('[data-mobile-needs-pill]')).toHaveCSS('opacity', '1');
+    await idleEventsRequest;
+
+    server.controlEventBus.append(sessionId, 'became_idle');
+    await expect(page.locator('[data-mobile-status-text]')).toHaveText('idle');
+    await expect(page.locator('[data-mobile-needs-pill]')).toHaveCSS('opacity', '0');
   });
 });

--- a/e2e/tests/80-mobile-mode-shell.spec.js
+++ b/e2e/tests/80-mobile-mode-shell.spec.js
@@ -263,6 +263,54 @@ test.describe('Mobile mode client shell', () => {
     await expect(planSheet).not.toHaveClass(/active/);
   });
 
+  test('dismisses a mobile decision when another surface resolves it', async ({ page }) => {
+    server.claudeSessions.clear();
+    server._stickyJsonl.clear();
+
+    const { sessionId } = await createBoundTranscriptSession('Mobile resolved elsewhere');
+    const firstEventsRequest = page.waitForRequest((request) => {
+      return request.url().includes('/api/control/events?')
+        && request.url().includes('decision_resolved');
+    }, { timeout: 20000 });
+    await startMobileMode(page);
+    await firstEventsRequest;
+    await waitForMobileSession(page, sessionId);
+
+    let decisionId = '';
+    let answeredFromMobile = false;
+    page.on('request', (request) => {
+      if (decisionId && request.method() === 'POST'
+          && request.url().includes('/api/control/decisions/' + encodeURIComponent(decisionId) + '/answer')) {
+        answeredFromMobile = true;
+      }
+    });
+
+    const toolDecision = await postControlDecision(sessionId, {
+      kind: 'tool_approval',
+      tool: 'Bash',
+      command: 'npm run mobile-mode:elsewhere',
+      cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die',
+    });
+    decisionId = toolDecision.decisionId;
+
+    const permissionSheet = page.locator('[data-testid="mobile-permission-sheet"]');
+    await expect(permissionSheet).toHaveClass(/active/);
+    await expect(permissionSheet).toHaveAttribute('aria-hidden', 'false');
+    await expect(permissionSheet).toHaveAttribute('data-decision-id', decisionId);
+
+    const nextEventsRequest = page.waitForRequest((request) => request.url().includes('/api/control/events?'), { timeout: 20000 });
+    server.controlEventBus.append(sessionId, 'decision_resolved', { decisionId });
+    await expect(permissionSheet).not.toHaveClass(/active/);
+    await nextEventsRequest;
+
+    await expect(permissionSheet).toHaveAttribute('aria-hidden', 'true');
+    await expect(page.locator('[data-testid="mobile-composer-sheet"]')).toHaveAttribute('aria-hidden', 'true');
+    await expect(page.locator('[data-testid="mobile-compose-fab"]')).toBeVisible();
+    await expect(page.locator('[data-mobile-status-text]')).toHaveText('idle');
+    await expect(page.locator('[data-mobile-needs-pill]')).toHaveCSS('opacity', '0');
+    expect(answeredFromMobile).toBe(false);
+  });
+
   test('renders the real turn stream tool card without executing tool-result HTML', async ({ page }) => {
     server.claudeSessions.clear();
     server._stickyJsonl.clear();

--- a/src/control/decision-store.js
+++ b/src/control/decision-store.js
@@ -132,6 +132,32 @@ class DecisionStore extends EventEmitter {
     return { ok: true };
   }
 
+  // Mark every pending decision for a session as resolved EXTERNALLY — the human
+  // answered Claude's native prompt directly (the desktop terminal), signalled by
+  // the tool actually running (PostToolUse). No keystroke is injected (the native
+  // answer already drove the terminal); this only clears the mirrored card and
+  // stops the decision from resurfacing on a later /decisions poll. Claude prompts
+  // serially, so at most one decision is pending. Returns the resolved ids.
+  externalResolve(sessionId, reason) {
+    this.cleanupExpired();
+    const ids = this._bySession.get(sessionId);
+    if (!ids) return [];
+    const resolved = [];
+    const now = this._now();
+    for (const decisionId of Array.from(ids)) {
+      const record = this._byId.get(decisionId);
+      if (!record || record.status !== 'pending') continue;
+      record.status = 'answered';
+      record.answer = { external: true, reason: reason || 'resolved' };
+      record.answeredAt = now;
+      record.expiresAt = Math.max(record.expiresAt, now + this._ttlMs);
+      this._finishWaiters(record, { status: 'answered', decision: this.answerSnapshot(record), sessionId: record.sessionId });
+      this.emit('answered', this.snapshot(record));
+      resolved.push(decisionId);
+    }
+    return resolved;
+  }
+
   awaitAnswer(decisionId, timeoutMs, options = {}) {
     this.cleanupExpired();
     const record = this._byId.get(decisionId);

--- a/src/control/decision-store.js
+++ b/src/control/decision-store.js
@@ -1,0 +1,324 @@
+'use strict';
+
+const crypto = require('crypto');
+const { EventEmitter } = require('events');
+
+const DEFAULT_DECISION_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_CLEANUP_INTERVAL_MS = 60 * 1000;
+const DECISION_KINDS = Object.freeze([
+  'tool_approval',
+  'plan_approval',
+  'choice_question',
+]);
+const SESSION_CLEAR_EVENT_KINDS = new Set(['exited', 'crashed', 'session_deleted']);
+
+class DecisionStore extends EventEmitter {
+  constructor(options = {}) {
+    super();
+    this.setMaxListeners(0);
+    this._ttlMs = positiveInt(options.ttlMs, DEFAULT_DECISION_TTL_MS);
+    this._now = typeof options.now === 'function' ? options.now : () => Date.now();
+    this._byId = new Map();
+    this._bySession = new Map();
+
+    const cleanupIntervalMs = positiveInt(options.cleanupIntervalMs, DEFAULT_CLEANUP_INTERVAL_MS);
+    this._cleanupTimer = cleanupIntervalMs > 0
+      ? setInterval(() => this.cleanupExpired(), cleanupIntervalMs)
+      : null;
+    if (this._cleanupTimer && typeof this._cleanupTimer.unref === 'function') this._cleanupTimer.unref();
+
+    this._eventBus = null;
+    this._onControlEvent = null;
+    if (options.eventBus) this.attachEventBus(options.eventBus);
+  }
+
+  attachEventBus(eventBus) {
+    if (!eventBus || typeof eventBus.on !== 'function') return;
+    if (this._eventBus && this._onControlEvent && typeof this._eventBus.removeListener === 'function') {
+      this._eventBus.removeListener('event', this._onControlEvent);
+    }
+    this._eventBus = eventBus;
+    this._onControlEvent = (event) => {
+      if (!event || !event.sessionId || !SESSION_CLEAR_EVENT_KINDS.has(event.kind)) return;
+      this.clearSession(event.sessionId);
+    };
+    eventBus.on('event', this._onControlEvent);
+  }
+
+  close() {
+    if (this._cleanupTimer) clearInterval(this._cleanupTimer);
+    this._cleanupTimer = null;
+    if (this._eventBus && this._onControlEvent && typeof this._eventBus.removeListener === 'function') {
+      this._eventBus.removeListener('event', this._onControlEvent);
+    }
+    this._eventBus = null;
+    this._onControlEvent = null;
+    for (const record of this._byId.values()) {
+      this._finishWaiters(record, { status: 'missing' });
+    }
+    this._byId.clear();
+    this._bySession.clear();
+  }
+
+  register(sessionId, request) {
+    if (!sessionId || typeof sessionId !== 'string') {
+      throw controlError('INVALID_ARGUMENT', 'sessionId is required', 400);
+    }
+    this.cleanupExpired();
+    const normalized = normalizeDecisionRequest(request || {});
+    const now = this._now();
+    const decisionId = this._newDecisionId();
+    const record = {
+      decisionId,
+      sessionId,
+      kind: normalized.kind,
+      request: normalized,
+      status: 'pending',
+      answer: null,
+      createdAt: now,
+      expiresAt: now + this._ttlMs,
+      answeredAt: null,
+      waiters: new Set(),
+    };
+    this._byId.set(decisionId, record);
+    let ids = this._bySession.get(sessionId);
+    if (!ids) {
+      ids = new Set();
+      this._bySession.set(sessionId, ids);
+    }
+    ids.add(decisionId);
+    this.emit('registered', this.snapshot(record));
+    return this.snapshot(record);
+  }
+
+  listPending(sessionId) {
+    this.cleanupExpired();
+    const ids = this._bySession.get(sessionId);
+    if (!ids) return [];
+    const out = [];
+    for (const decisionId of ids) {
+      const record = this._byId.get(decisionId);
+      if (record && record.status === 'pending') out.push(this.snapshot(record));
+    }
+    out.sort((a, b) => a.createdAt - b.createdAt || a.decisionId.localeCompare(b.decisionId));
+    return out;
+  }
+
+  get(decisionId) {
+    this.cleanupExpired();
+    const record = this._byId.get(decisionId);
+    return record ? this.snapshot(record) : null;
+  }
+
+  answer(decisionId, body) {
+    this.cleanupExpired();
+    const record = this._byId.get(decisionId);
+    if (!record) throw controlError('DECISION_NOT_FOUND', 'Unknown or expired decision', 404);
+    if (record.status !== 'pending') {
+      throw controlError('PRECONDITION_FAILED', 'Decision has already been answered', 409);
+    }
+
+    const answer = normalizeAnswer(body || {});
+    const now = this._now();
+    record.status = 'answered';
+    record.answer = answer;
+    record.answeredAt = now;
+    // Keep the answered tombstone long enough for racing await/retry callers to
+    // observe the first answer / 409, while removing it from the pending list.
+    record.expiresAt = Math.max(record.expiresAt, now + this._ttlMs);
+    const payload = { status: 'answered', decision: this.answerSnapshot(record), sessionId: record.sessionId };
+    this._finishWaiters(record, payload);
+    this.emit('answered', this.snapshot(record));
+    return { ok: true };
+  }
+
+  awaitAnswer(decisionId, timeoutMs, options = {}) {
+    this.cleanupExpired();
+    const record = this._byId.get(decisionId);
+    if (!record) return Promise.resolve({ status: 'missing' });
+    if (record.status === 'answered') {
+      return Promise.resolve({ status: 'answered', decision: this.answerSnapshot(record), sessionId: record.sessionId });
+    }
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      return Promise.resolve({ status: 'timeout', sessionId: record.sessionId });
+    }
+
+    const signal = options.signal;
+    if (signal && signal.aborted) return Promise.resolve({ status: 'canceled', sessionId: record.sessionId });
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const waiter = { resolve: null, timer: null, onAbort: null, signal };
+      const finish = (payload) => {
+        if (settled) return;
+        settled = true;
+        record.waiters.delete(waiter);
+        if (waiter.timer) clearTimeout(waiter.timer);
+        if (waiter.signal && waiter.onAbort && typeof waiter.signal.removeEventListener === 'function') {
+          waiter.signal.removeEventListener('abort', waiter.onAbort);
+        }
+        resolve(payload);
+      };
+      waiter.resolve = finish;
+      waiter.timer = setTimeout(() => finish({ status: 'timeout', sessionId: record.sessionId }), Math.trunc(timeoutMs));
+      if (typeof waiter.timer.unref === 'function') waiter.timer.unref();
+      if (signal && typeof signal.addEventListener === 'function') {
+        waiter.onAbort = () => finish({ status: 'canceled', sessionId: record.sessionId });
+        signal.addEventListener('abort', waiter.onAbort, { once: true });
+      }
+      record.waiters.add(waiter);
+    });
+  }
+
+  clearSession(sessionId) {
+    const ids = this._bySession.get(sessionId);
+    if (!ids) return 0;
+    let count = 0;
+    for (const decisionId of Array.from(ids)) {
+      const record = this._byId.get(decisionId);
+      if (record) {
+        this._deleteRecord(record, { status: 'missing' });
+        count++;
+      }
+    }
+    this._bySession.delete(sessionId);
+    return count;
+  }
+
+  cleanupExpired() {
+    const now = this._now();
+    let count = 0;
+    for (const record of Array.from(this._byId.values())) {
+      if (record.expiresAt <= now) {
+        this._deleteRecord(record, { status: 'missing' });
+        count++;
+      }
+    }
+    return count;
+  }
+
+  snapshot(record) {
+    const out = Object.assign({
+      decisionId: record.decisionId,
+      sessionId: record.sessionId,
+      createdAt: record.createdAt,
+      expiresAt: record.expiresAt,
+    }, cloneJson(record.request));
+    if (record.status === 'answered') {
+      out.answeredAt = record.answeredAt;
+    }
+    return out;
+  }
+
+  answerSnapshot(record) {
+    const answer = record.answer || {};
+    const out = {};
+    if (hasOwn(answer, 'choice')) out.choice = cloneJson(answer.choice);
+    if (hasOwn(answer, 'optionValue')) out.optionValue = cloneJson(answer.optionValue);
+    return out;
+  }
+
+  _newDecisionId() {
+    let id;
+    do {
+      id = 'dec_' + crypto.randomBytes(16).toString('hex');
+    } while (this._byId.has(id));
+    return id;
+  }
+
+  _deleteRecord(record, waiterPayload) {
+    this._finishWaiters(record, waiterPayload || { status: 'missing' });
+    this._byId.delete(record.decisionId);
+    const ids = this._bySession.get(record.sessionId);
+    if (ids) {
+      ids.delete(record.decisionId);
+      if (ids.size === 0) this._bySession.delete(record.sessionId);
+    }
+  }
+
+  _finishWaiters(record, payload) {
+    if (!record.waiters || record.waiters.size === 0) return;
+    const waiters = Array.from(record.waiters);
+    record.waiters.clear();
+    for (const waiter of waiters) {
+      if (waiter.timer) clearTimeout(waiter.timer);
+      try { waiter.resolve(payload); } catch (_) { /* ignore */ }
+    }
+  }
+}
+
+function normalizeDecisionRequest(body) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw controlError('INVALID_ARGUMENT', 'Decision body must be an object', 400);
+  }
+  const kind = typeof body.kind === 'string' ? body.kind : '';
+  if (!DECISION_KINDS.includes(kind)) {
+    throw controlError('INVALID_ARGUMENT', 'Decision kind must be tool_approval, plan_approval, or choice_question', 400);
+  }
+
+  const out = { kind };
+  for (const field of ['tool', 'command', 'cwd', 'plan', 'question']) {
+    if (hasOwn(body, field)) out[field] = cloneJson(body[field]);
+  }
+  if (hasOwn(body, 'options')) {
+    if (!Array.isArray(body.options)) {
+      throw controlError('INVALID_ARGUMENT', 'Decision options must be an array', 400);
+    }
+    out.options = body.options.map((option, index) => {
+      if (!option || typeof option !== 'object' || Array.isArray(option)) {
+        throw controlError('INVALID_ARGUMENT', `Decision option ${index} must be an object`, 400);
+      }
+      const label = typeof option.label === 'string' ? option.label.trim() : '';
+      if (!label) throw controlError('INVALID_ARGUMENT', `Decision option ${index} requires a label`, 400);
+      const normalized = { label };
+      if (hasOwn(option, 'description')) normalized.description = option.description == null ? '' : String(option.description);
+      return normalized;
+    });
+  }
+  return out;
+}
+
+function normalizeAnswer(body) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw controlError('INVALID_ARGUMENT', 'Decision answer body must be an object', 400);
+  }
+  const hasChoice = hasOwn(body, 'choice');
+  const hasOptionValue = hasOwn(body, 'optionValue');
+  if (!hasChoice && !hasOptionValue) {
+    throw controlError('INVALID_ARGUMENT', 'Decision answer requires choice or optionValue', 400);
+  }
+  const out = {};
+  if (hasChoice) out.choice = cloneJson(body.choice);
+  if (hasOptionValue) out.optionValue = cloneJson(body.optionValue);
+  return out;
+}
+
+function cloneJson(value) {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value !== 'object') return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function positiveInt(value, fallback) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return fallback;
+  return Math.trunc(n);
+}
+
+function hasOwn(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function controlError(code, message, statusCode) {
+  const err = new Error(message);
+  err.code = code;
+  err.statusCode = statusCode;
+  return err;
+}
+
+module.exports = {
+  DecisionStore,
+  DECISION_KINDS,
+  DEFAULT_DECISION_TTL_MS,
+  DEFAULT_CLEANUP_INTERVAL_MS,
+};

--- a/src/control/event-bus.js
+++ b/src/control/event-bus.js
@@ -55,6 +55,7 @@ const EVENT_KINDS = Object.freeze([
   'crashed',
   'session_created',
   'session_deleted',
+  'decision_pending',
 ]);
 
 class ControlEventBus extends EventEmitter {

--- a/src/control/event-bus.js
+++ b/src/control/event-bus.js
@@ -56,6 +56,7 @@ const EVENT_KINDS = Object.freeze([
   'session_created',
   'session_deleted',
   'decision_pending',
+  'decision_resolved',
 ]);
 
 class ControlEventBus extends EventEmitter {

--- a/src/control/routes.js
+++ b/src/control/routes.js
@@ -35,6 +35,28 @@ const DEFAULT_RATE_LIMIT_MAX = 600;
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 60000;
 const RATE_LIMIT_IDENTITY_CAP = 2000;
 
+// Keystrokes injected into Claude's paused native permission prompt to answer it
+// AS THE USER when the human taps the mobile decision card. The terminal is
+// static at the prompt (the github-router PermissionRequest notifier fired only
+// because Claude showed a dialog), so this is a deterministic write, not a race.
+// accept -> Enter (approve the pre-selected first option); reject -> Esc (deny).
+// These are TUI-invariant keys; overridable via env if Claude's prompt drifts.
+const DECISION_ACCEPT_KEYS = process.env.AIORDIE_DECISION_ACCEPT_KEYS || 'enter';
+const DECISION_REJECT_KEYS = process.env.AIORDIE_DECISION_REJECT_KEYS || 'escape';
+const DECISION_ACCEPT_CHOICES = new Set(['accept', 'approve', 'yes', 'allow']);
+
+// Map a structured mobile answer to the keystroke that answers Claude's native
+// prompt. Only choice-style answers (tool/plan approvals) are injected; an
+// optionValue (multi-option question) has no single-key mapping and returns null.
+function decisionAnswerKeystroke(body) {
+  if (!body || typeof body !== 'object') return null;
+  if (Object.prototype.hasOwnProperty.call(body, 'choice')) {
+    const choice = String(body.choice == null ? '' : body.choice).trim().toLowerCase();
+    return DECISION_ACCEPT_CHOICES.has(choice) ? DECISION_ACCEPT_KEYS : DECISION_REJECT_KEYS;
+  }
+  return null;
+}
+
 function statusForSession(deps, id, session) {
   const signal = (deps.getStatusSignal && deps.getStatusSignal(id)) || {};
   if (signal && typeof signal.then === 'function') {
@@ -379,6 +401,28 @@ function createControlRouter(deps) {
     }
   });
 
+  // POST /sessions/:id/decision-resolved — the github-router PostToolUse hook
+  // signals that a gated tool actually RAN, i.e. the human answered Claude's
+  // native prompt directly (on the desktop) rather than via the phone card. Clear
+  // any pending decision for the session and broadcast so a mirrored card on any
+  // other surface dismisses. No injection (the native answer already ran it);
+  // no-op when nothing is pending (the common case on every tool call).
+  router.post('/sessions/:id/decision-resolved', async (req, res, next) => {
+    try {
+      const id = req.params.id;
+      if (!deps.sessions.has(id)) {
+        return res.status(404).json({ error: { code: 'SESSION_NOT_FOUND', message: 'Unknown session' } });
+      }
+      const resolved = decisionStore.externalResolve(id, 'tool_ran');
+      if (deps.eventBus) {
+        for (const decisionId of resolved) deps.eventBus.append(id, 'decision_resolved', { decisionId });
+      }
+      res.json({ resolved: resolved.length });
+    } catch (err) {
+      sendControlError(res, next, err);
+    }
+  });
+
   // POST /sessions/:id/message — send a user message and optionally await a turn end.
   router.post('/sessions/:id/message', async (req, res, next) => {
     try {
@@ -447,9 +491,31 @@ function createControlRouter(deps) {
   });
 
   // POST /decisions/:decisionId/answer — structured answer from a human client.
+  // The mobile card answers Claude's OWN native prompt: after the atomic
+  // decisionStore.answer() (which enforces first-answer-wins with a 409), inject
+  // the corresponding keystroke into the paused session PTY so Claude proceeds,
+  // then broadcast decision_resolved so any other surface dismisses its card.
   router.post('/decisions/:decisionId/answer', async (req, res, next) => {
     try {
-      const out = decisionStore.answer(req.params.decisionId, req.body || {});
+      const decisionId = req.params.decisionId;
+      // Read the record first for its sessionId; answer() then atomically claims
+      // it (throws 409 if another surface already answered) so we inject at most once.
+      const record = decisionStore.get(decisionId);
+      const out = decisionStore.answer(decisionId, req.body || {});
+      if (record && record.sessionId) {
+        const keys = decisionAnswerKeystroke(req.body || {});
+        if (keys && deps.sendKeys) {
+          try {
+            await deps.sendKeys({ sessionId: record.sessionId, keys });
+          } catch (injErr) {
+            // The decision is already recorded as answered; a failed inject just
+            // means Claude's prompt wasn't driven from here (e.g. session gone).
+            // Surface nothing to the caller — first-answer-wins still holds.
+            if (deps.logError) deps.logError('decision keystroke inject failed', injErr);
+          }
+        }
+        if (deps.eventBus) deps.eventBus.append(record.sessionId, 'decision_resolved', { decisionId });
+      }
       res.json(out);
     } catch (err) {
       sendControlError(res, next, err);

--- a/src/control/routes.js
+++ b/src/control/routes.js
@@ -19,6 +19,7 @@
 //   deps.respond(opts)          -> Promise<object>
 
 const express = require('express');
+const { DecisionStore } = require('./decision-store');
 const { deriveStatus } = require('./session-status');
 
 const DEFAULT_READ_LINES = 80;
@@ -27,6 +28,8 @@ const DEFAULT_MESSAGE_LIMIT = 200;
 const MAX_MESSAGE_LIMIT = 1000;
 const DEFAULT_EVENTS_TIMEOUT_MS = 25000;
 const MAX_EVENTS_TIMEOUT_MS = 60000;
+const DEFAULT_DECISION_AWAIT_TIMEOUT_MS = 25000;
+const MAX_DECISION_AWAIT_TIMEOUT_MS = 60000;
 const ROUTE_IDEMPOTENCY_CAP = 500;
 const DEFAULT_RATE_LIMIT_MAX = 600;
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 60000;
@@ -189,6 +192,7 @@ function createControlRouter(deps) {
   const routeIdempotency = new Map();
   const rateLimitBuckets = new Map();
   const rateLimit = normalizeRateLimit(deps.rateLimit);
+  const decisionStore = deps.decisionStore || new DecisionStore({ eventBus: deps.eventBus });
 
   router.use((req, res, next) => {
     if (isRateLimitExempt(req) || !rateLimit.max || !rateLimit.windowMs) return next();
@@ -343,6 +347,38 @@ function createControlRouter(deps) {
     }
   });
 
+  // POST /sessions/:id/decision — register a structured mobile-mode decision.
+  router.post('/sessions/:id/decision', async (req, res, next) => {
+    try {
+      const id = req.params.id;
+      if (!deps.sessions.has(id)) {
+        return res.status(404).json({ error: { code: 'SESSION_NOT_FOUND', message: 'Unknown session' } });
+      }
+      const body = req.body || {};
+      const out = await routeIdempotent(routeIdempotency, 'decision', id, body.idempotencyKey, () => {
+        const decision = decisionStore.register(id, body);
+        if (deps.eventBus) deps.eventBus.append(id, 'decision_pending', decision);
+        return { decisionId: decision.decisionId };
+      });
+      sendControlResult(res, out);
+    } catch (err) {
+      sendControlError(res, next, err);
+    }
+  });
+
+  // GET /sessions/:id/decisions — currently pending structured decisions.
+  router.get('/sessions/:id/decisions', async (req, res, next) => {
+    try {
+      const id = req.params.id;
+      if (!deps.sessions.has(id)) {
+        return res.status(404).json({ error: { code: 'SESSION_NOT_FOUND', message: 'Unknown session' } });
+      }
+      res.json({ decisions: decisionStore.listPending(id) });
+    } catch (err) {
+      sendControlError(res, next, err);
+    }
+  });
+
   // POST /sessions/:id/message — send a user message and optionally await a turn end.
   router.post('/sessions/:id/message', async (req, res, next) => {
     try {
@@ -406,6 +442,45 @@ function createControlRouter(deps) {
       );
       sendControlResult(res, out);
     } catch (err) {
+      sendControlError(res, next, err);
+    }
+  });
+
+  // POST /decisions/:decisionId/answer — structured answer from a human client.
+  router.post('/decisions/:decisionId/answer', async (req, res, next) => {
+    try {
+      const out = decisionStore.answer(req.params.decisionId, req.body || {});
+      res.json(out);
+    } catch (err) {
+      sendControlError(res, next, err);
+    }
+  });
+
+  // GET /decisions/:decisionId/await?timeoutMs= — bounded long-poll for a structured answer.
+  router.get('/decisions/:decisionId/await', async (req, res, next) => {
+    const controller = new AbortController();
+    let responseOpen = true;
+    const onClose = () => {
+      if (responseOpen) controller.abort();
+    };
+    res.once('close', onClose);
+    try {
+      const timeoutMs = clampInt(req.query.timeoutMs, DEFAULT_DECISION_AWAIT_TIMEOUT_MS, 0, MAX_DECISION_AWAIT_TIMEOUT_MS);
+      const out = await decisionStore.awaitAnswer(req.params.decisionId, timeoutMs, { signal: controller.signal });
+      responseOpen = false;
+      res.removeListener('close', onClose);
+      if (!out || out.status === 'missing') {
+        return res.status(404).json({ error: { code: 'DECISION_NOT_FOUND', message: 'Unknown or expired decision' } });
+      }
+      if (out.status === 'canceled') return;
+      if (out.status === 'answered') {
+        return res.json(Object.assign({ answered: true }, out.decision || {}));
+      }
+      const viewers = deps.getSessionViewerCount ? deps.getSessionViewerCount(out.sessionId) : 0;
+      res.json({ answered: false, viewers });
+    } catch (err) {
+      responseOpen = false;
+      res.removeListener('close', onClose);
       sendControlError(res, next, err);
     }
   });

--- a/src/control/routes.js
+++ b/src/control/routes.js
@@ -10,6 +10,7 @@
 //   deps.sessions               Map<id, session>  (this.claudeSessions)
 //   deps.getStatusSignal(id)    -> { jsonl, renderedTail, exit, hadOutput }  (server-computed)
 //   deps.readTail(id, lines)    -> Promise<{ text, truncated, source }>
+//   deps.readMessages(id, cursor, limit) -> Promise<{ bound, items, cursor, epoch, reset, more }>
 //   deps.eventBus               ControlEventBus
 //   deps.createSession(opts)    -> Promise<{ sessionId, lifecycle }>
 //   deps.stopSession(id, mode, idempotencyKey) -> Promise<{ stopped, lifecycle }>
@@ -22,6 +23,8 @@ const { deriveStatus } = require('./session-status');
 
 const DEFAULT_READ_LINES = 80;
 const MAX_READ_LINES = 2000;
+const DEFAULT_MESSAGE_LIMIT = 200;
+const MAX_MESSAGE_LIMIT = 1000;
 const DEFAULT_EVENTS_TIMEOUT_MS = 25000;
 const MAX_EVENTS_TIMEOUT_MS = 60000;
 const ROUTE_IDEMPOTENCY_CAP = 500;
@@ -87,6 +90,38 @@ function parseCursor(raw) {
 
 function encodeCursor(cursor) {
   return `${cursor.epoch}:${cursor.seq}`;
+}
+
+function parseTurnCursor(raw) {
+  if (!raw) return undefined;
+  if (typeof raw === 'object') return normalizeTurnCursor(raw);
+  const s = String(raw).trim();
+  if (!s) return undefined;
+
+  if (s[0] === '{') {
+    try { return normalizeTurnCursor(JSON.parse(s)); } catch (_) { return undefined; }
+  }
+
+  if (s.includes(':')) {
+    const idx = s.lastIndexOf(':');
+    const epoch = s.slice(0, idx);
+    const offset = Number(s.slice(idx + 1));
+    if (epoch && Number.isSafeInteger(offset) && offset >= 0) return { epoch, offset };
+  }
+
+  try {
+    const obj = JSON.parse(Buffer.from(s, 'base64').toString('utf8'));
+    return normalizeTurnCursor(obj);
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeTurnCursor(obj) {
+  if (!obj || typeof obj.epoch !== 'string') return undefined;
+  const offset = Number(obj.offset);
+  if (!Number.isSafeInteger(offset) || offset < 0) return undefined;
+  return { epoch: obj.epoch, offset };
 }
 
 function clampInt(v, def, min, max) {
@@ -242,6 +277,34 @@ function createControlRouter(deps) {
       if (lines === 0) return res.json({ sessionId: id, text: '', truncated: false, source: 'none', status });
       const tail = await deps.readTail(id, lines);
       res.json({ sessionId: id, text: tail.text, truncated: !!tail.truncated, source: tail.source, status });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // GET /sessions/:id/messages?after=&limit= — durable semantic transcript stream.
+  router.get('/sessions/:id/messages', async (req, res, next) => {
+    try {
+      const id = req.params.id;
+      const session = deps.sessions.get(id);
+      if (!session) return res.status(404).json({ error: { code: 'SESSION_NOT_FOUND', message: 'Unknown session' } });
+      const after = parseTurnCursor(req.query.after);
+      if (req.query.after && after === undefined) {
+        return res.status(400).json({ error: { code: 'INVALID_ARGUMENT', message: 'invalid cursor' } });
+      }
+      const limit = clampInt(req.query.limit, DEFAULT_MESSAGE_LIMIT, 1, MAX_MESSAGE_LIMIT);
+      const out = deps.readMessages
+        ? await deps.readMessages(id, after, limit)
+        : { bound: false, items: [], cursor: null, epoch: null, reset: false, more: false };
+      res.json({
+        sessionId: id,
+        bound: !!out.bound,
+        items: out.items || [],
+        cursor: out.cursor || null,
+        epoch: out.epoch || null,
+        reset: !!out.reset,
+        more: !!out.more,
+      });
     } catch (err) {
       next(err);
     }

--- a/src/control/turn-stream.js
+++ b/src/control/turn-stream.js
@@ -1,0 +1,445 @@
+'use strict';
+
+// Durable semantic reader for Claude Code JSONL transcripts. Unlike the sticky
+// note tailer, this never skips ahead after a large byte gap and never flattens
+// tool/thinking blocks into prose. It reads from a byte cursor, emits stable
+// semantic items, and leaves the cursor at the last complete JSONL line.
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const COMPACT_MARK = ':compact:';
+const TRUNCATED_MARK = ':truncated:';
+const DEFAULT_MAX_BYTES = 4 * 1024 * 1024;
+const DEFAULT_MAX_LINE_BYTES = 1024 * 1024;
+const READ_CHUNK_BYTES = 64 * 1024;
+const MAX_EPOCH_LENGTH = 64;
+const VALID_EPOCH_RE = /^[0-9a-f]{16}(:compact:\d+|:truncated:\d+)?$/;
+const MAX_ID_LENGTH = 200;
+const MAX_SAFE_ID_PART_LENGTH = 80;
+const RESERVED_KEY_IDS = new Set(['__proto__', 'prototype', 'constructor']);
+const BLOCK_INDEX = Symbol('blockIndex');
+
+function basenameAny(file) {
+  return String(file || '').split(/[\\/]/).pop() || '';
+}
+
+function isSessionFileName(name) {
+  return name.endsWith('.jsonl') && !name.startsWith('agent-');
+}
+
+function fileEpoch(file, st) {
+  const identity = [path.resolve(String(file || '')), st && st.dev, st && st.ino, st && st.birthtimeMs].join('|');
+  return crypto.createHash('sha1').update(identity).digest('hex').slice(0, 16);
+}
+
+function epochBase(epoch) {
+  const s = String(epoch || '');
+  for (const mark of [COMPACT_MARK, TRUNCATED_MARK]) {
+    const idx = s.indexOf(mark);
+    if (idx !== -1) return s.slice(0, idx);
+  }
+  return s;
+}
+
+function compactEpoch(baseEpoch, lineOffset) {
+  return `${baseEpoch}${COMPACT_MARK}${lineOffset}`;
+}
+
+function truncatedEpoch(baseEpoch, size) {
+  return `${baseEpoch}${TRUNCATED_MARK}${size}`;
+}
+
+function validEpoch(epoch) {
+  return typeof epoch === 'string' && epoch.length <= MAX_EPOCH_LENGTH && VALID_EPOCH_RE.test(epoch);
+}
+
+function normalizeOffset(value) {
+  const n = Number(value);
+  if (!Number.isSafeInteger(n) || n < 0) return 0;
+  return n;
+}
+
+function normalizeLimit(value) {
+  if (value == null) return Infinity;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return Infinity;
+  return Math.max(1, Math.trunc(n));
+}
+
+function normalizeByteLimit(value, def) {
+  if (value == null) return def;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 1) return def;
+  return Math.max(1, Math.trunc(n));
+}
+
+async function readBoundaryByte(file, offset) {
+  const fh = await fs.promises.open(file, 'r');
+  try {
+    const buf = Buffer.allocUnsafe(1);
+    const out = await fh.read(buf, 0, 1, offset);
+    return out.bytesRead === 1 ? buf[0] : null;
+  } finally {
+    await fh.close();
+  }
+}
+
+async function readRange(file, start, end, opts, onRecord) {
+  const maxBytes = normalizeByteLimit(opts.maxBytes, DEFAULT_MAX_BYTES);
+  const maxLineBytes = Math.min(normalizeByteLimit(opts.maxLineBytes, DEFAULT_MAX_LINE_BYTES), maxBytes);
+  const windowEnd = Math.min(end, start + maxBytes);
+  const chunkBytes = Math.max(1, Math.min(READ_CHUNK_BYTES, maxBytes));
+  let readOffset = start;
+  let lineStart = start;
+  let lineBytes = 0;
+  let lineChunks = [];
+  let oversized = false;
+  let stopped = false;
+  let partialTail = false;
+
+  const fh = await fs.promises.open(file, 'r');
+  try {
+    while (readOffset < windowEnd && !stopped) {
+      const toRead = Math.min(chunkBytes, windowEnd - readOffset);
+      const buf = Buffer.allocUnsafe(toRead);
+      const out = await fh.read(buf, 0, toRead, readOffset);
+      if (!out.bytesRead) break;
+
+      const chunkBase = readOffset;
+      const chunk = out.bytesRead === buf.length ? buf : buf.subarray(0, out.bytesRead);
+      readOffset += out.bytesRead;
+      let segmentStart = 0;
+
+      for (let i = 0; i < chunk.length; i++) {
+        if (chunk[i] !== 0x0a) continue;
+
+        if (!oversized) appendLineBytes(chunk.subarray(segmentStart, i));
+        const lineEnd = chunkBase + i + 1;
+        const obj = oversized ? null : parseLine(lineChunks, lineBytes);
+        const keepGoing = onRecord({ lineStart, lineEnd, obj, oversized });
+        lineStart = lineEnd;
+        lineBytes = 0;
+        lineChunks = [];
+        oversized = false;
+        segmentStart = i + 1;
+        if (keepGoing === false) {
+          stopped = true;
+          break;
+        }
+      }
+
+      if (!stopped && segmentStart < chunk.length) {
+        appendLineBytes(chunk.subarray(segmentStart));
+      }
+    }
+
+    if (!stopped && !oversized && windowEnd < end && readOffset >= windowEnd && lineBytes >= maxLineBytes) {
+      oversized = true;
+      lineChunks = [];
+    }
+
+    if (!stopped && oversized) {
+      const lineEnd = await drainOversizedLine(fh, readOffset, end);
+      if (lineEnd != null) {
+        readOffset = lineEnd;
+        onRecord({ lineStart, lineEnd, obj: null, oversized: true });
+        lineStart = lineEnd;
+        lineBytes = 0;
+        lineChunks = [];
+        oversized = false;
+      } else {
+        partialTail = true;
+      }
+    }
+  } finally {
+    await fh.close();
+  }
+
+  return {
+    readOffset,
+    stopped,
+    partialTail,
+    windowTruncated: !stopped && !partialTail && windowEnd < end && readOffset >= windowEnd,
+  };
+
+  function appendLineBytes(bytes) {
+    if (!bytes.length || oversized) return;
+    lineBytes += bytes.length;
+    if (lineBytes > maxLineBytes) {
+      oversized = true;
+      lineChunks = [];
+      return;
+    }
+    lineChunks.push(Buffer.from(bytes));
+  }
+}
+
+async function drainOversizedLine(fh, offset, end) {
+  const buf = Buffer.allocUnsafe(READ_CHUNK_BYTES);
+  let readOffset = offset;
+  while (readOffset < end) {
+    const toRead = Math.min(buf.length, end - readOffset);
+    const out = await fh.read(buf, 0, toRead, readOffset);
+    if (!out.bytesRead) break;
+    const nl = buf.subarray(0, out.bytesRead).indexOf(0x0a);
+    if (nl !== -1) return readOffset + nl + 1;
+    readOffset += out.bytesRead;
+  }
+  return null;
+}
+
+function parseLine(chunks, length) {
+  if (!length) return null;
+  const line = Buffer.concat(chunks, length).toString('utf8');
+  if (!line.trim()) return null;
+  try { return JSON.parse(line); } catch (_) { return null; }
+}
+
+/**
+ * Read semantic items after a durable cursor. Cursor shape is { epoch, offset },
+ * where offset is a byte offset into the transcript and epoch is the current file
+ * identity plus any same-file compaction generation. Only complete newline-ended
+ * JSONL records are parsed; a trailing partial line is left for the next call.
+ */
+async function readItems(file, cursor, opts = {}) {
+  const limit = normalizeLimit(opts.limit);
+  let st;
+  try {
+    st = await fs.promises.stat(file);
+  } catch {
+    return emptyResult(cursor);
+  }
+
+  const baseEpoch = fileEpoch(file, st);
+  const rawCursorEpoch = cursor && typeof cursor.epoch === 'string' ? cursor.epoch : null;
+  const cursorEpoch = rawCursorEpoch && validEpoch(rawCursorEpoch) ? rawCursorEpoch : null;
+  const invalidEpoch = !!rawCursorEpoch && !cursorEpoch;
+  const epochChanged = invalidEpoch || !!(cursorEpoch && epochBase(cursorEpoch) !== baseEpoch);
+  let epoch = epochChanged ? baseEpoch : (cursorEpoch || baseEpoch);
+  let reset = epochChanged;
+  let start = epochChanged ? 0 : normalizeOffset(cursor && cursor.offset);
+
+  if (!isSessionFileName(basenameAny(file))) {
+    return { items: [], cursor: { epoch, offset: start }, epoch, reset, more: false };
+  }
+
+  if (start > st.size) {
+    reset = true;
+    start = 0;
+    epoch = truncatedEpoch(baseEpoch, st.size);
+  }
+
+  if (start > 0) {
+    let boundary = null;
+    try { boundary = await readBoundaryByte(file, start - 1); } catch (_) { boundary = null; }
+    if (boundary !== 0x0a) {
+      reset = true;
+      start = 0;
+      epoch = truncatedEpoch(baseEpoch, st.size);
+    }
+  }
+
+  if (st.size <= start) {
+    return { items: [], cursor: { epoch, offset: start }, epoch, reset, more: false };
+  }
+
+  const items = [];
+  let nextOffset = start;
+  let more = false;
+
+  const range = await readRange(file, start, st.size, opts, (rec) => {
+    if (isCompactBoundary(rec.obj)) {
+      reset = true;
+      epoch = compactEpoch(baseEpoch, rec.lineStart);
+      items.length = 0;
+      nextOffset = rec.lineEnd;
+      return true;
+    }
+
+    if (rec.oversized || !rec.obj) {
+      nextOffset = rec.lineEnd;
+      return true;
+    }
+
+    const lineItems = itemsForLine(rec.obj, { epoch, lineStart: rec.lineStart });
+    if (!lineItems.length) {
+      nextOffset = rec.lineEnd;
+      return true;
+    }
+
+    if (items.length > 0 && items.length + lineItems.length > limit) {
+      more = true;
+      return false;
+    }
+
+    items.push(...lineItems);
+    nextOffset = rec.lineEnd;
+
+    if (items.length >= limit && rec.lineEnd < st.size) {
+      more = true;
+      return false;
+    }
+
+    return true;
+  });
+
+  if (range.windowTruncated && nextOffset < st.size) more = true;
+
+  return { items, cursor: { epoch, offset: nextOffset }, epoch, reset, more };
+}
+
+function emptyResult(cursor) {
+  const rawEpoch = cursor && typeof cursor.epoch === 'string' ? cursor.epoch : null;
+  const epoch = rawEpoch && validEpoch(rawEpoch) ? rawEpoch : null;
+  const offset = epoch ? normalizeOffset(cursor && cursor.offset) : 0;
+  return { items: [], cursor: epoch ? { epoch, offset } : null, epoch, reset: false, more: false };
+}
+
+function isCompactBoundary(obj) {
+  return !!(obj && obj.type === 'system' && obj.subtype === 'compact_boundary');
+}
+
+function itemsForLine(obj, ctx) {
+  if (!obj || obj.isSidechain) return [];
+  if (obj.type === 'user') return userItems(obj, ctx);
+  if (obj.type === 'assistant') return assistantItems(obj, ctx);
+  return [];
+}
+
+function userItems(obj, ctx) {
+  const content = obj.message && obj.message.content;
+  const out = [];
+  if (typeof content === 'string') {
+    if (content) out.push(baseItem(obj, 'user-text', { text: content }));
+    return assignIds(out, obj, ctx);
+  }
+  if (!Array.isArray(content)) return [];
+
+  for (let i = 0; i < content.length; i++) {
+    const block = content[i];
+    if (!block || typeof block !== 'object') continue;
+    if (block.type === 'text' && typeof block.text === 'string' && block.text) {
+      const item = baseItem(obj, 'user-text', { text: block.text });
+      setBlockIndex(item, i);
+      out.push(item);
+    } else if (block.type === 'tool_result') {
+      const item = baseItem(obj, 'tool-result', {
+        toolUseId: block.tool_use_id || null,
+        content: Object.prototype.hasOwnProperty.call(block, 'content') ? block.content : null,
+        isError: !!block.is_error,
+      });
+      setBlockIndex(item, i);
+      if (Object.prototype.hasOwnProperty.call(obj, 'toolUseResult')) item.toolUseResult = obj.toolUseResult;
+      out.push(item);
+    }
+  }
+  return assignIds(out, obj, ctx);
+}
+
+function assistantItems(obj, ctx) {
+  const content = obj.message && obj.message.content;
+  if (!Array.isArray(content)) return [];
+
+  const out = [];
+  for (let i = 0; i < content.length; i++) {
+    const block = content[i];
+    if (!block || typeof block !== 'object') continue;
+    if (block.type === 'text' && typeof block.text === 'string' && block.text) {
+      const item = baseItem(obj, 'assistant-text', { text: block.text });
+      setBlockIndex(item, i);
+      out.push(item);
+    } else if (block.type === 'tool_use') {
+      const item = baseItem(obj, 'tool-call', {
+        toolUseId: block.id || null,
+        name: block.name || null,
+        input: Object.prototype.hasOwnProperty.call(block, 'input') ? block.input : null,
+      });
+      setBlockIndex(item, i);
+      out.push(item);
+    } else if (block.type === 'thinking') {
+      const item = baseItem(obj, 'thinking', {
+        thinking: typeof block.thinking === 'string' ? block.thinking : '',
+        signature: block.signature || null,
+      });
+      setBlockIndex(item, i);
+      out.push(item);
+    }
+  }
+  return assignIds(out, obj, ctx);
+}
+
+function baseItem(obj, kind, fields) {
+  const item = {
+    id: null,
+    kind,
+    uuid: obj.uuid || null,
+    timestamp: obj.timestamp || null,
+    ...fields,
+  };
+  if (obj.parentUuid) item.parentUuid = obj.parentUuid;
+  if (obj.sessionId) item.sessionId = obj.sessionId;
+  if (obj.cwd) item.cwd = obj.cwd;
+  return item;
+}
+
+function assignIds(items, obj, ctx) {
+  if (!items.length) return items;
+  const lineId = obj.uuid ? baseLineId(obj.uuid) : fallbackLineId(ctx.epoch, ctx.lineStart);
+  if (items.length === 1) {
+    items[0].id = capId(lineId);
+    return items;
+  }
+  for (let i = 0; i < items.length; i++) {
+    items[i].id = joinId(lineId, idPart(items[i], i));
+  }
+  return items;
+}
+
+function baseLineId(value) {
+  let id = capId(safeId(value));
+  if (RESERVED_KEY_IDS.has(id)) id = capId(`id-${id}`);
+  return id;
+}
+
+function fallbackLineId(epoch, lineStart) {
+  const safeEpoch = validEpoch(epoch) ? epoch : '0000000000000000';
+  return capId(`${safeEpoch}:offset:${normalizeOffset(lineStart)}`);
+}
+
+function joinId(base, suffix) {
+  const safeBase = capId(base);
+  const fullSuffix = `:${suffix}`;
+  if (safeBase.length + fullSuffix.length <= MAX_ID_LENGTH) return safeBase + fullSuffix;
+  if (fullSuffix.length >= MAX_ID_LENGTH) return capId(safeBase + fullSuffix);
+  return `${safeBase.slice(0, MAX_ID_LENGTH - fullSuffix.length)}${fullSuffix}`;
+}
+
+function capId(value) {
+  const s = String(value || '');
+  return s.length > MAX_ID_LENGTH ? s.slice(0, MAX_ID_LENGTH) : s;
+}
+
+function setBlockIndex(item, index) {
+  Object.defineProperty(item, BLOCK_INDEX, { value: index, enumerable: false });
+}
+
+function idPart(item, index) {
+  const blockIndex = Number.isSafeInteger(item[BLOCK_INDEX]) ? item[BLOCK_INDEX] : index;
+  if (item.kind === 'tool-call') return `tool-call:${safeId(item.toolUseId)}:${blockIndex}`;
+  if (item.kind === 'tool-result') return `tool-result:${safeId(item.toolUseId)}:${blockIndex}`;
+  return `${item.kind}:${blockIndex}`;
+}
+
+function safeId(value) {
+  const s = String(value || '').replace(/[^a-zA-Z0-9_.-]/g, '-');
+  return (s || 'unknown').slice(0, MAX_SAFE_ID_PART_LENGTH);
+}
+
+module.exports = {
+  readItems,
+  fileEpoch,
+  epochBase,
+  isSessionFileName,
+};

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -204,6 +204,7 @@ class ClaudeCodeWebInterface {
             if (spIdText && spId) { spIdText.textContent = identity; spId.hidden = false; }
         }
         this.setupTerminal();
+        this._setupMobileMode();
         this._setupExtraKeys();
         this._setupOrientationHandler();
         this._setupPwaStandaloneListener();
@@ -950,6 +951,26 @@ class ClaudeCodeWebInterface {
         if (width <= 360) return 12;
         if (width <= 414) return 13;
         return 14;
+    }
+
+    _setupMobileMode() {
+        if (!this.isMobile) return;
+
+        // The new mobile-mode shell is opt-in until the conversation and
+        // decision streams are fully wired and validated.
+        const mobileModeFromUrl = new URLSearchParams(location.search).get('mobileMode') === '1';
+        let mobileModeFromSession = false;
+        try {
+            if (mobileModeFromUrl) sessionStorage.setItem('cc-mobile-mode', '1');
+            mobileModeFromSession = sessionStorage.getItem('cc-mobile-mode') === '1';
+        } catch (_) { /* sessionStorage may be unavailable; URL opt-in still works */ }
+        if (!mobileModeFromUrl && !mobileModeFromSession) return;
+
+        document.body.classList.add('is-mobile');
+
+        if (window.MobileMode && !this.mobileMode) {
+            this.mobileMode = window.MobileMode.init({ app: this, isMobile: true });
+        }
     }
 
     _setupOrientationHandler() {

--- a/src/public/components/artifact-panel.css
+++ b/src/public/components/artifact-panel.css
@@ -9,7 +9,7 @@
   width: 420px;
   max-width: calc(100% - 32px);
   height: 60%;
-  max-height: 80vh;
+  max-height: calc(100dvh - 32px); /* no artificial cap; _clampToBounds keeps it inside the wrapper */
   min-width: 320px;
   min-height: 240px;
   display: flex;
@@ -302,8 +302,8 @@
     bottom: 0 !important;
     width: 100% !important;
     max-width: none;
-    height: 70vh !important;
-    height: 70dvh !important;
+    height: 90vh !important;
+    height: calc(100dvh - var(--sa-top, 0px) - 8px) !important;
     min-width: 0;
     border-radius: 12px 12px 0 0;
     box-sizing: border-box;

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -100,6 +100,7 @@
     <link rel="stylesheet" href="components/keys-panel.css">
     <link rel="stylesheet" href="mobile.css">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="mobile-mode.css">
     <!-- Loaded last: PWA standalone safe-area overrides win over component CSS. -->
     <link rel="stylesheet" href="components/safe-area.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -872,6 +873,7 @@
     <script src="extra-keys.js"></script>
     <script src="keys-panel.js"></script>
     <script src="input-overlay.js"></script>
+    <script src="mobile-mode.js"></script>
     <script src="join-repaint.js"></script>
     <script src="terminal-snapshot-cache.js"></script>
     <script src="app.js"></script>

--- a/src/public/mobile-mode.css
+++ b/src/public/mobile-mode.css
@@ -1393,5 +1393,6 @@ body.is-mobile.mobile-mode-active .mobile-mode .composer-actions {
     animation-iteration-count: 1 !important;
     scroll-behavior: auto !important;
     transition-duration: 1ms !important;
+    transition-delay: 0s !important;
   }
 }

--- a/src/public/mobile-mode.css
+++ b/src/public/mobile-mode.css
@@ -1,0 +1,1397 @@
+/* mobile-mode.css — production mobile client shell extracted from mobile-proto.html.
+   Scoped behind body.is-mobile.mobile-mode-active so desktop remains unaffected. */
+
+body.is-mobile.mobile-mode-active {
+  color-scheme: dark;
+  --safe-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  --safe-right: var(--safe-area-inset-right, env(safe-area-inset-right, 0px));
+  --safe-bottom: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
+  --safe-left: var(--safe-area-inset-left, env(safe-area-inset-left, 0px));
+  --keyboard-bottom: 0px;
+  --mobile-bg: #05070b;
+  --mobile-bg-2: #090d14;
+  --mobile-panel: rgba(14, 20, 30, 0.96);
+  --mobile-panel-solid: #0e141e;
+  --mobile-panel-2: #111a27;
+  --mobile-stroke: rgba(132, 151, 176, 0.18);
+  --mobile-stroke-strong: rgba(159, 178, 210, 0.28);
+  --mobile-text: #edf4ff;
+  --mobile-muted: #8e9bb0;
+  --mobile-faint: #5f6c80;
+  --mobile-accent: #ff8a2a;
+  --mobile-accent-2: #ffd29c;
+  --mobile-green: #48d597;
+  --mobile-green-2: #133a2b;
+  --mobile-blue: #77b7ff;
+  --mobile-red: #ff5d5d;
+  --mobile-red-2: #441417;
+  --mobile-yellow: #ffd166;
+  --mobile-shadow: 0 24px 70px rgba(0, 0, 0, 0.56);
+  --mobile-radius: 24px;
+  --mobile-header-height: 50px;
+  --mobile-input-height: 64px;
+  --mobile-status-height: 28px;
+  --mobile-dock-bottom: calc(var(--safe-bottom) + var(--keyboard-bottom) + 8px);
+  --mobile-sheet-bottom: calc(var(--safe-bottom) + var(--keyboard-bottom) + 8px);
+  --mobile-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --mobile-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% -10%, rgba(255, 138, 42, 0.18), transparent 34%),
+    radial-gradient(circle at 85% 15%, rgba(119, 183, 255, 0.10), transparent 28%),
+    var(--mobile-bg);
+}
+
+body.is-mobile.mobile-mode-active #app {
+  position: fixed;
+  inset: 0;
+  display: block;
+  height: 100dvh;
+  min-height: 100svh;
+  max-height: none;
+  padding: 0 !important;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(13, 19, 29, 0.65), rgba(5, 7, 11, 0.94)),
+    repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.015) 0 1px, transparent 1px 3px);
+}
+
+body.is-mobile.mobile-mode-active #app > :not(.mobile-mode) {
+  display: none !important;
+}
+
+body.is-mobile.mobile-mode-active .mode-switcher,
+body.is-mobile.mobile-mode-active .keys-panel-fab,
+body.is-mobile.mobile-mode-active .keys-panel,
+body.is-mobile.mobile-mode-active .keys-panel__backdrop,
+body.is-mobile.mobile-mode-active .extra-keys-bar {
+  display: none !important;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode,
+body.is-mobile.mobile-mode-active .mobile-mode * {
+  box-sizing: border-box;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode[hidden] {
+  display: none !important;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-overlay, 300);
+  width: 100%;
+  height: 100dvh;
+  min-height: 100svh;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  color: var(--mobile-text);
+  font-family: var(--mobile-sans);
+  font-size: 15px;
+  line-height: 1.42;
+  -webkit-font-smoothing: antialiased;
+  isolation: isolate;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode button,
+body.is-mobile.mobile-mode-active .mobile-mode textarea,
+body.is-mobile.mobile-mode-active .mobile-mode input {
+  font: inherit;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode button {
+  border: 0;
+  min-height: 44px;
+  color: inherit;
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode textarea {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode [hidden] {
+  display: none !important;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .app-shell {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  max-width: 1240px;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .conversation-pane {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(12, 17, 25, 0.94), rgba(5, 8, 13, 0.98)),
+    radial-gradient(circle at 20% 8%, rgba(255, 138, 42, 0.10), transparent 30%);
+  transition: filter 220ms ease, transform 220ms ease;
+}
+
+body.is-mobile.mobile-mode-active.has-surface .mobile-mode .conversation-pane {
+  filter: saturate(0.82) brightness(0.62);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .topbar {
+  position: relative;
+  flex: 0 0 calc(var(--safe-top) + var(--mobile-header-height));
+  min-height: calc(var(--safe-top) + var(--mobile-header-height));
+  padding: var(--safe-top) max(12px, calc(var(--safe-right) + 12px)) 0 max(12px, calc(var(--safe-left) + 12px));
+  display: flex;
+  align-items: flex-end;
+  border-bottom: 1px solid rgba(132, 151, 176, 0.12);
+  background: rgba(7, 10, 15, 0.82);
+  backdrop-filter: blur(18px) saturate(130%);
+  -webkit-backdrop-filter: blur(18px) saturate(130%);
+  z-index: 5;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .topbar-inner {
+  width: 100%;
+  min-height: var(--mobile-header-height);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .session-mark {
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  flex: 0 0 28px;
+  color: #070a0f;
+  font-family: var(--mobile-mono);
+  font-size: 15px;
+  font-weight: 900;
+  background: linear-gradient(135deg, var(--mobile-accent), #ffcf7a);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.10), 0 8px 24px rgba(255, 138, 42, 0.20);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .session-title {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .session-name {
+  color: var(--mobile-text);
+  font-weight: 760;
+  letter-spacing: -0.01em;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .session-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--mobile-muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .mode-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 99px;
+  background: var(--mobile-green);
+  box-shadow: 0 0 10px rgba(72, 213, 151, 0.75);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .overflow-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: transparent;
+  color: var(--mobile-muted);
+  font-size: 24px;
+  line-height: 1;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .overflow-btn:active {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .needs-pill {
+  position: absolute;
+  top: calc(var(--safe-top) + var(--mobile-header-height) + 8px);
+  right: max(12px, calc(var(--safe-right) + 12px));
+  z-index: 6;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 32px;
+  padding: 6px 11px;
+  border: 1px solid rgba(255, 209, 102, 0.34);
+  border-radius: 999px;
+  background: rgba(39, 28, 10, 0.86);
+  color: #ffdf8d;
+  font-size: 12px;
+  font-weight: 760;
+  letter-spacing: 0.01em;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  transform: translateY(-4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+body.is-mobile.mobile-mode-active.has-decision .mobile-mode .needs-pill {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .needs-pill .pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--mobile-yellow);
+  box-shadow: 0 0 0 0 rgba(255, 209, 102, 0.65);
+  animation: mobile-mode-pulse 1.8s infinite;
+}
+
+@keyframes mobile-mode-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(255, 209, 102, 0.55); }
+  70% { box-shadow: 0 0 0 8px rgba(255, 209, 102, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(255, 209, 102, 0); }
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .message-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  padding: 14px max(14px, calc(var(--safe-right) + 14px)) calc(var(--safe-bottom) + var(--keyboard-bottom) + var(--mobile-input-height) + var(--mobile-status-height) + 34px) max(14px, calc(var(--safe-left) + 14px));
+  scroll-padding-bottom: calc(var(--safe-bottom) + var(--keyboard-bottom) + var(--mobile-input-height) + 60px);
+}
+
+body.is-mobile.mobile-mode-active.has-surface .mobile-mode .message-list {
+  pointer-events: none;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .message-stack {
+  max-width: 820px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .message-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .message-row.user {
+  justify-content: flex-end;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .message-row.assistant {
+  justify-content: flex-start;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .bubble {
+  max-width: min(84vw, 640px);
+  border-radius: 20px;
+  padding: 11px 13px;
+  border: 1px solid rgba(132, 151, 176, 0.13);
+  box-shadow: 0 8px 26px rgba(0, 0, 0, 0.20);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .user .bubble {
+  border-bottom-right-radius: 8px;
+  color: #07100c;
+  background: linear-gradient(135deg, #79e8af, #3fcf88);
+  border-color: rgba(121, 232, 175, 0.50);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .assistant .bubble {
+  border-bottom-left-radius: 8px;
+  color: #dce7f7;
+  background: rgba(17, 25, 37, 0.92);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .bubble p {
+  margin: 0;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .message-label {
+  margin: 0 0 4px;
+  color: var(--mobile-faint);
+  font-size: 11px;
+  font-weight: 680;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .event-row {
+  justify-content: center;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .event-chip {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 10px;
+  border: 1px solid rgba(132, 151, 176, 0.14);
+  border-radius: 999px;
+  color: var(--mobile-muted);
+  background: rgba(255, 255, 255, 0.035);
+  font-size: 12px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-card {
+  align-self: stretch;
+  max-width: min(100%, 760px);
+  margin: 0 auto;
+  border: 1px solid rgba(132, 151, 176, 0.16);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(12, 20, 31, 0.96), rgba(9, 14, 22, 0.96));
+  overflow: hidden;
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-summary {
+  width: 100%;
+  min-height: 50px;
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  background: transparent;
+  color: #dce7f7;
+  text-align: left;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-summary:active {
+  background: rgba(255, 255, 255, 0.045);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-disclosure {
+  color: var(--mobile-accent);
+  font-size: 15px;
+  transform-origin: 50% 50%;
+  transition: transform 160ms ease;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-card.expanded .tool-disclosure {
+  transform: rotate(90deg);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-line {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-weight: 710;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-line code {
+  font-family: var(--mobile-mono);
+  color: var(--mobile-accent-2);
+  font-size: 0.92em;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-result {
+  flex: 0 0 auto;
+  min-width: 28px;
+  color: var(--mobile-green);
+  text-align: right;
+  font-weight: 900;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-result.error {
+  color: var(--mobile-red);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-details {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 190ms ease;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-details > div {
+  overflow: hidden;
+  border-top: 1px solid transparent;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-card.expanded .tool-details {
+  grid-template-rows: 1fr;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-card.expanded .tool-details > div {
+  border-top-color: rgba(132, 151, 176, 0.12);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .tool-body {
+  padding: 11px 12px 13px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .detail-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 10px;
+  color: var(--mobile-muted);
+  font-size: 12px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .detail-grid code,
+body.is-mobile.mobile-mode-active .mobile-mode .terminal-output,
+body.is-mobile.mobile-mode-active .mobile-mode .diff-output {
+  font-family: var(--mobile-mono);
+  font-size: 12px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .detail-grid code {
+  color: #dbe7f5;
+  overflow-wrap: anywhere;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .terminal-output,
+body.is-mobile.mobile-mode-active .mobile-mode .diff-output {
+  margin: 10px 0 0;
+  padding: 10px;
+  border: 1px solid rgba(132, 151, 176, 0.13);
+  border-radius: 12px;
+  overflow-x: auto;
+  color: #b9c7d9;
+  background: rgba(0, 0, 0, 0.24);
+  line-height: 1.45;
+  white-space: pre;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .diff-output .add {
+  color: #76f2ae;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .diff-output .del {
+  color: #ff8c8c;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .status-line {
+  position: absolute;
+  left: max(14px, calc(var(--safe-left) + 14px));
+  right: max(14px, calc(var(--safe-right) + 14px));
+  bottom: calc(var(--mobile-dock-bottom) + var(--mobile-input-height) + 2px);
+  z-index: 7;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .status-chip {
+  min-height: var(--mobile-status-height);
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 10px;
+  border: 1px solid rgba(132, 151, 176, 0.13);
+  border-radius: 999px;
+  color: var(--mobile-muted);
+  background: rgba(7, 10, 15, 0.74);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  font-size: 12px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 99px;
+  background: var(--mobile-green);
+  box-shadow: 0 0 10px rgba(72, 213, 151, 0.55);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .status-chip.working .status-dot {
+  background: var(--mobile-accent);
+  animation: mobile-mode-blink 1s infinite alternate;
+}
+
+@keyframes mobile-mode-blink {
+  from { opacity: 0.35; }
+  to { opacity: 1; }
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .input-dock {
+  position: absolute;
+  left: max(10px, calc(var(--safe-left) + 10px));
+  right: max(10px, calc(var(--safe-right) + 10px));
+  bottom: var(--mobile-dock-bottom);
+  z-index: 8;
+  min-height: var(--mobile-input-height);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  max-width: 860px;
+  margin-inline: auto;
+  transition: opacity 170ms ease, transform 170ms ease;
+}
+
+body.is-mobile.mobile-mode-active.has-surface .mobile-mode .input-dock {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(10px);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .mobile-compose-fab {
+  width: 58px;
+  height: 58px;
+  border-radius: 20px;
+  display: grid;
+  place-items: center;
+  color: #09120d;
+  border: 1px solid rgba(84, 229, 151, 0.55);
+  background: linear-gradient(135deg, #6df0aa, #35c77e);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.34), 0 10px 24px rgba(72, 213, 151, 0.16);
+  font-size: 25px;
+  font-weight: 900;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .input-field {
+  min-width: 0;
+  height: 52px;
+  padding: 0 14px;
+  border: 1px solid rgba(132, 151, 176, 0.18);
+  border-radius: 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--mobile-muted);
+  text-align: left;
+  background: rgba(12, 18, 27, 0.94);
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.32);
+  backdrop-filter: blur(18px) saturate(130%);
+  -webkit-backdrop-filter: blur(18px) saturate(130%);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .input-cursor {
+  width: 2px;
+  height: 18px;
+  border-radius: 2px;
+  background: var(--mobile-accent);
+  opacity: 0.85;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .round-btn {
+  width: 48px;
+  height: 48px;
+  border-radius: 17px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(132, 151, 176, 0.17);
+  background: rgba(12, 18, 27, 0.94);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.26);
+  color: #dce7f7;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .round-btn.primary {
+  color: #09120d;
+  border-color: rgba(84, 229, 151, 0.55);
+  background: linear-gradient(135deg, #6df0aa, #35c77e);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .round-btn:active,
+body.is-mobile.mobile-mode-active .mobile-mode .mobile-compose-fab:active {
+  transform: translateY(1px);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  background: rgba(0, 0, 0, 0.54);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease;
+}
+
+body.is-mobile.mobile-mode-active.has-surface .mobile-mode .backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .surface-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  pointer-events: none;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .side-placeholder {
+  display: none;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .sheet,
+body.is-mobile.mobile-mode-active .mobile-mode .full-sheet {
+  pointer-events: auto;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(calc(100% + var(--safe-bottom) + 20px));
+  transition: transform 260ms cubic-bezier(.2, .9, .2, 1), opacity 200ms ease, visibility 0s linear 260ms;
+  will-change: transform;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .sheet.active,
+body.is-mobile.mobile-mode-active .mobile-mode .full-sheet.active {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  transition-delay: 0s;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .sheet {
+  position: fixed;
+  left: max(10px, calc(var(--safe-left) + 10px));
+  right: max(10px, calc(var(--safe-right) + 10px));
+  bottom: var(--mobile-sheet-bottom);
+  max-height: min(78dvh, calc(100dvh - var(--safe-top) - var(--safe-bottom) - var(--keyboard-bottom) - 18px), 680px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--mobile-stroke-strong);
+  border-radius: var(--mobile-radius);
+  background: linear-gradient(180deg, rgba(18, 26, 38, 0.98), rgba(9, 13, 20, 0.98));
+  box-shadow: var(--mobile-shadow);
+  backdrop-filter: blur(26px) saturate(135%);
+  -webkit-backdrop-filter: blur(26px) saturate(135%);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .sheet.nudge {
+  animation: mobile-mode-nudge 190ms ease;
+}
+
+@keyframes mobile-mode-nudge {
+  0%, 100% { transform: translateY(0); }
+  35% { transform: translateY(5px); }
+  70% { transform: translateY(-2px); }
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .sheet-grip {
+  align-self: center;
+  width: 42px;
+  height: 5px;
+  margin: 9px 0 7px;
+  border-radius: 999px;
+  background: rgba(159, 178, 210, 0.38);
+  cursor: grab;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .sheet-head {
+  padding: 0 16px 10px;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .sheet-title {
+  flex: 1;
+  min-width: 0;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .eyebrow {
+  margin: 0 0 2px;
+  color: var(--mobile-muted);
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .sheet h2,
+body.is-mobile.mobile-mode-active .mobile-mode .full-sheet h2 {
+  margin: 0;
+  color: var(--mobile-text);
+  font-size: 21px;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .sheet-subtitle {
+  margin: 0;
+  color: var(--mobile-muted);
+  font-size: 13px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .close-btn {
+  position: static;
+  top: auto;
+  right: auto;
+  transform: none;
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  border-radius: 15px;
+  color: var(--mobile-muted);
+  background: rgba(255, 255, 255, 0.045);
+  font-size: 20px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .close-btn:active {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .sheet-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 0 16px 14px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .command-box {
+  margin-top: 12px;
+  max-height: 116px;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  border: 1px solid rgba(255, 138, 42, 0.26);
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.30);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .command-box code {
+  display: block;
+  min-width: max-content;
+  padding: 13px;
+  color: #ffe2bd;
+  font-family: var(--mobile-mono);
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .cwd-line,
+body.is-mobile.mobile-mode-active .mobile-mode .risk-line {
+  display: flex;
+  gap: 8px;
+  margin: 10px 2px 0;
+  color: var(--mobile-muted);
+  font-size: 12px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .cwd-line code {
+  min-width: 0;
+  color: #dce7f7;
+  font-family: var(--mobile-mono);
+  overflow-wrap: anywhere;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .risk-line strong {
+  color: #ffddad;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .countdown {
+  margin-top: 14px;
+  padding: 11px;
+  border: 1px solid rgba(255, 209, 102, 0.18);
+  border-radius: 15px;
+  background: rgba(255, 209, 102, 0.06);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .countdown-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: #ffdf8d;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .countdown small {
+  color: var(--mobile-muted);
+  font-weight: 600;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .countdown-track {
+  position: relative;
+  height: 5px;
+  margin-top: 9px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .countdown-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  transform: scaleX(var(--mobile-countdown-pct, 1));
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--mobile-yellow), var(--mobile-accent), var(--mobile-red));
+  transition: transform 240ms linear;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .raw-link {
+  min-height: 44px;
+  padding: 0;
+  color: var(--mobile-blue);
+  background: transparent;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .raw-box {
+  margin: 0 0 12px;
+  max-height: 150px;
+  overflow: auto;
+  padding: 11px;
+  border: 1px solid rgba(132, 151, 176, 0.16);
+  border-radius: 14px;
+  color: #bdcadc;
+  background: rgba(0, 0, 0, 0.25);
+  font-family: var(--mobile-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  white-space: pre;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .sheet-actions {
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  padding: 10px 16px calc(16px + max(0px, var(--safe-bottom)));
+  border-top: 1px solid rgba(132, 151, 176, 0.12);
+  background: rgba(8, 12, 18, 0.86);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .btn {
+  min-height: 50px;
+  border-radius: 16px;
+  border: 1px solid rgba(132, 151, 176, 0.18);
+  background: rgba(255, 255, 255, 0.055);
+  color: var(--mobile-text);
+  font-weight: 780;
+  letter-spacing: -0.01em;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .btn:active {
+  transform: translateY(1px);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .btn.safe {
+  color: #07120d;
+  border-color: rgba(98, 236, 162, 0.62);
+  background: linear-gradient(135deg, #80efb4, #3cca82);
+  box-shadow: 0 10px 24px rgba(72, 213, 151, 0.16);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .btn.danger {
+  color: #fff4f4;
+  border-color: rgba(255, 93, 93, 0.60);
+  background: linear-gradient(135deg, #d93540, #8d1b21);
+  box-shadow: 0 12px 28px rgba(255, 93, 93, 0.16);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .btn.primary {
+  color: #07101b;
+  border-color: rgba(119, 183, 255, 0.58);
+  background: linear-gradient(135deg, #9ed0ff, #62a9ff);
+  box-shadow: 0 12px 28px rgba(119, 183, 255, 0.14);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .btn.ghost {
+  color: #dce7f7;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .btn.warn {
+  color: #140d04;
+  background: linear-gradient(135deg, #ffd889, #ff9b2f);
+  border-color: rgba(255, 209, 102, 0.55);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .full-sheet {
+  position: fixed;
+  inset: 0;
+  height: 100dvh;
+  min-height: 100svh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: linear-gradient(180deg, #111926, #070a0f 70%);
+  box-shadow: var(--mobile-shadow);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .plan-header {
+  flex: 0 0 auto;
+  padding: calc(var(--safe-top) + 10px) max(16px, calc(var(--safe-right) + 16px)) 12px max(16px, calc(var(--safe-left) + 16px));
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-bottom: 1px solid rgba(132, 151, 176, 0.14);
+  background: rgba(10, 15, 23, 0.92);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  z-index: 2;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .plan-header h2 {
+  flex: 1;
+  font-size: 19px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .plan-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 18px max(16px, calc(var(--safe-right) + 16px)) 18px max(16px, calc(var(--safe-left) + 16px));
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .plan-doc {
+  max-width: 760px;
+  margin: 0 auto;
+  color: #dbe6f4;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .plan-doc h3 {
+  margin: 20px 0 8px;
+  color: #fff4df;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .plan-doc h3:first-child {
+  margin-top: 0;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .plan-doc p {
+  margin: 0 0 10px;
+  color: #aebbd0;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .checklist {
+  display: grid;
+  gap: 9px;
+  margin: 12px 0 4px;
+  padding: 0;
+  list-style: none;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .checklist li {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 8px;
+  align-items: start;
+  padding: 10px;
+  border: 1px solid rgba(132, 151, 176, 0.13);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .box-check {
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  color: #07120d;
+  background: var(--mobile-green);
+  font-size: 13px;
+  font-weight: 900;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .fake-diff {
+  margin: 12px 0 0;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid rgba(132, 151, 176, 0.16);
+  border-radius: 15px;
+  background: rgba(0, 0, 0, 0.30);
+  color: #b9c8db;
+  font-family: var(--mobile-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .fake-diff .add {
+  color: #76f2ae;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .fake-diff .context {
+  color: #78869a;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .plan-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 3;
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1.1fr;
+  gap: 9px;
+  padding: 10px max(16px, calc(var(--safe-right) + 16px)) calc(12px + var(--safe-bottom)) max(16px, calc(var(--safe-left) + 16px));
+  border-top: 1px solid rgba(132, 151, 176, 0.14);
+  background: rgba(8, 12, 18, 0.92);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .option-list {
+  display: grid;
+  gap: 9px;
+  margin: 14px 0 18px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .option-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 26px 1fr;
+  gap: 10px;
+  align-items: start;
+  min-height: 58px;
+  padding: 12px;
+  border: 1px solid rgba(132, 151, 176, 0.15);
+  border-radius: 17px;
+  background: rgba(255, 255, 255, 0.035);
+  color: #dbe7f5;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .option-card input {
+  width: 22px;
+  height: 22px;
+  margin: 1px 0 0;
+  accent-color: var(--mobile-accent);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .option-card strong {
+  display: block;
+  margin-bottom: 2px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .option-card span span {
+  display: block;
+  color: var(--mobile-muted);
+  font-size: 12px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .option-card.is-selected {
+  border-color: rgba(255, 138, 42, 0.55);
+  background: rgba(255, 138, 42, 0.10);
+  box-shadow: 0 0 0 1px rgba(255, 138, 42, 0.10) inset;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .variant-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .variant-title h3 {
+  margin: 0;
+  font-size: 15px;
+  color: #fff4df;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .variant-title small {
+  color: var(--mobile-muted);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .composer-sheet {
+  max-height: min(70dvh, calc(100dvh - var(--safe-top) - var(--safe-bottom) - var(--keyboard-bottom) - 14px), 560px);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .composer-body {
+  display: grid;
+  gap: 12px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .composer-textarea {
+  width: 100%;
+  min-height: 132px;
+  max-height: 32dvh;
+  resize: none;
+  padding: 13px;
+  border: 1px solid rgba(132, 151, 176, 0.18);
+  border-radius: 17px;
+  outline: none;
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--mobile-text);
+  font-family: var(--mobile-sans);
+  line-height: 1.45;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .composer-textarea:focus {
+  border-color: rgba(255, 138, 42, 0.55);
+  box-shadow: 0 0 0 3px rgba(255, 138, 42, 0.12);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .control-row {
+  display: grid;
+  grid-template-columns: 48px 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .control-btn {
+  min-height: 44px;
+  border: 1px solid rgba(132, 151, 176, 0.15);
+  border-radius: 15px;
+  color: #dce7f7;
+  background: rgba(255, 255, 255, 0.05);
+  font-weight: 750;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .slash-btn {
+  font-family: var(--mobile-mono);
+  font-size: 22px;
+  color: var(--mobile-accent-2);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .mode-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 12px;
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .toggle-light {
+  width: 9px;
+  height: 9px;
+  border-radius: 99px;
+  background: var(--mobile-green);
+  box-shadow: 0 0 10px rgba(72, 213, 151, 0.6);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .stop-btn {
+  padding: 0 12px;
+  color: #ffd7d7;
+  border-color: rgba(255, 93, 93, 0.28);
+  background: rgba(255, 93, 93, 0.10);
+}
+
+body.is-mobile.mobile-mode-active .mobile-mode .composer-actions {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  gap: 9px;
+}
+
+@media (orientation: landscape) and (max-height: 520px) {
+  body.is-mobile.mobile-mode-active .mobile-mode .topbar {
+    flex-basis: calc(var(--safe-top) + 44px);
+    min-height: calc(var(--safe-top) + 44px);
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .topbar-inner {
+    min-height: 44px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .message-list {
+    padding-top: 10px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .sheet {
+    left: auto;
+    right: max(10px, calc(var(--safe-right) + 10px));
+    width: min(560px, calc(100vw - var(--safe-left) - var(--safe-right) - 20px));
+    max-height: calc(100dvh - var(--safe-top) - var(--safe-bottom) - var(--keyboard-bottom) - 16px);
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .full-sheet {
+    inset: calc(var(--safe-top) + 8px) max(8px, calc(var(--safe-right) + 8px)) calc(var(--safe-bottom) + 8px) max(8px, calc(var(--safe-left) + 8px));
+    height: auto;
+    min-height: 0;
+    border: 1px solid var(--mobile-stroke-strong);
+    border-radius: 24px;
+    overflow: hidden;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .plan-header {
+    padding-top: 10px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .plan-footer {
+    padding-bottom: 10px;
+  }
+}
+
+@media (min-width: 760px) and (min-height: 620px) {
+  body.is-mobile.mobile-mode-active.has-surface .mobile-mode .conversation-pane {
+    filter: none;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .app-shell {
+    display: grid;
+    grid-template-columns: minmax(360px, 0.98fr) minmax(360px, 0.88fr);
+    gap: 16px;
+    padding: max(16px, var(--safe-top)) max(16px, var(--safe-right)) max(16px, var(--safe-bottom)) max(16px, var(--safe-left));
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .conversation-pane {
+    position: relative;
+    border: 1px solid rgba(132, 151, 176, 0.16);
+    border-radius: 28px;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.40);
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .topbar {
+    flex-basis: var(--mobile-header-height);
+    min-height: var(--mobile-header-height);
+    padding: 0 14px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .message-list {
+    padding: 16px 16px 128px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .needs-pill {
+    top: 62px;
+    right: 18px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .input-dock {
+    left: 16px;
+    right: 16px;
+    bottom: 14px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .status-line {
+    left: 16px;
+    right: 16px;
+    bottom: 80px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .backdrop {
+    display: none;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .surface-layer {
+    position: relative;
+    inset: auto;
+    z-index: 1;
+    display: flex;
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid rgba(132, 151, 176, 0.16);
+    border-radius: 28px;
+    background: rgba(7, 10, 15, 0.56);
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.34);
+    pointer-events: auto;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .side-placeholder {
+    width: 100%;
+    min-height: 100%;
+    display: grid;
+    place-items: center;
+    padding: 28px;
+    color: var(--mobile-muted);
+    text-align: center;
+  }
+
+  body.is-mobile.mobile-mode-active.has-surface .mobile-mode .side-placeholder {
+    display: none;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .side-placeholder strong {
+    display: block;
+    margin-bottom: 6px;
+    color: #eaf2ff;
+    font-size: 18px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .sheet,
+  body.is-mobile.mobile-mode-active .mobile-mode .full-sheet {
+    position: absolute;
+    inset: 0;
+    width: auto;
+    max-height: none;
+    height: auto;
+    min-height: 0;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    transform: translateX(18px);
+    background: linear-gradient(180deg, rgba(18, 26, 38, 0.98), rgba(9, 13, 20, 0.98));
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .sheet.active,
+  body.is-mobile.mobile-mode-active .mobile-mode .full-sheet.active {
+    transform: translateX(0);
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .sheet-grip {
+    display: none;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .sheet-head {
+    padding-top: 18px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .sheet-actions {
+    padding-bottom: 16px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .plan-header {
+    padding: 16px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .plan-scroll {
+    padding: 18px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .plan-footer {
+    padding: 12px 16px 16px;
+  }
+}
+
+@media (min-width: 1100px) {
+  body.is-mobile.mobile-mode-active .mobile-mode .app-shell {
+    max-width: 1180px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .message-stack {
+    max-width: 780px;
+  }
+
+  body.is-mobile.mobile-mode-active .mobile-mode .bubble {
+    max-width: 640px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.is-mobile.mobile-mode-active .mobile-mode,
+  body.is-mobile.mobile-mode-active .mobile-mode *,
+  body.is-mobile.mobile-mode-active .mobile-mode *::before,
+  body.is-mobile.mobile-mode-active .mobile-mode *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}

--- a/src/public/mobile-mode.js
+++ b/src/public/mobile-mode.js
@@ -11,7 +11,7 @@
 (function () {
   var controller = null;
   var TURN_PAGE_LIMIT = 200;
-  var CONTROL_EVENT_KINDS = 'turn_ended,became_busy,became_idle,waiting_input,decision_pending';
+  var CONTROL_EVENT_KINDS = 'turn_ended,became_busy,became_idle,waiting_input,decision_pending,decision_resolved';
   var CONTROL_EVENTS_TIMEOUT_MS = 25000;
   var SESSION_WATCH_MS = 500;
   var EVENT_RETRY_MS = 1200;
@@ -650,6 +650,14 @@
     if (!event || !event.kind) return;
     if (event.kind === 'decision_pending') {
       this._scheduleDecisionLoad(this._streamGeneration);
+      return;
+    }
+    if (event.kind === 'decision_resolved') {
+      var detail = event.detail || {};
+      var decisionId = detail.decisionId;
+      var matchesCurrent = this.currentDecision && String(this.currentDecision.decisionId || '') === String(decisionId || '');
+      var matchesPending = findDecision(this.pendingDecisions, decisionId);
+      if (decisionId && (matchesCurrent || matchesPending)) this._completeDecision(decisionId, true, 'idle');
       return;
     }
     if (event.kind === 'became_busy') {

--- a/src/public/mobile-mode.js
+++ b/src/public/mobile-mode.js
@@ -1,0 +1,1176 @@
+'use strict';
+
+/*
+ * mobile-mode.js — hook-independent mobile client shell.
+ *
+ * The production data seams are intentionally local stubs in this increment:
+ *   - turn stream items: {id, kind:'user-text'|'assistant-text'|'tool-call'|
+ *     'tool-result'|'thinking', text?, toolUseId?, name?, input?, content?, isError?}
+ *   - decision sheet data: {kind, tool, command, cwd, plan, question,
+ *     options:[{label, description}]}
+ *
+ * TODO(wire): Replace the stubs with the control-plane message stream and hook
+ * decision payloads when those endpoints/channels land. Do not invent fetches in
+ * this shell; it only renders data handed to it and sends Channel-2 input bytes.
+ */
+(function () {
+  var controller = null;
+
+  var STUB_TURN_STREAM = [
+    {
+      id: 'stub-user-1',
+      kind: 'user-text',
+      text: 'Can you prep mobile mode before wiring the backend? I need to feel the permission gates on an iPhone.'
+    },
+    {
+      id: 'stub-assistant-1',
+      kind: 'assistant-text',
+      text: 'I\u2019ll keep this shell hook-independent: conversation rendering, approval sheets, questions, plan review, and a keyboard-safe composer.'
+    },
+    {
+      id: 'stub-tool-call-1',
+      kind: 'tool-call',
+      toolUseId: 'stub-tool-1',
+      name: 'Bash',
+      input: { command: 'npm test', cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die' }
+    },
+    {
+      id: 'stub-tool-result-1',
+      kind: 'tool-result',
+      toolUseId: 'stub-tool-1',
+      content: 'PASS test/mobile-layout.test.js\nPASS test/tool-permission.test.js\n\n38 passed, 0 failed',
+      isError: false
+    },
+    {
+      id: 'stub-thinking-1',
+      kind: 'thinking',
+      text: 'Mapping the next mobile surface without touching backend hooks.'
+    },
+    {
+      id: 'stub-assistant-2',
+      kind: 'assistant-text',
+      text: 'The real message stream will attach at the TODO(wire) seam; for now this is a documented stub contract.'
+    }
+  ];
+
+  var STUB_DECISIONS = {
+    permission: {
+      kind: 'permission',
+      tool: 'Bash',
+      command: 'rm -rf build/',
+      cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die',
+      destructive: true,
+      risk: 'Destructive filesystem operation',
+      options: []
+    },
+    plan: {
+      kind: 'plan',
+      tool: 'ExitPlanMode',
+      command: '',
+      cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die',
+      plan: '### Goal\nValidate the mobile interaction model before backend wiring.\n\n### Plan\n- [x] Keep state local and canned for this increment.\n- [x] Render the conversation, tool cards, plan, question, and permission sheets.\n- [x] Send Channel-2 input through app.send({type:\'input\', data}).\n- [ ] Wire the turn stream and hook decision channels in a later stream.\n\n### Files touched\n```diff\n+ src/public/mobile-mode.css\n+ src/public/mobile-mode.js\n+ e2e/tests/80-mobile-mode-shell.spec.js\n```',
+      question: '',
+      options: []
+    },
+    question: {
+      kind: 'question',
+      tool: 'AskUserQuestion',
+      command: '',
+      cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die',
+      question: 'Which route should Claude take?',
+      options: [
+        { label: 'Keep prototype local', description: 'No backend calls. Use canned permission, plan, and question data.' },
+        { label: 'Mirror desktop flows', description: 'Use the existing mental model, compressed for thumbs.' },
+        { label: 'Experiment freely', description: 'Prioritize iPhone ergonomics even if desktop diverges.' }
+      ]
+    }
+  };
+
+  function MobileModeController(options) {
+    options = options || {};
+    this.app = options.app || null;
+    this.body = document.body;
+    this.root = document.documentElement;
+    this.el = null;
+    this.messageList = null;
+    this.messageStack = null;
+    this.statusChip = null;
+    this.statusText = null;
+    this.modeLabel = null;
+    this.needsPill = null;
+    this.backdrop = null;
+    this.sheets = [];
+    this.composerText = null;
+    this.composerModeText = null;
+    this.permissionSheet = null;
+    this.permissionCommand = null;
+    this.permissionCwd = null;
+    this.permissionRisk = null;
+    this.permissionTool = null;
+    this.countdownText = null;
+    this.countdownFill = null;
+    this.rawToggle = null;
+    this.rawBox = null;
+    this.approvePermissionBtn = null;
+    this.denyPermissionBtn = null;
+    this.planDoc = null;
+    this.questionTitle = null;
+    this.questionOptions = null;
+    this._focusTrap = null;
+    this._boundKeydown = null;
+    this._boundResize = null;
+    this._boundOrientation = null;
+    this._boundViewport = null;
+    this._lastActiveElement = null;
+    this.decisionStubs = {
+      permission: clone(STUB_DECISIONS.permission),
+      plan: clone(STUB_DECISIONS.plan),
+      question: clone(STUB_DECISIONS.question)
+    };
+    this.state = {
+      activeSurface: null,
+      pendingSurface: null,
+      countdownTimer: null,
+      countdownDeadline: 0,
+      countdownTotalMs: 45000,
+      composerMode: 'plan'
+    };
+  }
+
+  MobileModeController.prototype.init = function () {
+    var appRoot = document.getElementById('app');
+    if (!appRoot || this.el) return;
+
+    this.el = document.createElement('section');
+    this.el.className = 'mobile-mode';
+    this.el.setAttribute('data-testid', 'mobile-mode-shell');
+    this.el.setAttribute('aria-label', 'ai-or-die mobile mode');
+    this.el.innerHTML = this._template();
+    appRoot.appendChild(this.el);
+
+    this._cacheElements();
+    this._bindEvents();
+    this.renderConversation(STUB_TURN_STREAM);
+    this.renderDecision(this.decisionStubs.permission);
+    this.renderDecision(this.decisionStubs.plan);
+    this.renderDecision(this.decisionStubs.question);
+    this._syncSessionChrome();
+    this.syncVisualViewport();
+    this.scrollMessagesToBottom(true);
+
+    this.body.classList.add('mobile-mode-active');
+  };
+
+  MobileModeController.prototype._template = function () {
+    return [
+      '<div class="app-shell" data-mobile-app-shell>',
+      '  <section class="conversation-pane" aria-label="Conversation">',
+      '    <header class="topbar">',
+      '      <div class="topbar-inner">',
+      '        <div class="session-mark" aria-hidden="true">&gt;_</div>',
+      '        <div class="session-title">',
+      '          <div class="session-name" data-mobile-session-name>ai-or-die</div>',
+      '          <div class="session-meta"><span>Claude</span><span>\u00b7</span><span data-mobile-mode-label>code mode</span><span>\u00b7</span><span class="mode-dot" aria-hidden="true"></span><span>mobile mode</span></div>',
+      '        </div>',
+      '        <button class="overflow-btn" type="button" aria-label="More options">\u22ee</button>',
+      '      </div>',
+      '    </header>',
+      '    <button class="needs-pill" type="button" data-mobile-needs-pill aria-live="polite"><span class="pulse" aria-hidden="true"></span><span>Claude needs you</span></button>',
+      '    <main class="message-list" data-mobile-message-list aria-label="Messages">',
+      '      <div class="message-stack" data-mobile-message-stack></div>',
+      '    </main>',
+      '    <div class="status-line" aria-live="polite">',
+      '      <div class="status-chip" data-mobile-status-chip><span class="status-dot" aria-hidden="true"></span><span data-mobile-status-text>Claude idle</span></div>',
+      '    </div>',
+      '    <div class="input-dock" aria-label="Message input bar">',
+      '      <button class="mobile-compose-fab" data-testid="mobile-compose-fab" data-open-surface="composer" type="button" aria-haspopup="dialog" aria-label="Message Claude">\u2191</button>',
+      '    </div>',
+      '  </section>',
+      '  <div class="backdrop" data-testid="mobile-backdrop" data-mobile-backdrop aria-hidden="true"></div>',
+      '  <aside class="surface-layer" aria-label="Mobile mode surfaces">',
+      '    <div class="side-placeholder" aria-hidden="true"><div><strong>Right-side panel</strong><p>On iPad, approvals and plans live here while the conversation stays visible.</p></div></div>',
+      '    <section class="sheet permission-sheet" data-surface="permission" data-testid="mobile-permission-sheet" role="dialog" aria-modal="true" aria-labelledby="mobilePermissionTitle" aria-hidden="true">',
+      '      <div class="sheet-grip" aria-hidden="true"></div>',
+      '      <div class="sheet-head">',
+      '        <div class="sheet-title">',
+      '          <p class="eyebrow">Tool permission</p>',
+      '          <h2 id="mobilePermissionTitle">\u26a0 Claude wants to run</h2>',
+      '          <p class="sheet-subtitle">Review the exact command before letting it touch this folder.</p>',
+      '        </div>',
+      '      </div>',
+      '      <div class="sheet-content">',
+      '        <div class="command-box" aria-label="Exact command"><code data-mobile-permission-command></code></div>',
+      '        <div class="cwd-line"><span>cwd</span><code data-mobile-permission-cwd></code></div>',
+      '        <div class="risk-line"><span>risk</span><strong data-mobile-permission-risk></strong></div>',
+      '        <div class="countdown" aria-live="polite">',
+      '          <div class="countdown-row"><span data-mobile-countdown-text>falls back in 45s</span><small>fail-closed</small></div>',
+      '          <div class="countdown-track" aria-hidden="true"><div class="countdown-fill" data-mobile-countdown-fill></div></div>',
+      '        </div>',
+      '        <button class="raw-link" data-mobile-raw-toggle type="button">Show raw</button>',
+      '        <pre class="raw-box" data-mobile-raw-box hidden></pre>',
+      '      </div>',
+      '      <div class="sheet-actions">',
+      '        <button class="btn safe" data-mobile-deny-permission data-testid="mobile-deny-permission" type="button">Deny</button>',
+      '        <button class="btn" data-mobile-approve-permission data-testid="mobile-approve-permission" type="button">Approve</button>',
+      '      </div>',
+      '    </section>',
+      '    <section class="full-sheet plan-sheet" data-surface="plan" data-testid="mobile-plan-sheet" role="dialog" aria-modal="true" aria-labelledby="mobilePlanTitle" aria-hidden="true">',
+      '      <header class="plan-header">',
+      '        <h2 id="mobilePlanTitle">Plan \u2014 approve to start</h2>',
+      '        <button class="close-btn" type="button" data-close-surface aria-label="Close plan">\u2715</button>',
+      '      </header>',
+      '      <div class="plan-scroll"><article class="plan-doc" data-mobile-plan-doc></article></div>',
+      '      <footer class="plan-footer">',
+      '        <button class="btn ghost" data-mobile-reject-plan type="button">Reject</button>',
+      '        <button class="btn warn" data-mobile-comment-plan type="button">Comment</button>',
+      '        <button class="btn primary" data-mobile-approve-plan type="button">Approve</button>',
+      '      </footer>',
+      '    </section>',
+      '    <section class="sheet question-sheet" data-surface="question" data-testid="mobile-question-sheet" role="dialog" aria-modal="true" aria-labelledby="mobileQuestionTitle" aria-hidden="true">',
+      '      <div class="sheet-grip" aria-hidden="true"></div>',
+      '      <div class="sheet-head">',
+      '        <div class="sheet-title">',
+      '          <p class="eyebrow">Question</p>',
+      '          <h2 id="mobileQuestionTitle" data-mobile-question-title>Which route should Claude take?</h2>',
+      '          <p class="sheet-subtitle">Choose one answer from Claude\'s structured options.</p>',
+      '        </div>',
+      '        <button class="close-btn" type="button" data-close-surface aria-label="Close question">\u2715</button>',
+      '      </div>',
+      '      <div class="sheet-content">',
+      '        <div class="option-list" data-mobile-question-options role="radiogroup" aria-label="Choose one answer"></div>',
+      '      </div>',
+      '      <div class="sheet-actions">',
+      '        <button class="btn ghost" type="button" data-close-surface>Cancel</button>',
+      '        <button class="btn primary" data-mobile-send-question type="button">Send</button>',
+      '      </div>',
+      '    </section>',
+      '    <section class="sheet composer-sheet" data-surface="composer" data-testid="mobile-composer-sheet" role="dialog" aria-modal="true" aria-labelledby="mobileComposerTitle" aria-hidden="true">',
+      '      <div class="sheet-grip" aria-hidden="true"></div>',
+      '      <div class="sheet-head">',
+      '        <div class="sheet-title">',
+      '          <p class="eyebrow">Input composer</p>',
+      '          <h2 id="mobileComposerTitle">Message Claude</h2>',
+      '        </div>',
+      '        <button class="close-btn" type="button" data-close-surface aria-label="Close composer">\u2715</button>',
+      '      </div>',
+      '      <div class="sheet-content composer-body">',
+      '        <textarea class="composer-textarea" data-mobile-composer-text data-testid="mobile-composer-text" rows="5" placeholder="Ask Claude to change the plan, run a safe command, or stop work\u2026" autocapitalize="sentences" autocorrect="off" autocomplete="off" spellcheck="false"></textarea>',
+      '        <div class="control-row" aria-label="Structured composer controls">',
+      '          <button class="control-btn slash-btn" data-mobile-slash type="button" aria-label="Slash commands">/</button>',
+      '          <button class="control-btn mode-toggle" data-mobile-mode-toggle type="button"><span class="toggle-light" aria-hidden="true"></span><span data-mobile-composer-mode-text>Plan mode</span></button>',
+      '          <button class="control-btn stop-btn" data-mobile-stop data-testid="mobile-stop-button" type="button">\u25a0 Stop</button>',
+      '        </div>',
+      '        <div class="composer-actions">',
+      '          <button class="round-btn" data-mobile-composer-mic type="button" aria-label="Start voice input">mic</button>',
+      '          <button class="btn primary" data-mobile-send-composer data-testid="mobile-send-composer" type="button">Send</button>',
+      '        </div>',
+      '      </div>',
+      '    </section>',
+      '  </aside>',
+      '</div>'
+    ].join('');
+  };
+
+  MobileModeController.prototype._cacheElements = function () {
+    this.messageList = this.el.querySelector('[data-mobile-message-list]');
+    this.messageStack = this.el.querySelector('[data-mobile-message-stack]');
+    this.statusChip = this.el.querySelector('[data-mobile-status-chip]');
+    this.statusText = this.el.querySelector('[data-mobile-status-text]');
+    this.modeLabel = this.el.querySelector('[data-mobile-mode-label]');
+    this.needsPill = this.el.querySelector('[data-mobile-needs-pill]');
+    this.backdrop = this.el.querySelector('[data-mobile-backdrop]');
+    this.sheets = toArray(this.el.querySelectorAll('[data-surface]'));
+    this.composerText = this.el.querySelector('[data-mobile-composer-text]');
+    this.composerModeText = this.el.querySelector('[data-mobile-composer-mode-text]');
+    this.permissionSheet = this.el.querySelector('[data-surface="permission"]');
+    this.permissionCommand = this.el.querySelector('[data-mobile-permission-command]');
+    this.permissionCwd = this.el.querySelector('[data-mobile-permission-cwd]');
+    this.permissionRisk = this.el.querySelector('[data-mobile-permission-risk]');
+    this.countdownText = this.el.querySelector('[data-mobile-countdown-text]');
+    this.countdownFill = this.el.querySelector('[data-mobile-countdown-fill]');
+    this.rawToggle = this.el.querySelector('[data-mobile-raw-toggle]');
+    this.rawBox = this.el.querySelector('[data-mobile-raw-box]');
+    this.approvePermissionBtn = this.el.querySelector('[data-mobile-approve-permission]');
+    this.denyPermissionBtn = this.el.querySelector('[data-mobile-deny-permission]');
+    this.planDoc = this.el.querySelector('[data-mobile-plan-doc]');
+    this.questionTitle = this.el.querySelector('[data-mobile-question-title]');
+    this.questionOptions = this.el.querySelector('[data-mobile-question-options]');
+  };
+
+  MobileModeController.prototype._bindEvents = function () {
+    var self = this;
+
+    this.el.addEventListener('click', function (event) {
+      var openButton = closest(event.target, '[data-open-surface]', self.el);
+      if (openButton) {
+        self.openSurface(openButton.getAttribute('data-open-surface'));
+        return;
+      }
+
+      var closeButton = closest(event.target, '[data-close-surface]', self.el);
+      if (closeButton) {
+        self.closeSurface('Claude idle');
+        return;
+      }
+
+      var summary = closest(event.target, '.tool-summary', self.el);
+      if (summary) {
+        self._toggleToolCard(summary);
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-needs-pill]', self.el)) {
+        if (self.state.pendingSurface) self.openSurface(self.state.pendingSurface);
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-raw-toggle]', self.el)) {
+        self.toggleRawPermission();
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-deny-permission]', self.el)) {
+        self.denyPermission('manual');
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-approve-permission]', self.el)) {
+        self.approvePermission();
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-reject-plan]', self.el)) {
+        self.closeSurface('Claude idle \u00b7 plan rejected');
+        self.addEventChip('Plan rejected');
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-approve-plan]', self.el)) {
+        self.closeSurface('working\u2026 \u00b7 plan approved');
+        self.addEventChip('Plan approved \u00b7 TODO(wire) hook return');
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-comment-plan]', self.el)) {
+        self.composerText.value = 'I want to adjust the plan: ';
+        self.openSurface('composer');
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-send-question]', self.el)) {
+        self.sendQuestionAnswer();
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-slash]', self.el)) {
+        self.insertComposerText('/');
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-mode-toggle]', self.el)) {
+        self.insertModeText();
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-stop]', self.el)) {
+        self.interrupt();
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-composer-mic]', self.el)) {
+        self.addEventChip('Mic tapped \u00b7 voice capture TODO(wire)');
+        return;
+      }
+
+      if (closest(event.target, '[data-mobile-send-composer]', self.el)) {
+        self.sendComposer();
+      }
+    });
+
+    this.el.addEventListener('change', function (event) {
+      if (closest(event.target, '.option-card', self.el)) self.updateOptionCards();
+    });
+
+    this.backdrop.addEventListener('click', function () {
+      if (self.state.activeSurface === 'permission') {
+        self.nudgePermission();
+        return;
+      }
+      self.closeSurface('Claude idle');
+    });
+
+    this._boundKeydown = function (event) {
+      if (!self.state.activeSurface) return;
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        if (self.state.activeSurface === 'permission') self.denyPermission('manual');
+        else self.closeSurface('Claude idle');
+      }
+    };
+    document.addEventListener('keydown', this._boundKeydown);
+
+    this._boundViewport = function () { self.syncVisualViewport(); };
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', this._boundViewport);
+      window.visualViewport.addEventListener('scroll', this._boundViewport);
+    }
+    this._boundResize = function () { self.syncVisualViewport(); };
+    window.addEventListener('resize', this._boundResize);
+    this._boundOrientation = function () {
+      window.setTimeout(function () {
+        self.syncVisualViewport();
+        self.scrollMessagesToBottom(true);
+      }, 250);
+    };
+    window.addEventListener('orientationchange', this._boundOrientation);
+
+    this._bindDragDismiss();
+  };
+
+  MobileModeController.prototype._bindDragDismiss = function () {
+    var self = this;
+    this.sheets.forEach(function (sheet) {
+      if (sheet.classList.contains('full-sheet')) return;
+      var grip = sheet.querySelector('.sheet-grip');
+      if (!grip || !window.PointerEvent) return;
+      var startY = 0;
+      var lastY = 0;
+      var dragging = false;
+
+      grip.addEventListener('pointerdown', function (event) {
+        if (window.innerWidth >= 760 && window.innerHeight >= 620) return;
+        if (!sheet.classList.contains('active')) return;
+        dragging = true;
+        startY = event.clientY;
+        lastY = startY;
+        sheet.style.transition = 'none';
+        try { grip.setPointerCapture(event.pointerId); } catch (_) {}
+      });
+
+      grip.addEventListener('pointermove', function (event) {
+        if (!dragging) return;
+        lastY = event.clientY;
+        var dy = Math.max(0, lastY - startY);
+        sheet.style.transform = 'translateY(' + dy + 'px)';
+      });
+
+      function finish(event) {
+        if (!dragging) return;
+        dragging = false;
+        var dy = Math.max(0, lastY - startY);
+        sheet.style.transition = '';
+        sheet.style.transform = '';
+        try { grip.releasePointerCapture(event.pointerId); } catch (_) {}
+        if (dy > 90) {
+          if (self.state.activeSurface === 'permission') self.denyPermission('dismiss');
+          else self.closeSurface('Claude idle');
+        }
+      }
+
+      grip.addEventListener('pointerup', finish);
+      grip.addEventListener('pointercancel', finish);
+    });
+  };
+
+  MobileModeController.prototype.renderConversation = function (items) {
+    // TODO(wire): Feed this from GET /api/control/sessions/:id/messages once the
+    // turn-stream endpoint lands. This renderer intentionally accepts only the
+    // documented item contract and performs no backend reads itself.
+    items = items || [];
+    if (!this.messageStack) return;
+    this.messageStack.innerHTML = '';
+
+    var grouped = this._groupTurnItems(items);
+    for (var i = 0; i < grouped.length; i++) {
+      if (grouped[i].type === 'tool') {
+        this.messageStack.appendChild(this._renderToolCard(grouped[i]));
+      } else {
+        this.messageStack.appendChild(this._renderTurnItem(grouped[i].item));
+      }
+    }
+    this.scrollMessagesToBottom(true);
+  };
+
+  MobileModeController.prototype.renderDecision = function (data) {
+    // TODO(wire): Feed this from hook/control decision payloads. Channel-1
+    // allow/deny/answer transport is deliberately absent in this client-shell
+    // increment; buttons only update local UI stubs.
+    if (!data || !data.kind) return;
+    if (data.kind === 'permission') this.renderPermission(data);
+    if (data.kind === 'plan') this.renderPlan(data);
+    if (data.kind === 'question') this.renderQuestion(data);
+  };
+
+  MobileModeController.prototype.setDecisionStub = function (kind, data) {
+    if (typeof kind === 'object') {
+      data = kind;
+      kind = data && data.kind;
+    }
+    if (!kind || !data) return;
+    this.decisionStubs[kind] = merge(clone(this.decisionStubs[kind] || {}), data);
+    this.renderDecision(this.decisionStubs[kind]);
+  };
+
+  MobileModeController.prototype.openSurface = function (name) {
+    if (!name) {
+      this.closeSurface('Claude idle');
+      return;
+    }
+
+    if (name === 'permission') this.renderPermission(this.decisionStubs.permission);
+    if (name === 'plan') this.renderPlan(this.decisionStubs.plan);
+    if (name === 'question') this.renderQuestion(this.decisionStubs.question);
+
+    if (this.state.activeSurface === 'permission' && name !== 'permission') this.stopCountdown();
+    this.state.activeSurface = name;
+    if (isDecisionSurface(name)) this.state.pendingSurface = name;
+
+    this.body.classList.toggle('has-surface', Boolean(name));
+    this.body.classList.toggle('has-decision', isDecisionSurface(name));
+    this.body.dataset.surface = name || '';
+
+    for (var i = 0; i < this.sheets.length; i++) {
+      var sheet = this.sheets[i];
+      var active = sheet.getAttribute('data-surface') === name;
+      sheet.classList.toggle('active', active);
+      sheet.setAttribute('aria-hidden', active ? 'false' : 'true');
+    }
+
+    if (name === 'permission') {
+      this.startCountdown();
+      this.setStatus('working\u2026 \u00b7 waiting for permission');
+      this._focusSurface(name, this.denyPermissionBtn);
+    } else if (name === 'plan') {
+      this.stopCountdown();
+      this.setStatus('working\u2026 \u00b7 plan waiting');
+      this._focusSurface(name);
+    } else if (name === 'question') {
+      this.stopCountdown();
+      this.setStatus('working\u2026 \u00b7 question waiting');
+      this._focusSurface(name);
+    } else if (name === 'composer') {
+      this.stopCountdown();
+      this.setStatus('Claude idle');
+      this._focusSurface(name, this.composerText);
+    }
+
+    this.syncVisualViewport();
+  };
+
+  MobileModeController.prototype.closeSurface = function (nextStatus) {
+    if (this.state.activeSurface === 'permission') this.stopCountdown();
+    this._deactivateFocusTrap();
+    if (document.activeElement && this.el.contains(document.activeElement) && typeof document.activeElement.blur === 'function') {
+      document.activeElement.blur();
+    }
+
+    this.state.activeSurface = null;
+    this.state.pendingSurface = null;
+    this.body.classList.remove('has-surface', 'has-decision');
+    this.body.dataset.surface = '';
+
+    for (var i = 0; i < this.sheets.length; i++) {
+      this.sheets[i].classList.remove('active', 'nudge');
+      this.sheets[i].setAttribute('aria-hidden', 'true');
+      this.sheets[i].style.transform = '';
+      this.sheets[i].style.transition = '';
+    }
+
+    if (nextStatus) this.setStatus(nextStatus);
+    this.syncVisualViewport();
+  };
+
+  MobileModeController.prototype.renderPermission = function (data) {
+    data = data || this.decisionStubs.permission;
+    this.decisionStubs.permission = merge(clone(this.decisionStubs.permission), data);
+    data = this.decisionStubs.permission;
+
+    var destructive = data.destructive;
+    if (destructive == null) destructive = this._isDestructiveCommand(data.command || '');
+
+    this.permissionCommand.textContent = data.command || '';
+    this.permissionCwd.textContent = data.cwd || '';
+    this.permissionRisk.textContent = data.risk || (destructive ? 'Destructive filesystem operation' : 'Read-only-ish command');
+    this.rawBox.textContent = JSON.stringify(data, null, 2);
+    this.rawBox.hidden = true;
+    this.rawToggle.textContent = 'Show raw';
+    this.approvePermissionBtn.classList.toggle('danger', !!destructive);
+    this.approvePermissionBtn.classList.toggle('primary', !destructive);
+    this.approvePermissionBtn.setAttribute('data-destructive', destructive ? 'true' : 'false');
+    this.permissionSheet.classList.toggle('destructive-command', !!destructive);
+  };
+
+  MobileModeController.prototype.renderPlan = function (data) {
+    data = data || this.decisionStubs.plan;
+    this.decisionStubs.plan = merge(clone(this.decisionStubs.plan), data);
+    this._renderPlanText(this.decisionStubs.plan.plan || '');
+  };
+
+  MobileModeController.prototype.renderQuestion = function (data) {
+    data = data || this.decisionStubs.question;
+    this.decisionStubs.question = merge(clone(this.decisionStubs.question), data);
+    data = this.decisionStubs.question;
+    this.questionTitle.textContent = data.question || 'Claude has a question';
+    this.questionOptions.innerHTML = '';
+
+    var options = data.options || [];
+    for (var i = 0; i < options.length; i++) {
+      var label = document.createElement('label');
+      label.className = 'option-card' + (i === 0 ? ' is-selected' : '');
+      var input = document.createElement('input');
+      input.type = 'radio';
+      input.name = 'mobileQuestionChoice';
+      input.value = options[i].label || ('Option ' + (i + 1));
+      input.checked = i === 0;
+      var copy = document.createElement('span');
+      var strong = document.createElement('strong');
+      strong.textContent = options[i].label || ('Option ' + (i + 1));
+      var desc = document.createElement('span');
+      desc.textContent = options[i].description || '';
+      copy.appendChild(strong);
+      copy.appendChild(desc);
+      label.appendChild(input);
+      label.appendChild(copy);
+      this.questionOptions.appendChild(label);
+    }
+  };
+
+  MobileModeController.prototype.sendComposer = function () {
+    var raw = this.composerText.value;
+    if (!raw || !raw.replace(/\s+/g, '').length) return;
+
+    var enter = this.encodeKey({ key: 'enter' }) || '\r';
+    var data = this.normalizeLineEndings(raw) + enter;
+    this.sendInput(data);
+    this.addUserMessage(raw);
+    this.composerText.value = '';
+    this.closeSurface('Claude idle \u00b7 sent');
+  };
+
+  MobileModeController.prototype.interrupt = function () {
+    var ctrlC = this.encodeKey({ char: 'c', ctrl: true }) || '\x03';
+    this.sendInput(ctrlC);
+    this.setStatus('Claude idle \u00b7 interrupted');
+    this.addEventChip('Stop tapped \u00b7 Ctrl-C sent');
+  };
+
+  MobileModeController.prototype.insertModeText = function () {
+    var text = this.state.composerMode === 'plan' ? '/plan ' : '/accept-edits ';
+    this.insertComposerText(text);
+    this.state.composerMode = this.state.composerMode === 'plan' ? 'accept-edits' : 'plan';
+    this.composerModeText.textContent = this.state.composerMode === 'plan' ? 'Plan mode' : 'Accept edits';
+  };
+
+  MobileModeController.prototype.insertComposerText = function (text) {
+    var ta = this.composerText;
+    if (!ta) return;
+    var start = typeof ta.selectionStart === 'number' ? ta.selectionStart : ta.value.length;
+    var end = typeof ta.selectionEnd === 'number' ? ta.selectionEnd : start;
+    ta.value = ta.value.slice(0, start) + text + ta.value.slice(end);
+    var next = start + text.length;
+    try { ta.setSelectionRange(next, next); } catch (_) {}
+    try { ta.focus({ preventScroll: true }); } catch (__) { ta.focus(); }
+  };
+
+  MobileModeController.prototype.sendQuestionAnswer = function () {
+    var selected = this.questionOptions.querySelector('input[name="mobileQuestionChoice"]:checked');
+    var answer = selected ? selected.value : 'No answer';
+    this.closeSurface('Claude idle \u00b7 answered');
+    this.addEventChip('Answered question \u00b7 ' + answer + ' \u00b7 TODO(wire) hook return');
+  };
+
+  MobileModeController.prototype.approvePermission = function () {
+    var cmd = this.decisionStubs.permission.command || '';
+    this.stopCountdown();
+    this.closeSurface('working\u2026 \u00b7 approved');
+    this.addEventChip('Approved \u00b7 TODO(wire) hook return: ' + cmd);
+  };
+
+  MobileModeController.prototype.denyPermission = function (reason) {
+    var timeout = reason === 'timeout';
+    var dismiss = reason === 'dismiss';
+    var cmd = this.decisionStubs.permission.command || '';
+    this.stopCountdown();
+    this.closeSurface(timeout ? 'Claude idle \u00b7 denied by timeout' : 'Claude idle \u00b7 denied');
+    this.addEventChip((timeout ? 'Denied by timeout' : (dismiss ? 'Denied by dismiss' : 'Denied')) + ' \u00b7 command was not run: ' + cmd);
+  };
+
+  MobileModeController.prototype.toggleRawPermission = function () {
+    this.rawBox.hidden = !this.rawBox.hidden;
+    this.rawToggle.textContent = this.rawBox.hidden ? 'Show raw' : 'Hide raw';
+  };
+
+  MobileModeController.prototype.nudgePermission = function () {
+    if (!this.permissionSheet) return;
+    this.permissionSheet.classList.remove('nudge');
+    void this.permissionSheet.offsetWidth;
+    this.permissionSheet.classList.add('nudge');
+  };
+
+  MobileModeController.prototype.startCountdown = function () {
+    var self = this;
+    this.stopCountdown();
+    this.state.countdownDeadline = Date.now() + this.state.countdownTotalMs;
+    this.updateCountdown();
+    this.state.countdownTimer = window.setInterval(function () { self.updateCountdown(); }, 250);
+  };
+
+  MobileModeController.prototype.stopCountdown = function () {
+    if (this.state.countdownTimer) {
+      window.clearInterval(this.state.countdownTimer);
+      this.state.countdownTimer = null;
+    }
+  };
+
+  MobileModeController.prototype.updateCountdown = function () {
+    var remainingMs = Math.max(0, this.state.countdownDeadline - Date.now());
+    var seconds = Math.ceil(remainingMs / 1000);
+    var pct = this.state.countdownTotalMs ? remainingMs / this.state.countdownTotalMs : 0;
+    this.countdownText.textContent = 'falls back in ' + seconds + 's';
+    this.countdownFill.style.setProperty('--mobile-countdown-pct', String(Math.max(0, Math.min(1, pct))));
+    if (remainingMs <= 0) {
+      this.stopCountdown();
+      this.denyPermission('timeout');
+    }
+  };
+
+  MobileModeController.prototype.syncVisualViewport = function () {
+    var keyboardBottom = 0;
+    if (window.visualViewport) {
+      keyboardBottom = Math.max(0, window.innerHeight - window.visualViewport.height - window.visualViewport.offsetTop);
+      this.root.style.setProperty('--visual-viewport-height', Math.round(window.visualViewport.height) + 'px');
+    }
+    this.root.style.setProperty('--keyboard-bottom', Math.round(keyboardBottom) + 'px');
+    this.body.style.setProperty('--keyboard-bottom', Math.round(keyboardBottom) + 'px');
+    if (this.state.activeSurface === 'composer') this.scrollMessagesToBottom(true);
+  };
+
+  MobileModeController.prototype.setStatus = function (text) {
+    this.statusText.textContent = text;
+    this.statusChip.classList.toggle('working', /working|waiting|running/i.test(text));
+  };
+
+  MobileModeController.prototype.addUserMessage = function (text) {
+    var row = document.createElement('div');
+    row.className = 'message-row user';
+    var bubble = document.createElement('div');
+    bubble.className = 'bubble';
+    var p = document.createElement('p');
+    p.textContent = text;
+    bubble.appendChild(p);
+    row.appendChild(bubble);
+    this.messageStack.appendChild(row);
+    this.scrollMessagesToBottom(true);
+  };
+
+  MobileModeController.prototype.addAssistantMessage = function (text) {
+    var row = document.createElement('div');
+    row.className = 'message-row assistant';
+    var bubble = document.createElement('div');
+    bubble.className = 'bubble';
+    var label = document.createElement('div');
+    label.className = 'message-label';
+    label.textContent = 'Claude';
+    var p = document.createElement('p');
+    p.textContent = text;
+    bubble.appendChild(label);
+    bubble.appendChild(p);
+    row.appendChild(bubble);
+    this.messageStack.appendChild(row);
+    this.scrollMessagesToBottom(true);
+  };
+
+  MobileModeController.prototype.addEventChip = function (text) {
+    var row = document.createElement('div');
+    row.className = 'message-row event-row';
+    var chip = document.createElement('div');
+    chip.className = 'event-chip';
+    chip.textContent = text;
+    row.appendChild(chip);
+    this.messageStack.appendChild(row);
+    this.scrollMessagesToBottom(true);
+  };
+
+  MobileModeController.prototype.scrollMessagesToBottom = function (force) {
+    var list = this.messageList;
+    if (!list) return;
+    var distance = list.scrollHeight - list.scrollTop - list.clientHeight;
+    if (!force && distance > 180) return;
+    window.requestAnimationFrame(function () {
+      list.scrollTop = list.scrollHeight;
+    });
+  };
+
+  MobileModeController.prototype.encodeKey = function (spec) {
+    var encoder = (typeof window !== 'undefined' && window.KeyEncoder) ? window.KeyEncoder : null;
+    if (!encoder || !encoder.encode) return null;
+    return encoder.encode(spec, this._terminalModes());
+  };
+
+  MobileModeController.prototype.sendInput = function (data) {
+    if (this.app && typeof this.app.send === 'function') {
+      this.app.send({ type: 'input', data: data });
+    }
+  };
+
+  MobileModeController.prototype.normalizeLineEndings = function (text) {
+    if (typeof window.attachClipboardHandler !== 'undefined' && window.attachClipboardHandler.normalizeLineEndings) {
+      return window.attachClipboardHandler.normalizeLineEndings(text);
+    }
+    return String(text).replace(/\r\n/g, '\r').replace(/\n/g, '\r');
+  };
+
+  MobileModeController.prototype.updateOptionCards = function () {
+    var cards = this.el.querySelectorAll('.option-card');
+    for (var i = 0; i < cards.length; i++) {
+      var input = cards[i].querySelector('input');
+      cards[i].classList.toggle('is-selected', Boolean(input && input.checked));
+    }
+  };
+
+  MobileModeController.prototype._terminalModes = function () {
+    var modes = {};
+    var term = this.app && this.app.terminal;
+    if (term && term.modes) {
+      modes.applicationCursorKeys = !!term.modes.applicationCursorKeysMode;
+      modes.bracketedPaste = !!term.modes.bracketedPasteMode;
+    }
+    return modes;
+  };
+
+  MobileModeController.prototype._syncSessionChrome = function () {
+    var nameEl = this.el.querySelector('[data-mobile-session-name]');
+    var name = (this.app && (this.app.currentClaudeSessionName || this.app.currentClaudeSessionId)) || 'mobile-mode shell';
+    nameEl.textContent = name;
+    var mode = (this.app && this.app.currentMode) || 'code';
+    this.modeLabel.textContent = mode + ' mode';
+  };
+
+  MobileModeController.prototype._groupTurnItems = function (items) {
+    var out = [];
+    var byToolUseId = {};
+
+    for (var i = 0; i < items.length; i++) {
+      var item = items[i];
+      if (!item) continue;
+      if (item.kind === 'tool-call') {
+        var group = { type: 'tool', call: item, result: null };
+        out.push(group);
+        if (item.toolUseId) byToolUseId[item.toolUseId] = group;
+      } else if (item.kind === 'tool-result') {
+        var existing = item.toolUseId && byToolUseId[item.toolUseId];
+        if (existing) existing.result = item;
+        else out.push({ type: 'tool', call: null, result: item });
+      } else {
+        out.push({ type: 'item', item: item });
+      }
+    }
+    return out;
+  };
+
+  MobileModeController.prototype._renderTurnItem = function (item) {
+    if (item.kind === 'user-text') return this._renderBubble('user', null, item.text || '');
+    if (item.kind === 'assistant-text') return this._renderBubble('assistant', 'Claude', item.text || '');
+    if (item.kind === 'thinking') return this._renderEvent('thinking\u2026 ' + (item.text || ''));
+    return this._renderEvent(item.text || item.kind || 'event');
+  };
+
+  MobileModeController.prototype._renderBubble = function (who, labelText, text) {
+    var row = document.createElement('div');
+    row.className = 'message-row ' + who;
+    var bubble = document.createElement('div');
+    bubble.className = 'bubble';
+    if (labelText) {
+      var label = document.createElement('div');
+      label.className = 'message-label';
+      label.textContent = labelText;
+      bubble.appendChild(label);
+    }
+    var p = document.createElement('p');
+    p.textContent = text;
+    bubble.appendChild(p);
+    row.appendChild(bubble);
+    return row;
+  };
+
+  MobileModeController.prototype._renderEvent = function (text) {
+    var row = document.createElement('div');
+    row.className = 'message-row event-row';
+    var chip = document.createElement('div');
+    chip.className = 'event-chip';
+    chip.textContent = text;
+    row.appendChild(chip);
+    return row;
+  };
+
+  MobileModeController.prototype._renderToolCard = function (group) {
+    var call = group.call || {};
+    var result = group.result || {};
+    var name = call.name || result.name || 'tool';
+    var target = this._toolTarget(call);
+
+    var card = document.createElement('article');
+    card.className = 'tool-card';
+    card.setAttribute('aria-label', 'Tool card: ' + name);
+
+    var summary = document.createElement('button');
+    summary.className = 'tool-summary';
+    summary.type = 'button';
+    summary.setAttribute('aria-expanded', 'false');
+
+    var disclosure = document.createElement('span');
+    disclosure.className = 'tool-disclosure';
+    disclosure.setAttribute('aria-hidden', 'true');
+    disclosure.textContent = '\u25b8';
+    summary.appendChild(disclosure);
+
+    var line = document.createElement('span');
+    line.className = 'tool-line';
+    line.appendChild(document.createTextNode(name === 'Bash' ? 'Ran ' : 'Used ' + name + ' '));
+    var code = document.createElement('code');
+    code.textContent = target;
+    line.appendChild(code);
+    summary.appendChild(line);
+
+    var status = document.createElement('span');
+    status.className = 'tool-result' + (result.isError ? ' error' : '');
+    status.textContent = result.isError ? '!' : '\u2713';
+    summary.appendChild(status);
+    card.appendChild(summary);
+
+    var details = document.createElement('div');
+    details.className = 'tool-details';
+    var detailsInner = document.createElement('div');
+    var body = document.createElement('div');
+    body.className = 'tool-body';
+
+    var grid = document.createElement('div');
+    grid.className = 'detail-grid';
+    this._appendDetail(grid, 'tool', name);
+    if (call.toolUseId || result.toolUseId) this._appendDetail(grid, 'id', call.toolUseId || result.toolUseId);
+    if (call.input) this._appendDetail(grid, 'input', stringify(call.input));
+    body.appendChild(grid);
+
+    if (result.content != null) {
+      var pre = document.createElement('pre');
+      pre.className = result.isError ? 'terminal-output error' : 'terminal-output';
+      pre.textContent = stringify(result.content);
+      body.appendChild(pre);
+    }
+
+    detailsInner.appendChild(body);
+    details.appendChild(detailsInner);
+    card.appendChild(details);
+    return card;
+  };
+
+  MobileModeController.prototype._appendDetail = function (grid, labelText, value) {
+    var label = document.createElement('span');
+    label.textContent = labelText;
+    var code = document.createElement('code');
+    code.textContent = value;
+    grid.appendChild(label);
+    grid.appendChild(code);
+  };
+
+  MobileModeController.prototype._toolTarget = function (call) {
+    if (!call) return 'result';
+    var input = call.input || {};
+    if (typeof input === 'string') return input;
+    if (input.command) return input.command;
+    if (input.file_path) return input.file_path;
+    if (input.path) return input.path;
+    return call.name || 'tool';
+  };
+
+  MobileModeController.prototype._toggleToolCard = function (summary) {
+    var card = closest(summary, '.tool-card', this.el);
+    if (!card) return;
+    var expanded = !card.classList.contains('expanded');
+    card.classList.toggle('expanded', expanded);
+    summary.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+  };
+
+  MobileModeController.prototype._renderPlanText = function (text) {
+    this.planDoc.innerHTML = '';
+    var lines = String(text || '').split(/\r?\n/);
+    var list = null;
+    var fence = null;
+
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      if (/^```/.test(line)) {
+        if (fence) {
+          this.planDoc.appendChild(fence);
+          fence = null;
+        } else {
+          fence = document.createElement('pre');
+          fence.className = 'fake-diff';
+        }
+        list = null;
+        continue;
+      }
+      if (fence) {
+        fence.textContent += (fence.textContent ? '\n' : '') + line;
+        continue;
+      }
+      if (!line.trim()) {
+        list = null;
+        continue;
+      }
+      var heading = line.match(/^#{1,3}\s+(.+)$/);
+      if (heading) {
+        var h = document.createElement('h3');
+        h.textContent = heading[1];
+        this.planDoc.appendChild(h);
+        list = null;
+        continue;
+      }
+      var check = line.match(/^[-*]\s+\[(x| )\]\s+(.+)$/i);
+      if (check) {
+        if (!list) {
+          list = document.createElement('ul');
+          list.className = 'checklist';
+          this.planDoc.appendChild(list);
+        }
+        var li = document.createElement('li');
+        var box = document.createElement('span');
+        box.className = 'box-check';
+        box.textContent = check[1].toLowerCase() === 'x' ? '\u2713' : '\u2022';
+        var span = document.createElement('span');
+        span.textContent = check[2];
+        li.appendChild(box);
+        li.appendChild(span);
+        list.appendChild(li);
+        continue;
+      }
+      var p = document.createElement('p');
+      p.textContent = line;
+      this.planDoc.appendChild(p);
+      list = null;
+    }
+    if (fence) this.planDoc.appendChild(fence);
+  };
+
+  MobileModeController.prototype._focusSurface = function (name, preferred) {
+    var sheet = this.el.querySelector('[data-surface="' + name + '"]');
+    if (!sheet) return;
+    this._activateFocusTrap(sheet);
+    var target = preferred || sheet.querySelector('button, textarea, input, [tabindex]:not([tabindex="-1"])');
+    if (!target) return;
+    window.requestAnimationFrame(function () {
+      try { target.focus({ preventScroll: true }); } catch (_) { target.focus(); }
+    });
+  };
+
+  MobileModeController.prototype._activateFocusTrap = function (surface) {
+    this._deactivateFocusTrap();
+    this._lastActiveElement = document.activeElement;
+    var self = this;
+    this._focusTrap = function (event) {
+      if (event.key !== 'Tab') return;
+      var focusable = toArray(surface.querySelectorAll('a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'));
+      focusable = focusable.filter(function (el) { return el.offsetParent !== null; });
+      if (!focusable.length) return;
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    surface.addEventListener('keydown', this._focusTrap);
+    this._focusTrapSurface = surface;
+    self.syncVisualViewport();
+  };
+
+  MobileModeController.prototype._deactivateFocusTrap = function () {
+    if (this._focusTrap && this._focusTrapSurface) {
+      this._focusTrapSurface.removeEventListener('keydown', this._focusTrap);
+    }
+    this._focusTrap = null;
+    this._focusTrapSurface = null;
+    if (this._lastActiveElement && typeof this._lastActiveElement.focus === 'function' && document.contains(this._lastActiveElement)) {
+      try { this._lastActiveElement.focus({ preventScroll: true }); } catch (_) {}
+    }
+    this._lastActiveElement = null;
+  };
+
+  MobileModeController.prototype._isDestructiveCommand = function (command) {
+    return /\b(rm\s+-rf|del\s+\/s|rmdir\s+\/s|remove-item\b.*\b-recurse\b|git\s+clean\s+-fd|drop\s+table)\b/i.test(command || '');
+  };
+
+  function init(options) {
+    options = options || {};
+    if (options.isMobile !== true) return null;
+    if (!document.body.classList.contains('is-mobile')) return null;
+    if (controller) return controller;
+    controller = new MobileModeController(options);
+    controller.init();
+    api.controller = controller;
+    return controller;
+  }
+
+  function requireController() {
+    return controller;
+  }
+
+  var api = {
+    init: init,
+    getController: requireController,
+    openSurface: function (name) { if (controller) controller.openSurface(name); },
+    closeSurface: function () { if (controller) controller.closeSurface('Claude idle'); },
+    renderConversation: function (items) { if (controller) controller.renderConversation(items); },
+    renderDecision: function (data) { if (controller) controller.renderDecision(data); },
+    setDecisionStub: function (kind, data) { if (controller) controller.setDecisionStub(kind, data); },
+    STUB_TURN_STREAM: STUB_TURN_STREAM,
+    STUB_DECISIONS: STUB_DECISIONS
+  };
+
+  function isDecisionSurface(name) {
+    return name === 'permission' || name === 'plan' || name === 'question';
+  }
+
+  function toArray(list) {
+    return Array.prototype.slice.call(list || []);
+  }
+
+  function closest(node, selector, stopAt) {
+    while (node && node !== document && node !== stopAt.parentNode) {
+      if (matches(node, selector)) return node;
+      if (node === stopAt) break;
+      node = node.parentNode;
+    }
+    return null;
+  }
+
+  function matches(node, selector) {
+    if (!node || node.nodeType !== 1) return false;
+    var fn = node.matches || node.msMatchesSelector || node.webkitMatchesSelector;
+    return fn ? fn.call(node, selector) : false;
+  }
+
+  function clone(value) {
+    return JSON.parse(JSON.stringify(value || {}));
+  }
+
+  function merge(target, source) {
+    target = target || {};
+    source = source || {};
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) target[key] = source[key];
+    }
+    return target;
+  }
+
+  function stringify(value) {
+    if (value == null) return '';
+    if (typeof value === 'string') return value;
+    try { return JSON.stringify(value, null, 2); } catch (_) { return String(value); }
+  }
+
+  window.MobileMode = api;
+}());

--- a/src/public/mobile-mode.js
+++ b/src/public/mobile-mode.js
@@ -3,55 +3,18 @@
 /*
  * mobile-mode.js — hook-independent mobile client shell.
  *
- * The production data seams are intentionally local stubs in this increment:
- *   - turn stream items: {id, kind:'user-text'|'assistant-text'|'tool-call'|
- *     'tool-result'|'thinking', text?, toolUseId?, name?, input?, content?, isError?}
- *   - decision sheet data: {kind, tool, command, cwd, plan, question,
- *     options:[{label, description}]}
- *
- * TODO(wire): Replace the stubs with the control-plane message stream and hook
- * decision payloads when those endpoints/channels land. Do not invent fetches in
- * this shell; it only renders data handed to it and sends Channel-2 input bytes.
+ * Conversation data is read from the control-plane semantic turn stream:
+ *   {id, kind:'user-text'|'assistant-text'|'tool-call'|'tool-result'|
+ *    'thinking', text?, thinking?, toolUseId?, name?, input?, content?, isError?}
+ * Decision sheets remain locally rendered until the hook decision channel lands.
  */
 (function () {
   var controller = null;
-
-  var STUB_TURN_STREAM = [
-    {
-      id: 'stub-user-1',
-      kind: 'user-text',
-      text: 'Can you prep mobile mode before wiring the backend? I need to feel the permission gates on an iPhone.'
-    },
-    {
-      id: 'stub-assistant-1',
-      kind: 'assistant-text',
-      text: 'I\u2019ll keep this shell hook-independent: conversation rendering, approval sheets, questions, plan review, and a keyboard-safe composer.'
-    },
-    {
-      id: 'stub-tool-call-1',
-      kind: 'tool-call',
-      toolUseId: 'stub-tool-1',
-      name: 'Bash',
-      input: { command: 'npm test', cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die' }
-    },
-    {
-      id: 'stub-tool-result-1',
-      kind: 'tool-result',
-      toolUseId: 'stub-tool-1',
-      content: 'PASS test/mobile-layout.test.js\nPASS test/tool-permission.test.js\n\n38 passed, 0 failed',
-      isError: false
-    },
-    {
-      id: 'stub-thinking-1',
-      kind: 'thinking',
-      text: 'Mapping the next mobile surface without touching backend hooks.'
-    },
-    {
-      id: 'stub-assistant-2',
-      kind: 'assistant-text',
-      text: 'The real message stream will attach at the TODO(wire) seam; for now this is a documented stub contract.'
-    }
-  ];
+  var TURN_PAGE_LIMIT = 200;
+  var CONTROL_EVENT_KINDS = 'turn_ended,became_busy,became_idle,waiting_input';
+  var CONTROL_EVENTS_TIMEOUT_MS = 25000;
+  var SESSION_WATCH_MS = 500;
+  var EVENT_RETRY_MS = 1200;
 
   var STUB_DECISIONS = {
     permission: {
@@ -122,6 +85,18 @@
     this._boundOrientation = null;
     this._boundViewport = null;
     this._lastActiveElement = null;
+    this.currentSessionId = null;
+    this.messageCursor = null;
+    this.messageEpoch = null;
+    this.eventCursor = null;
+    this.turnItems = [];
+    this.renderedItemIds = new Map();
+    this._streamGeneration = 0;
+    this._sessionWatchTimer = null;
+    this._eventRetryTimer = null;
+    this._messageLoadInFlight = false;
+    this._messageLoadQueued = false;
+    this._localItemSeq = 0;
     this.decisionStubs = {
       permission: clone(STUB_DECISIONS.permission),
       plan: clone(STUB_DECISIONS.plan),
@@ -130,6 +105,7 @@
     this.state = {
       activeSurface: null,
       pendingSurface: null,
+      needsInput: false,
       countdownTimer: null,
       countdownDeadline: 0,
       countdownTotalMs: 45000,
@@ -150,7 +126,7 @@
 
     this._cacheElements();
     this._bindEvents();
-    this.renderConversation(STUB_TURN_STREAM);
+    this.renderConversation([]);
     this.renderDecision(this.decisionStubs.permission);
     this.renderDecision(this.decisionStubs.plan);
     this.renderDecision(this.decisionStubs.question);
@@ -159,6 +135,7 @@
     this.scrollMessagesToBottom(true);
 
     this.body.classList.add('mobile-mode-active');
+    this.startTurnStream();
   };
 
   MobileModeController.prototype._template = function () {
@@ -473,14 +450,186 @@
   };
 
   MobileModeController.prototype.renderConversation = function (items) {
-    // TODO(wire): Feed this from GET /api/control/sessions/:id/messages once the
-    // turn-stream endpoint lands. This renderer intentionally accepts only the
-    // documented item contract and performs no backend reads itself.
-    items = items || [];
-    if (!this.messageStack) return;
-    this.messageStack.innerHTML = '';
+    this._resetConversationState();
+    this._appendTurnItems(items || [], true);
+  };
 
-    var grouped = this._groupTurnItems(items);
+  MobileModeController.prototype.startTurnStream = function () {
+    if (this._sessionWatchTimer) return;
+    var self = this;
+    this._sessionWatchTimer = window.setInterval(function () {
+      self._syncTurnSession();
+    }, SESSION_WATCH_MS);
+    this._syncTurnSession();
+  };
+
+  MobileModeController.prototype._syncTurnSession = function () {
+    var sessionId = this._currentSessionId();
+    if (sessionId === this.currentSessionId) return;
+
+    this._streamGeneration += 1;
+    var generation = this._streamGeneration;
+    this.currentSessionId = sessionId;
+    this.eventCursor = null;
+    this._messageLoadQueued = false;
+    this._clearEventRetry();
+    this._resetConversationState();
+    this._syncSessionChrome();
+    this.setNeedsInput(false);
+    this.setStatus('idle');
+
+    if (!sessionId) return;
+    this._pollControlEvents(generation);
+    this._scheduleMessageLoad(generation, true);
+  };
+
+  MobileModeController.prototype._currentSessionId = function () {
+    var app = this.app || window.app || null;
+    var sessionId = app && app.currentClaudeSessionId;
+    return sessionId ? String(sessionId) : null;
+  };
+
+  MobileModeController.prototype._scheduleMessageLoad = function (generation, fromStart) {
+    if (generation !== this._streamGeneration || !this.currentSessionId) return;
+    if (fromStart) this._messageLoadQueued = 'reset';
+    else if (!this._messageLoadQueued) this._messageLoadQueued = 'append';
+    if (this._messageLoadInFlight) return;
+    this._drainMessageLoads(generation);
+  };
+
+  MobileModeController.prototype._drainMessageLoads = async function (generation) {
+    if (this._messageLoadInFlight) return;
+    this._messageLoadInFlight = true;
+    try {
+      while (this._messageLoadQueued && generation === this._streamGeneration && this.currentSessionId) {
+        var mode = this._messageLoadQueued;
+        this._messageLoadQueued = false;
+        if (mode === 'reset') this._resetConversationState();
+        await this._fetchMessagePages(generation);
+      }
+    } catch (err) {
+      if (generation === this._streamGeneration) {
+        this.setStatus('idle');
+        this._logStreamError('message load failed', err);
+      }
+    } finally {
+      this._messageLoadInFlight = false;
+      if (this._messageLoadQueued) {
+        this._scheduleMessageLoad(this._streamGeneration, false);
+      }
+    }
+  };
+
+  MobileModeController.prototype._fetchMessagePages = async function (generation) {
+    var sessionId = this.currentSessionId;
+    if (!sessionId) return;
+
+    for (;;) {
+      if (generation !== this._streamGeneration || sessionId !== this.currentSessionId) return;
+      var after = this.messageCursor ? encodeTurnCursor(this.messageCursor) : null;
+      var url = '/api/control/sessions/' + encodeURIComponent(sessionId) + '/messages?limit=' + TURN_PAGE_LIMIT;
+      if (after) url += '&after=' + encodeURIComponent(after);
+
+      var data = await this._fetchJson(url);
+      if (generation !== this._streamGeneration || sessionId !== this.currentSessionId) return;
+
+      var nextEpoch = data && data.epoch;
+      var epochChanged = !!(this.messageEpoch && nextEpoch && nextEpoch !== this.messageEpoch);
+      if ((data.reset || epochChanged) && after) {
+        this._resetConversationState();
+        continue;
+      }
+      if (data.reset || epochChanged) this._resetConversationState();
+
+      if (nextEpoch) this.messageEpoch = nextEpoch;
+      if (data.cursor) this.messageCursor = data.cursor;
+      this._appendTurnItems(data.items || [], false);
+      if (!data.more) break;
+    }
+  };
+
+  MobileModeController.prototype._pollControlEvents = async function (generation) {
+    if (generation !== this._streamGeneration || !this.currentSessionId) return;
+
+    var url = '/api/control/events?kinds=' + encodeURIComponent(CONTROL_EVENT_KINDS) + '&timeoutMs=' + CONTROL_EVENTS_TIMEOUT_MS;
+    if (this.eventCursor) url += '&cursor=' + encodeURIComponent(this.eventCursor);
+
+    try {
+      var data = await this._fetchJson(url);
+      if (generation !== this._streamGeneration || !this.currentSessionId) return;
+      if (data.cursor) this.eventCursor = data.cursor;
+
+      if (data.gaps && data.gaps.length) {
+        this._scheduleMessageLoad(generation, true);
+      }
+
+      var events = data.events || [];
+      var sawCurrentSession = false;
+      for (var i = 0; i < events.length; i++) {
+        if (String(events[i].sessionId || '') !== this.currentSessionId) continue;
+        sawCurrentSession = true;
+        this._applyControlEvent(events[i]);
+      }
+      if (sawCurrentSession) this._scheduleMessageLoad(generation, false);
+      this._pollControlEvents(generation);
+    } catch (err) {
+      if (generation !== this._streamGeneration) return;
+      this._logStreamError('event poll failed', err);
+      var self = this;
+      this._clearEventRetry();
+      this._eventRetryTimer = window.setTimeout(function () {
+        self._eventRetryTimer = null;
+        self._pollControlEvents(generation);
+      }, EVENT_RETRY_MS);
+    }
+  };
+
+  MobileModeController.prototype._applyControlEvent = function (event) {
+    if (!event || !event.kind) return;
+    if (event.kind === 'became_busy') {
+      this.setNeedsInput(false);
+      this.setStatus('working\u2026');
+    } else if (event.kind === 'waiting_input') {
+      this.state.pendingSurface = 'composer';
+      this.setNeedsInput(true);
+      this.setStatus('needs you');
+    } else if (event.kind === 'became_idle' || event.kind === 'turn_ended') {
+      if (this.state.pendingSurface === 'composer') this.state.pendingSurface = null;
+      this.setNeedsInput(false);
+      this.setStatus('idle');
+    }
+  };
+
+  MobileModeController.prototype._resetConversationState = function () {
+    this.turnItems = [];
+    this.renderedItemIds = new Map();
+    this.messageCursor = null;
+    this.messageEpoch = null;
+    this._paintConversation(true);
+  };
+
+  MobileModeController.prototype._appendTurnItems = function (items, forceScroll) {
+    var added = false;
+    for (var i = 0; i < items.length; i++) {
+      var item = normalizeTurnItem(items[i]);
+      if (!item) continue;
+      var key = item.id;
+      if (key == null || key === '') {
+        key = 'local:' + (++this._localItemSeq);
+        item.id = key;
+      }
+      if (this.renderedItemIds.has(key)) continue;
+      this.renderedItemIds.set(key, true);
+      this.turnItems.push(item);
+      added = true;
+    }
+    if (added || forceScroll) this._paintConversation(forceScroll !== false);
+  };
+
+  MobileModeController.prototype._paintConversation = function (forceScroll) {
+    if (!this.messageStack) return;
+    clearNode(this.messageStack);
+    var grouped = this._groupTurnItems(this.turnItems || []);
     for (var i = 0; i < grouped.length; i++) {
       if (grouped[i].type === 'tool') {
         this.messageStack.appendChild(this._renderToolCard(grouped[i]));
@@ -488,7 +637,44 @@
         this.messageStack.appendChild(this._renderTurnItem(grouped[i].item));
       }
     }
-    this.scrollMessagesToBottom(true);
+    this.scrollMessagesToBottom(forceScroll);
+  };
+
+  MobileModeController.prototype._fetchJson = async function (url) {
+    var response = await this._authFetch(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json' }
+    });
+    if (!response.ok) {
+      throw new Error('HTTP ' + response.status + ' for ' + url);
+    }
+    return response.json();
+  };
+
+  MobileModeController.prototype._authFetch = function (url, options) {
+    options = options || {};
+    if (this.app && typeof this.app.authFetch === 'function') {
+      return this.app.authFetch(url, options);
+    }
+
+    var headers = {};
+    if (window.authManager && typeof window.authManager.getAuthHeaders === 'function') {
+      headers = window.authManager.getAuthHeaders();
+    }
+    var request = merge({}, options);
+    request.method = request.method || 'GET';
+    request.headers = merge(headers, options.headers || {});
+    return fetch(url, request);
+  };
+
+  MobileModeController.prototype._clearEventRetry = function () {
+    if (!this._eventRetryTimer) return;
+    window.clearTimeout(this._eventRetryTimer);
+    this._eventRetryTimer = null;
+  };
+
+  MobileModeController.prototype._logStreamError = function (message, err) {
+    if (window.console && console.warn) console.warn('[mobile-mode] ' + message, err && err.message ? err.message : err);
   };
 
   MobileModeController.prototype.renderDecision = function (data) {
@@ -526,7 +712,7 @@
     if (isDecisionSurface(name)) this.state.pendingSurface = name;
 
     this.body.classList.toggle('has-surface', Boolean(name));
-    this.body.classList.toggle('has-decision', isDecisionSurface(name));
+    this._syncNeedsPill();
     this.body.dataset.surface = name || '';
 
     for (var i = 0; i < this.sheets.length; i++) {
@@ -550,7 +736,7 @@
       this._focusSurface(name);
     } else if (name === 'composer') {
       this.stopCountdown();
-      this.setStatus('Claude idle');
+      this.setStatus(this._statusAfterSurfaceChange('idle'));
       this._focusSurface(name, this.composerText);
     }
 
@@ -565,8 +751,10 @@
     }
 
     this.state.activeSurface = null;
-    this.state.pendingSurface = null;
-    this.body.classList.remove('has-surface', 'has-decision');
+    if (!this.state.needsInput) this.state.pendingSurface = null;
+    else this.state.pendingSurface = 'composer';
+    this.body.classList.remove('has-surface');
+    this._syncNeedsPill();
     this.body.dataset.surface = '';
 
     for (var i = 0; i < this.sheets.length; i++) {
@@ -576,7 +764,7 @@
       this.sheets[i].style.transition = '';
     }
 
-    if (nextStatus) this.setStatus(nextStatus);
+    if (nextStatus) this.setStatus(this._statusAfterSurfaceChange(nextStatus));
     this.syncVisualViewport();
   };
 
@@ -611,7 +799,7 @@
     this.decisionStubs.question = merge(clone(this.decisionStubs.question), data);
     data = this.decisionStubs.question;
     this.questionTitle.textContent = data.question || 'Claude has a question';
-    this.questionOptions.innerHTML = '';
+    clearNode(this.questionOptions);
 
     var options = data.options || [];
     for (var i = 0; i < options.length; i++) {
@@ -747,7 +935,22 @@
 
   MobileModeController.prototype.setStatus = function (text) {
     this.statusText.textContent = text;
-    this.statusChip.classList.toggle('working', /working|waiting|running/i.test(text));
+    this.statusChip.classList.toggle('working', /working|waiting|running|needs/i.test(text));
+  };
+
+  MobileModeController.prototype._statusAfterSurfaceChange = function (fallback) {
+    if (this.state.needsInput && (!fallback || /^Claude idle|^idle$/i.test(fallback))) return 'needs you';
+    return fallback || (this.state.needsInput ? 'needs you' : 'idle');
+  };
+
+  MobileModeController.prototype.setNeedsInput = function (needsInput) {
+    this.state.needsInput = !!needsInput;
+    this._syncNeedsPill();
+  };
+
+  MobileModeController.prototype._syncNeedsPill = function () {
+    var active = !!(this.state.needsInput || isDecisionSurface(this.state.pendingSurface) || isDecisionSurface(this.state.activeSurface));
+    this.body.classList.toggle('has-decision', active);
   };
 
   MobileModeController.prototype.addUserMessage = function (text) {
@@ -848,7 +1051,7 @@
 
   MobileModeController.prototype._groupTurnItems = function (items) {
     var out = [];
-    var byToolUseId = {};
+    var byToolUseId = new Map();
 
     for (var i = 0; i < items.length; i++) {
       var item = items[i];
@@ -856,9 +1059,9 @@
       if (item.kind === 'tool-call') {
         var group = { type: 'tool', call: item, result: null };
         out.push(group);
-        if (item.toolUseId) byToolUseId[item.toolUseId] = group;
+        if (item.toolUseId) byToolUseId.set(item.toolUseId, group);
       } else if (item.kind === 'tool-result') {
-        var existing = item.toolUseId && byToolUseId[item.toolUseId];
+        var existing = item.toolUseId ? byToolUseId.get(item.toolUseId) : null;
         if (existing) existing.result = item;
         else out.push({ type: 'tool', call: null, result: item });
       } else {
@@ -871,7 +1074,7 @@
   MobileModeController.prototype._renderTurnItem = function (item) {
     if (item.kind === 'user-text') return this._renderBubble('user', null, item.text || '');
     if (item.kind === 'assistant-text') return this._renderBubble('assistant', 'Claude', item.text || '');
-    if (item.kind === 'thinking') return this._renderEvent('thinking\u2026 ' + (item.text || ''));
+    if (item.kind === 'thinking') return this._renderEvent('thinking\u2026 ' + (item.text || item.thinking || ''));
     return this._renderEvent(item.text || item.kind || 'event');
   };
 
@@ -992,7 +1195,7 @@
   };
 
   MobileModeController.prototype._renderPlanText = function (text) {
-    this.planDoc.innerHTML = '';
+    clearNode(this.planDoc);
     var lines = String(text || '').split(/\r?\n/);
     var list = null;
     var fence = null;
@@ -1126,7 +1329,6 @@
     renderConversation: function (items) { if (controller) controller.renderConversation(items); },
     renderDecision: function (data) { if (controller) controller.renderDecision(data); },
     setDecisionStub: function (kind, data) { if (controller) controller.setDecisionStub(kind, data); },
-    STUB_TURN_STREAM: STUB_TURN_STREAM,
     STUB_DECISIONS: STUB_DECISIONS
   };
 
@@ -1151,6 +1353,35 @@
     if (!node || node.nodeType !== 1) return false;
     var fn = node.matches || node.msMatchesSelector || node.webkitMatchesSelector;
     return fn ? fn.call(node, selector) : false;
+  }
+
+  function clearNode(node) {
+    while (node && node.firstChild) node.removeChild(node.firstChild);
+  }
+
+  function encodeTurnCursor(cursor) {
+    if (!cursor || !cursor.epoch) return '';
+    return JSON.stringify({ epoch: String(cursor.epoch), offset: Number(cursor.offset) || 0 });
+  }
+
+  function normalizeTurnItem(item) {
+    if (!item || typeof item !== 'object') return null;
+    var kind = String(item.kind || '');
+    if (!/^(user-text|assistant-text|tool-call|tool-result|thinking)$/.test(kind)) return null;
+    var out = {
+      id: item.id == null ? null : String(item.id),
+      kind: kind
+    };
+    if (item.uuid != null) out.uuid = String(item.uuid);
+    if (item.timestamp != null) out.timestamp = item.timestamp;
+    if (item.text != null) out.text = String(item.text);
+    if (item.thinking != null) out.thinking = String(item.thinking);
+    if (item.toolUseId != null) out.toolUseId = String(item.toolUseId);
+    if (item.name != null) out.name = String(item.name);
+    if (Object.prototype.hasOwnProperty.call(item, 'input')) out.input = item.input;
+    if (Object.prototype.hasOwnProperty.call(item, 'content')) out.content = item.content;
+    if (Object.prototype.hasOwnProperty.call(item, 'isError')) out.isError = !!item.isError;
+    return out;
   }
 
   function clone(value) {

--- a/src/public/mobile-mode.js
+++ b/src/public/mobile-mode.js
@@ -6,12 +6,12 @@
  * Conversation data is read from the control-plane semantic turn stream:
  *   {id, kind:'user-text'|'assistant-text'|'tool-call'|'tool-result'|
  *    'thinking', text?, thinking?, toolUseId?, name?, input?, content?, isError?}
- * Decision sheets remain locally rendered until the hook decision channel lands.
+ * Decision sheets are rendered from the structured Channel-1 decision store.
  */
 (function () {
   var controller = null;
   var TURN_PAGE_LIMIT = 200;
-  var CONTROL_EVENT_KINDS = 'turn_ended,became_busy,became_idle,waiting_input';
+  var CONTROL_EVENT_KINDS = 'turn_ended,became_busy,became_idle,waiting_input,decision_pending';
   var CONTROL_EVENTS_TIMEOUT_MS = 25000;
   var SESSION_WATCH_MS = 500;
   var EVENT_RETRY_MS = 1200;
@@ -61,6 +61,7 @@
     this.statusText = null;
     this.modeLabel = null;
     this.needsPill = null;
+    this.needsPillLabel = null;
     this.backdrop = null;
     this.sheets = [];
     this.composerText = null;
@@ -96,7 +97,13 @@
     this._eventRetryTimer = null;
     this._messageLoadInFlight = false;
     this._messageLoadQueued = false;
+    this._decisionLoadInFlight = false;
+    this._decisionLoadQueued = false;
+    this._decisionAnswerInFlight = false;
     this._localItemSeq = 0;
+    this.pendingDecisions = [];
+    this.currentDecision = null;
+    this.currentDecisionSurface = null;
     this.decisionStubs = {
       permission: clone(STUB_DECISIONS.permission),
       plan: clone(STUB_DECISIONS.plan),
@@ -152,7 +159,7 @@
       '        <button class="overflow-btn" type="button" aria-label="More options">\u22ee</button>',
       '      </div>',
       '    </header>',
-      '    <button class="needs-pill" type="button" data-mobile-needs-pill aria-live="polite"><span class="pulse" aria-hidden="true"></span><span>Claude needs you</span></button>',
+      '    <button class="needs-pill" type="button" data-mobile-needs-pill aria-live="polite"><span class="pulse" aria-hidden="true"></span><span data-mobile-needs-label>Claude needs you</span></button>',
       '    <main class="message-list" data-mobile-message-list aria-label="Messages">',
       '      <div class="message-stack" data-mobile-message-stack></div>',
       '    </main>',
@@ -255,6 +262,7 @@
     this.statusText = this.el.querySelector('[data-mobile-status-text]');
     this.modeLabel = this.el.querySelector('[data-mobile-mode-label]');
     this.needsPill = this.el.querySelector('[data-mobile-needs-pill]');
+    this.needsPillLabel = this.el.querySelector('[data-mobile-needs-label]');
     this.backdrop = this.el.querySelector('[data-mobile-backdrop]');
     this.sheets = toArray(this.el.querySelectorAll('[data-surface]'));
     this.composerText = this.el.querySelector('[data-mobile-composer-text]');
@@ -280,7 +288,9 @@
     this.el.addEventListener('click', function (event) {
       var openButton = closest(event.target, '[data-open-surface]', self.el);
       if (openButton) {
-        self.openSurface(openButton.getAttribute('data-open-surface'));
+        var requestedSurface = openButton.getAttribute('data-open-surface');
+        if (requestedSurface === 'composer' && self._hasBlockingDecision()) self._presentNextDecision();
+        else self.openSurface(requestedSurface);
         return;
       }
 
@@ -297,7 +307,8 @@
       }
 
       if (closest(event.target, '[data-mobile-needs-pill]', self.el)) {
-        if (self.state.pendingSurface) self.openSurface(self.state.pendingSurface);
+        if (self.currentDecision) self._presentNextDecision();
+        else if (self.state.pendingSurface) self.openSurface(self.state.pendingSurface);
         return;
       }
 
@@ -317,18 +328,30 @@
       }
 
       if (closest(event.target, '[data-mobile-reject-plan]', self.el)) {
-        self.closeSurface('Claude idle \u00b7 plan rejected');
-        self.addEventChip('Plan rejected');
+        if (self.currentDecision && self.currentDecision.kind === 'plan') {
+          self._answerCurrentDecision({ choice: 'reject' }, 'Claude idle \u00b7 plan rejected');
+        } else {
+          self.closeSurface('Claude idle \u00b7 plan rejected');
+          self.addEventChip('Plan rejected');
+        }
         return;
       }
 
       if (closest(event.target, '[data-mobile-approve-plan]', self.el)) {
-        self.closeSurface('working\u2026 \u00b7 plan approved');
-        self.addEventChip('Plan approved \u00b7 TODO(wire) hook return');
+        if (self.currentDecision && self.currentDecision.kind === 'plan') {
+          self._answerCurrentDecision({ choice: 'accept' }, 'working\u2026 \u00b7 plan approved');
+        } else {
+          self.closeSurface('working\u2026 \u00b7 plan approved');
+          self.addEventChip('Plan approved \u00b7 TODO(wire) hook return');
+        }
         return;
       }
 
       if (closest(event.target, '[data-mobile-comment-plan]', self.el)) {
+        if (self._hasBlockingDecision()) {
+          self.setStatus('needs you \u00b7 approve or reject first');
+          return;
+        }
         self.composerText.value = 'I want to adjust the plan: ';
         self.openSurface('composer');
         return;
@@ -472,8 +495,11 @@
     this.currentSessionId = sessionId;
     this.eventCursor = null;
     this._messageLoadQueued = false;
+    this._decisionLoadQueued = false;
+    this._decisionAnswerInFlight = false;
     this._clearEventRetry();
     this._resetConversationState();
+    this._resetDecisionState();
     this._syncSessionChrome();
     this.setNeedsInput(false);
     this.setStatus('idle');
@@ -481,6 +507,7 @@
     if (!sessionId) return;
     this._pollControlEvents(generation);
     this._scheduleMessageLoad(generation, true);
+    this._scheduleDecisionLoad(generation);
   };
 
   MobileModeController.prototype._currentSessionId = function () {
@@ -548,6 +575,38 @@
     }
   };
 
+  MobileModeController.prototype._scheduleDecisionLoad = function (generation) {
+    if (generation !== this._streamGeneration || !this.currentSessionId) return;
+    this._decisionLoadQueued = true;
+    if (this._decisionLoadInFlight) return;
+    this._drainDecisionLoads(generation);
+  };
+
+  MobileModeController.prototype._drainDecisionLoads = async function (generation) {
+    if (this._decisionLoadInFlight) return;
+    this._decisionLoadInFlight = true;
+    try {
+      while (this._decisionLoadQueued && generation === this._streamGeneration && this.currentSessionId) {
+        this._decisionLoadQueued = false;
+        await this._fetchPendingDecisions(generation);
+      }
+    } catch (err) {
+      if (generation === this._streamGeneration) this._logStreamError('decision load failed', err);
+    } finally {
+      this._decisionLoadInFlight = false;
+      if (this._decisionLoadQueued) this._scheduleDecisionLoad(this._streamGeneration);
+    }
+  };
+
+  MobileModeController.prototype._fetchPendingDecisions = async function (generation) {
+    var sessionId = this.currentSessionId;
+    if (!sessionId) return;
+    var url = '/api/control/sessions/' + encodeURIComponent(sessionId) + '/decisions';
+    var data = await this._fetchJson(url);
+    if (generation !== this._streamGeneration || sessionId !== this.currentSessionId) return;
+    this._syncPendingDecisions(data && data.decisions ? data.decisions : []);
+  };
+
   MobileModeController.prototype._pollControlEvents = async function (generation) {
     if (generation !== this._streamGeneration || !this.currentSessionId) return;
 
@@ -561,6 +620,7 @@
 
       if (data.gaps && data.gaps.length) {
         this._scheduleMessageLoad(generation, true);
+        this._scheduleDecisionLoad(generation);
       }
 
       var events = data.events || [];
@@ -571,6 +631,7 @@
         this._applyControlEvent(events[i]);
       }
       if (sawCurrentSession) this._scheduleMessageLoad(generation, false);
+      if (this._hasBlockingDecision()) this._scheduleDecisionLoad(generation);
       this._pollControlEvents(generation);
     } catch (err) {
       if (generation !== this._streamGeneration) return;
@@ -579,6 +640,7 @@
       this._clearEventRetry();
       this._eventRetryTimer = window.setTimeout(function () {
         self._eventRetryTimer = null;
+        self._scheduleDecisionLoad(generation);
         self._pollControlEvents(generation);
       }, EVENT_RETRY_MS);
     }
@@ -586,17 +648,26 @@
 
   MobileModeController.prototype._applyControlEvent = function (event) {
     if (!event || !event.kind) return;
+    if (event.kind === 'decision_pending') {
+      this._scheduleDecisionLoad(this._streamGeneration);
+      return;
+    }
     if (event.kind === 'became_busy') {
       this.setNeedsInput(false);
-      this.setStatus('working\u2026');
+      if (!this._hasBlockingDecision()) this.setStatus('working\u2026');
     } else if (event.kind === 'waiting_input') {
-      this.state.pendingSurface = 'composer';
       this.setNeedsInput(true);
-      this.setStatus('needs you');
+      if (this._hasBlockingDecision()) {
+        if (this.currentDecision) this.state.pendingSurface = this.currentDecisionSurface || this.currentDecision.kind;
+        this._syncNeedsPill();
+      } else {
+        this.state.pendingSurface = 'composer';
+        this.setStatus('needs you');
+      }
     } else if (event.kind === 'became_idle' || event.kind === 'turn_ended') {
       if (this.state.pendingSurface === 'composer') this.state.pendingSurface = null;
       this.setNeedsInput(false);
-      this.setStatus('idle');
+      if (!this._hasBlockingDecision()) this.setStatus('idle');
     }
   };
 
@@ -677,14 +748,171 @@
     if (window.console && console.warn) console.warn('[mobile-mode] ' + message, err && err.message ? err.message : err);
   };
 
+  MobileModeController.prototype._resetDecisionState = function () {
+    this.pendingDecisions = [];
+    this.currentDecision = null;
+    this.currentDecisionSurface = null;
+    this._decisionAnswerInFlight = false;
+    if (isDecisionSurface(this.state.activeSurface)) this.closeSurface('idle');
+    if (isDecisionSurface(this.state.pendingSurface)) this.state.pendingSurface = null;
+    this._setDecisionAnswering(false);
+    this._syncNeedsPill();
+  };
+
+  MobileModeController.prototype._syncPendingDecisions = function (decisions) {
+    var normalized = [];
+    for (var i = 0; i < (decisions || []).length; i++) {
+      var decision = normalizeDecision(decisions[i]);
+      if (decision) normalized.push(decision);
+    }
+    normalized.sort(function (a, b) {
+      return (a.createdAt - b.createdAt) || String(a.decisionId || '').localeCompare(String(b.decisionId || ''));
+    });
+
+    var currentId = this.currentDecision && this.currentDecision.decisionId;
+    if (currentId) {
+      var current = findDecision(normalized, currentId);
+      this.pendingDecisions = normalized;
+      if (!current) {
+        this._completeDecision(currentId, true, 'idle');
+        return;
+      }
+      this.currentDecision = current;
+      this.currentDecisionSurface = current.kind;
+      this.state.pendingSurface = current.kind;
+      this.renderDecision(current);
+      this._syncNeedsPill();
+      if (this.state.activeSurface === 'composer') this.openSurface(current.kind);
+      return;
+    }
+
+    this.pendingDecisions = normalized;
+    if (!this.pendingDecisions.length) {
+      this._syncNeedsPill();
+      return;
+    }
+    this._presentNextDecision();
+  };
+
+  MobileModeController.prototype._presentNextDecision = function () {
+    if (this.currentDecision) {
+      this.renderDecision(this.currentDecision);
+      this.state.pendingSurface = this.currentDecisionSurface || this.currentDecision.kind;
+      this._syncNeedsPill();
+      this.openSurface(this.state.pendingSurface);
+      return;
+    }
+    var next = this.pendingDecisions && this.pendingDecisions.length ? this.pendingDecisions[0] : null;
+    if (!next) {
+      if (isDecisionSurface(this.state.pendingSurface)) this.state.pendingSurface = this.state.needsInput ? 'composer' : null;
+      this._syncNeedsPill();
+      return;
+    }
+    this.currentDecision = next;
+    this.currentDecisionSurface = next.kind;
+    this.renderDecision(next);
+    this.state.pendingSurface = next.kind;
+    this._syncNeedsPill();
+    this.openSurface(next.kind);
+  };
+
+  MobileModeController.prototype._hasBlockingDecision = function () {
+    return !!(this.currentDecision || (this.pendingDecisions && this.pendingDecisions.length));
+  };
+
+  MobileModeController.prototype._answerCurrentDecision = async function (body, nextStatus) {
+    if (!this.currentDecision || !this.currentDecision.decisionId || this._decisionAnswerInFlight) return false;
+    var decisionId = this.currentDecision.decisionId;
+    this._decisionAnswerInFlight = true;
+    this._setDecisionAnswering(true);
+
+    try {
+      var response = await this._authFetch('/api/control/decisions/' + encodeURIComponent(decisionId) + '/answer', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(body || {})
+      });
+
+      if (response.status === 409 || response.status === 404) {
+        this._completeDecision(decisionId, true, 'idle');
+        this._scheduleDecisionLoad(this._streamGeneration);
+        return true;
+      }
+      if (!response.ok) throw new Error('HTTP ' + response.status + ' for decision answer');
+
+      var data = null;
+      try { data = await response.json(); } catch (_) { data = null; }
+      if (data && data.ok === true) {
+        this._completeDecision(decisionId, false, nextStatus || 'idle');
+        this._scheduleDecisionLoad(this._streamGeneration);
+        return true;
+      }
+      throw new Error('decision answer was not accepted');
+    } catch (err) {
+      if (this.currentDecision && this.currentDecision.decisionId === decisionId) {
+        this._setDecisionAnswering(false);
+        this._decisionAnswerInFlight = false;
+        this.setStatus('needs you \u00b7 answer failed');
+      }
+      this._logStreamError('decision answer failed', err);
+      return true;
+    }
+  };
+
+  MobileModeController.prototype._completeDecision = function (decisionId, quiet, nextStatus) {
+    decisionId = String(decisionId || '');
+    this.pendingDecisions = (this.pendingDecisions || []).filter(function (decision) {
+      return String(decision.decisionId || '') !== decisionId;
+    });
+
+    var wasCurrent = this.currentDecision && String(this.currentDecision.decisionId || '') === decisionId;
+    if (wasCurrent) {
+      var surface = this.currentDecisionSurface || this.currentDecision.kind;
+      this.currentDecision = null;
+      this.currentDecisionSurface = null;
+      this._decisionAnswerInFlight = false;
+      this._setDecisionAnswering(false);
+      if (this.state.activeSurface === surface) this.closeSurface(quiet ? (nextStatus || 'idle') : nextStatus);
+      else if (this.state.pendingSurface === surface) this.state.pendingSurface = this.state.needsInput ? 'composer' : null;
+    }
+
+    this._syncNeedsPill();
+    this._presentNextDecision();
+  };
+
+  MobileModeController.prototype._setDecisionAnswering = function (answering) {
+    var selectors = [
+      '[data-mobile-deny-permission]',
+      '[data-mobile-approve-permission]',
+      '[data-mobile-reject-plan]',
+      '[data-mobile-approve-plan]',
+      '[data-mobile-send-question]'
+    ];
+    for (var i = 0; i < selectors.length; i++) {
+      var nodes = this.el ? this.el.querySelectorAll(selectors[i]) : [];
+      for (var j = 0; j < nodes.length; j++) nodes[j].disabled = !!answering;
+    }
+    var inputs = this.questionOptions ? this.questionOptions.querySelectorAll('input') : [];
+    for (var k = 0; k < inputs.length; k++) inputs[k].disabled = !!answering;
+  };
+
   MobileModeController.prototype.renderDecision = function (data) {
-    // TODO(wire): Feed this from hook/control decision payloads. Channel-1
-    // allow/deny/answer transport is deliberately absent in this client-shell
-    // increment; buttons only update local UI stubs.
-    if (!data || !data.kind) return;
-    if (data.kind === 'permission') this.renderPermission(data);
-    if (data.kind === 'plan') this.renderPlan(data);
-    if (data.kind === 'question') this.renderQuestion(data);
+    var decision = normalizeDecision(data);
+    if (!decision) return;
+    this._markDecisionSurface(decision.kind, decision.decisionId);
+    if (decision.kind === 'permission') this.renderPermission(decision);
+    if (decision.kind === 'plan') this.renderPlan(decision);
+    if (decision.kind === 'question') this.renderQuestion(decision);
+  };
+
+  MobileModeController.prototype._markDecisionSurface = function (kind, decisionId) {
+    var sheet = this.el && this.el.querySelector('[data-surface="' + kind + '"]');
+    if (!sheet) return;
+    if (decisionId) sheet.setAttribute('data-decision-id', decisionId);
+    else sheet.removeAttribute('data-decision-id');
   };
 
   MobileModeController.prototype.setDecisionStub = function (kind, data) {
@@ -703,9 +931,10 @@
       return;
     }
 
-    if (name === 'permission') this.renderPermission(this.decisionStubs.permission);
-    if (name === 'plan') this.renderPlan(this.decisionStubs.plan);
-    if (name === 'question') this.renderQuestion(this.decisionStubs.question);
+    if (this.currentDecision && this.currentDecision.kind === name) this.renderDecision(this.currentDecision);
+    else if (name === 'permission') this.renderPermission(this.decisionStubs.permission);
+    else if (name === 'plan') this.renderPlan(this.decisionStubs.plan);
+    else if (name === 'question') this.renderQuestion(this.decisionStubs.question);
 
     if (this.state.activeSurface === 'permission' && name !== 'permission') this.stopCountdown();
     this.state.activeSurface = name;
@@ -770,8 +999,12 @@
 
   MobileModeController.prototype.renderPermission = function (data) {
     data = data || this.decisionStubs.permission;
-    this.decisionStubs.permission = merge(clone(this.decisionStubs.permission), data);
-    data = this.decisionStubs.permission;
+    if (!data.decisionId) {
+      var base = clone(this.decisionStubs.permission);
+      if (data && !Object.prototype.hasOwnProperty.call(data, 'destructive')) delete base.destructive;
+      this.decisionStubs.permission = merge(base, data);
+      data = this.decisionStubs.permission;
+    }
 
     var destructive = data.destructive;
     if (destructive == null) destructive = this._isDestructiveCommand(data.command || '');
@@ -790,29 +1023,37 @@
 
   MobileModeController.prototype.renderPlan = function (data) {
     data = data || this.decisionStubs.plan;
+    if (data.decisionId) {
+      this._renderPlanText(data.plan || '');
+      return;
+    }
     this.decisionStubs.plan = merge(clone(this.decisionStubs.plan), data);
     this._renderPlanText(this.decisionStubs.plan.plan || '');
   };
 
   MobileModeController.prototype.renderQuestion = function (data) {
     data = data || this.decisionStubs.question;
-    this.decisionStubs.question = merge(clone(this.decisionStubs.question), data);
-    data = this.decisionStubs.question;
+    if (!data.decisionId) {
+      this.decisionStubs.question = merge(clone(this.decisionStubs.question), data);
+      data = this.decisionStubs.question;
+    }
     this.questionTitle.textContent = data.question || 'Claude has a question';
     clearNode(this.questionOptions);
 
     var options = data.options || [];
     for (var i = 0; i < options.length; i++) {
+      var optionLabel = options[i].label || ('Option ' + (i + 1));
+      var optionValue = options[i].value != null ? options[i].value : optionLabel;
       var label = document.createElement('label');
       label.className = 'option-card' + (i === 0 ? ' is-selected' : '');
       var input = document.createElement('input');
       input.type = 'radio';
       input.name = 'mobileQuestionChoice';
-      input.value = options[i].label || ('Option ' + (i + 1));
+      input.value = String(optionValue);
       input.checked = i === 0;
       var copy = document.createElement('span');
       var strong = document.createElement('strong');
-      strong.textContent = options[i].label || ('Option ' + (i + 1));
+      strong.textContent = optionLabel;
       var desc = document.createElement('span');
       desc.textContent = options[i].description || '';
       copy.appendChild(strong);
@@ -863,6 +1104,10 @@
   MobileModeController.prototype.sendQuestionAnswer = function () {
     var selected = this.questionOptions.querySelector('input[name="mobileQuestionChoice"]:checked');
     var answer = selected ? selected.value : 'No answer';
+    if (this.currentDecision && this.currentDecision.kind === 'question') {
+      this._answerCurrentDecision({ optionValue: answer }, 'Claude idle \u00b7 answered');
+      return;
+    }
     this.closeSurface('Claude idle \u00b7 answered');
     this.addEventChip('Answered question \u00b7 ' + answer + ' \u00b7 TODO(wire) hook return');
   };
@@ -870,6 +1115,10 @@
   MobileModeController.prototype.approvePermission = function () {
     var cmd = this.decisionStubs.permission.command || '';
     this.stopCountdown();
+    if (this.currentDecision && this.currentDecision.kind === 'permission') {
+      this._answerCurrentDecision({ choice: 'accept' }, 'working\u2026 \u00b7 approved');
+      return;
+    }
     this.closeSurface('working\u2026 \u00b7 approved');
     this.addEventChip('Approved \u00b7 TODO(wire) hook return: ' + cmd);
   };
@@ -879,6 +1128,10 @@
     var dismiss = reason === 'dismiss';
     var cmd = this.decisionStubs.permission.command || '';
     this.stopCountdown();
+    if (this.currentDecision && this.currentDecision.kind === 'permission') {
+      this._answerCurrentDecision({ choice: 'reject' }, timeout ? 'Claude idle \u00b7 denied by timeout' : 'Claude idle \u00b7 denied');
+      return;
+    }
     this.closeSurface(timeout ? 'Claude idle \u00b7 denied by timeout' : 'Claude idle \u00b7 denied');
     this.addEventChip((timeout ? 'Denied by timeout' : (dismiss ? 'Denied by dismiss' : 'Denied')) + ' \u00b7 command was not run: ' + cmd);
   };
@@ -949,8 +1202,14 @@
   };
 
   MobileModeController.prototype._syncNeedsPill = function () {
-    var active = !!(this.state.needsInput || isDecisionSurface(this.state.pendingSurface) || isDecisionSurface(this.state.activeSurface));
+    var decisionCount = this.pendingDecisions ? this.pendingDecisions.length : 0;
+    var active = !!(this.state.needsInput || decisionCount || isDecisionSurface(this.state.pendingSurface) || isDecisionSurface(this.state.activeSurface));
     this.body.classList.toggle('has-decision', active);
+    if (this.needsPillLabel) {
+      if (decisionCount > 1) this.needsPillLabel.textContent = decisionCount + ' pending';
+      else if (decisionCount === 1 || isDecisionSurface(this.state.pendingSurface) || isDecisionSurface(this.state.activeSurface)) this.needsPillLabel.textContent = 'Claude needs you';
+      else this.needsPillLabel.textContent = 'Claude needs you';
+    }
   };
 
   MobileModeController.prototype.addUserMessage = function (text) {
@@ -1303,7 +1562,26 @@
   };
 
   MobileModeController.prototype._isDestructiveCommand = function (command) {
-    return /\b(rm\s+-rf|del\s+\/s|rmdir\s+\/s|remove-item\b.*\b-recurse\b|git\s+clean\s+-fd|drop\s+table)\b/i.test(command || '');
+    command = String(command || '');
+    var patterns = [
+      /\brm\s+-[\w-]*[rf][\w-]*[rf]?\b/i,
+      /\bgit\s+reset\s+--hard\b/i,
+      /\bgit\s+clean\s+-[\w-]*[df][\w-]*\b/i,
+      /\bmkfs(?:\.[\w-]+)?\b/i,
+      /\bdd\s+\S+/i,
+      /(^|[^<>])>\s*\S/,
+      /\btruncate\s+-s\s*0\b/i,
+      /\b(shred|wipefs)\b/i,
+      /\b(del|erase)\s+\/s\b/i,
+      /\brmdir\s+\/s\b/i,
+      /\bremove-item\b.*\b-recurse\b/i,
+      /\bdrop\s+table\b/i,
+      /\b(format|diskpart)\b.*\b(clean|delete)\b/i
+    ];
+    for (var i = 0; i < patterns.length; i++) {
+      if (patterns[i].test(command)) return true;
+    }
+    return false;
   };
 
   function init(options) {
@@ -1381,6 +1659,52 @@
     if (Object.prototype.hasOwnProperty.call(item, 'input')) out.input = item.input;
     if (Object.prototype.hasOwnProperty.call(item, 'content')) out.content = item.content;
     if (Object.prototype.hasOwnProperty.call(item, 'isError')) out.isError = !!item.isError;
+    return out;
+  }
+
+  function findDecision(decisions, decisionId) {
+    decisionId = String(decisionId || '');
+    for (var i = 0; i < (decisions || []).length; i++) {
+      if (String(decisions[i].decisionId || '') === decisionId) return decisions[i];
+    }
+    return null;
+  }
+
+  function normalizeDecision(item) {
+    if (!item || typeof item !== 'object') return null;
+    var rawKind = String(item.kind || '');
+    var kind = null;
+    if (rawKind === 'tool_approval' || rawKind === 'permission') kind = 'permission';
+    if (rawKind === 'plan_approval' || rawKind === 'plan') kind = 'plan';
+    if (rawKind === 'choice_question' || rawKind === 'question') kind = 'question';
+    if (!kind) return null;
+
+    var out = { kind: kind };
+    if (rawKind && rawKind !== kind) out.backendKind = rawKind;
+    if (item.decisionId != null) out.decisionId = String(item.decisionId);
+    if (item.sessionId != null) out.sessionId = String(item.sessionId);
+    out.createdAt = Number(item.createdAt) || 0;
+    out.expiresAt = Number(item.expiresAt) || 0;
+
+    if (item.tool != null) out.tool = String(item.tool);
+    if (item.command != null) out.command = String(item.command);
+    if (item.cwd != null) out.cwd = String(item.cwd);
+    if (item.plan != null) out.plan = String(item.plan);
+    if (item.question != null) out.question = String(item.question);
+    if (item.risk != null) out.risk = String(item.risk);
+    if (Object.prototype.hasOwnProperty.call(item, 'destructive')) out.destructive = !!item.destructive;
+
+    var options = Array.isArray(item.options) ? item.options : [];
+    out.options = [];
+    for (var i = 0; i < options.length; i++) {
+      var option = options[i] || {};
+      var label = option.label != null ? String(option.label) : '';
+      if (!label) label = 'Option ' + (i + 1);
+      var normalized = { label: label };
+      if (option.description != null) normalized.description = String(option.description);
+      if (option.value != null) normalized.value = String(option.value);
+      out.options.push(normalized);
+    }
     return out;
   }
 

--- a/src/public/mobile-proto.html
+++ b/src/public/mobile-proto.html
@@ -1,0 +1,1854 @@
+<!doctype html>
+<!--
+  ============================================================================
+  ai-or-die — "Mobile Mode" UI/UX DESIGN REFERENCE MOCK
+  ============================================================================
+  Status  : approved design reference, 2026-07-07 (NOT production).
+  Purpose : self-contained, backend-free, clickable prototype of every mobile
+            surface (conversation, tool-permission sheet, plan sheet, question
+            sheet, input composer) + the iOS dimension handling, for on-device
+            review before any backend is wired.
+  Spec    : docs/specs/mobile-mode-ui.md   (the "how" and "when")
+  Decision: docs/adrs/0038-mobile-mode-transparent-user-proxy.md
+  Plan    : docs/planning/mobile-mode.md
+  View    : serve src/public and open /mobile-proto.html on a real device
+            (LAN or over a dev tunnel / mesh). Bottom trigger toolbar pops each
+            surface (Permission / destructive toggle / Plan / Question /
+            Composer / iPad-desktop toggle).
+  Self-contained: inline CSS+JS only; no fetch, no external scripts/fonts.
+  ============================================================================
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content">
+  <meta name="theme-color" content="#070a0f">
+  <title>ai-or-die mobile mode prototype</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-left: env(safe-area-inset-left, 0px);
+      --keyboard-bottom: 0px;
+      --bg: #05070b;
+      --bg-2: #090d14;
+      --panel: rgba(14, 20, 30, 0.96);
+      --panel-solid: #0e141e;
+      --panel-2: #111a27;
+      --stroke: rgba(132, 151, 176, 0.18);
+      --stroke-strong: rgba(159, 178, 210, 0.28);
+      --text: #edf4ff;
+      --muted: #8e9bb0;
+      --faint: #5f6c80;
+      --accent: #ff8a2a;
+      --accent-2: #ffd29c;
+      --green: #48d597;
+      --green-2: #133a2b;
+      --blue: #77b7ff;
+      --red: #ff5d5d;
+      --red-2: #441417;
+      --yellow: #ffd166;
+      --shadow: 0 24px 70px rgba(0, 0, 0, 0.56);
+      --radius: 24px;
+      --header-height: 50px;
+      --input-height: 64px;
+      --status-height: 28px;
+      --dock-bottom: calc(var(--safe-bottom) + var(--keyboard-bottom) + 8px);
+      --sheet-bottom: calc(var(--safe-bottom) + var(--keyboard-bottom) + 8px);
+      --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    html {
+      height: 100%;
+      min-height: 100svh;
+      background: var(--bg);
+      -webkit-text-size-adjust: 100%;
+      text-size-adjust: 100%;
+    }
+    body {
+      margin: 0;
+      height: 100%;
+      min-height: 100svh;
+      overflow: hidden;
+      background:
+        radial-gradient(circle at 50% -10%, rgba(255, 138, 42, 0.18), transparent 34%),
+        radial-gradient(circle at 85% 15%, rgba(119, 183, 255, 0.10), transparent 28%),
+        var(--bg);
+      color: var(--text);
+      font-family: var(--sans);
+      font-size: 15px;
+      line-height: 1.42;
+      overscroll-behavior: none;
+      -webkit-font-smoothing: antialiased;
+    }
+    button, textarea, input { font: inherit; }
+    button {
+      border: 0;
+      min-height: 44px;
+      color: inherit;
+      cursor: pointer;
+      touch-action: manipulation;
+      -webkit-tap-highlight-color: transparent;
+    }
+    textarea { -webkit-appearance: none; appearance: none; }
+    [hidden] { display: none !important; }
+
+    #app {
+      position: fixed;
+      inset: 0;
+      height: 100dvh;
+      min-height: 100svh;
+      overflow: hidden;
+      display: flex;
+      justify-content: center;
+      background:
+        linear-gradient(180deg, rgba(13, 19, 29, 0.65), rgba(5, 7, 11, 0.94)),
+        repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.015) 0 1px, transparent 1px 3px);
+    }
+
+    .app-shell {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      max-width: 1240px;
+      overflow: hidden;
+      isolation: isolate;
+    }
+
+    .conversation-pane {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      overflow: hidden;
+      background:
+        linear-gradient(180deg, rgba(12, 17, 25, 0.94), rgba(5, 8, 13, 0.98)),
+        radial-gradient(circle at 20% 8%, rgba(255, 138, 42, 0.10), transparent 30%);
+      transition: filter 220ms ease, transform 220ms ease;
+    }
+    body.has-surface .conversation-pane {
+      filter: saturate(0.82) brightness(0.62);
+    }
+
+    .topbar {
+      position: relative;
+      flex: 0 0 calc(var(--safe-top) + var(--header-height));
+      min-height: calc(var(--safe-top) + var(--header-height));
+      padding: var(--safe-top) max(12px, calc(var(--safe-right) + 12px)) 0 max(12px, calc(var(--safe-left) + 12px));
+      display: flex;
+      align-items: flex-end;
+      border-bottom: 1px solid rgba(132, 151, 176, 0.12);
+      background: rgba(7, 10, 15, 0.82);
+      backdrop-filter: blur(18px) saturate(130%);
+      -webkit-backdrop-filter: blur(18px) saturate(130%);
+      z-index: 5;
+    }
+    .topbar-inner {
+      width: 100%;
+      min-height: var(--header-height);
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .session-mark {
+      width: 28px;
+      height: 28px;
+      border-radius: 10px;
+      display: grid;
+      place-items: center;
+      flex: 0 0 28px;
+      color: #070a0f;
+      font-family: var(--mono);
+      font-size: 15px;
+      font-weight: 900;
+      background: linear-gradient(135deg, var(--accent), #ffcf7a);
+      box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.10), 0 8px 24px rgba(255, 138, 42, 0.20);
+    }
+    .session-title {
+      min-width: 0;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+    }
+    .session-name {
+      color: var(--text);
+      font-weight: 760;
+      letter-spacing: -0.01em;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    .session-meta {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--muted);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+    .mode-dot {
+      width: 5px;
+      height: 5px;
+      border-radius: 99px;
+      background: var(--green);
+      box-shadow: 0 0 10px rgba(72, 213, 151, 0.75);
+    }
+    .overflow-btn {
+      width: 44px;
+      height: 44px;
+      border-radius: 14px;
+      background: transparent;
+      color: var(--muted);
+      font-size: 24px;
+      line-height: 1;
+    }
+    .overflow-btn:active { background: rgba(255, 255, 255, 0.06); }
+
+    .needs-pill {
+      position: absolute;
+      top: calc(var(--safe-top) + var(--header-height) + 8px);
+      right: max(12px, calc(var(--safe-right) + 12px));
+      z-index: 6;
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      min-height: 32px;
+      padding: 6px 11px;
+      border: 1px solid rgba(255, 209, 102, 0.34);
+      border-radius: 999px;
+      background: rgba(39, 28, 10, 0.86);
+      color: #ffdf8d;
+      font-size: 12px;
+      font-weight: 760;
+      letter-spacing: 0.01em;
+      box-shadow: 0 10px 28px rgba(0, 0, 0, 0.28);
+      backdrop-filter: blur(14px);
+      -webkit-backdrop-filter: blur(14px);
+      transform: translateY(-4px);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 180ms ease, transform 180ms ease;
+    }
+    body.has-decision .needs-pill {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    .needs-pill .pulse {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--yellow);
+      box-shadow: 0 0 0 0 rgba(255, 209, 102, 0.65);
+      animation: pulse 1.8s infinite;
+    }
+    @keyframes pulse {
+      0% { box-shadow: 0 0 0 0 rgba(255, 209, 102, 0.55); }
+      70% { box-shadow: 0 0 0 8px rgba(255, 209, 102, 0); }
+      100% { box-shadow: 0 0 0 0 rgba(255, 209, 102, 0); }
+    }
+
+    .message-list {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+      overscroll-behavior: contain;
+      padding: 14px max(14px, calc(var(--safe-right) + 14px)) calc(var(--safe-bottom) + var(--keyboard-bottom) + var(--input-height) + var(--status-height) + 34px) max(14px, calc(var(--safe-left) + 14px));
+      scroll-padding-bottom: calc(var(--safe-bottom) + var(--keyboard-bottom) + var(--input-height) + 60px);
+    }
+    body.has-surface .message-list { pointer-events: none; }
+    .message-stack {
+      max-width: 820px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .message-row { display: flex; align-items: flex-end; gap: 8px; }
+    .message-row.user { justify-content: flex-end; }
+    .message-row.assistant { justify-content: flex-start; }
+    .bubble {
+      max-width: min(84vw, 640px);
+      border-radius: 20px;
+      padding: 11px 13px;
+      border: 1px solid rgba(132, 151, 176, 0.13);
+      box-shadow: 0 8px 26px rgba(0, 0, 0, 0.20);
+    }
+    .user .bubble {
+      border-bottom-right-radius: 8px;
+      color: #07100c;
+      background: linear-gradient(135deg, #79e8af, #3fcf88);
+      border-color: rgba(121, 232, 175, 0.50);
+    }
+    .assistant .bubble {
+      border-bottom-left-radius: 8px;
+      color: #dce7f7;
+      background: rgba(17, 25, 37, 0.92);
+    }
+    .bubble p { margin: 0; }
+    .message-label {
+      margin: 0 0 4px;
+      color: var(--faint);
+      font-size: 11px;
+      font-weight: 680;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .event-row { justify-content: center; }
+    .event-chip {
+      min-height: 28px;
+      display: inline-flex;
+      align-items: center;
+      padding: 5px 10px;
+      border: 1px solid rgba(132, 151, 176, 0.14);
+      border-radius: 999px;
+      color: var(--muted);
+      background: rgba(255, 255, 255, 0.035);
+      font-size: 12px;
+    }
+
+    .tool-card {
+      align-self: stretch;
+      max-width: min(100%, 760px);
+      margin: 0 auto;
+      border: 1px solid rgba(132, 151, 176, 0.16);
+      border-radius: 18px;
+      background: linear-gradient(180deg, rgba(12, 20, 31, 0.96), rgba(9, 14, 22, 0.96));
+      overflow: hidden;
+      box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28);
+    }
+    .tool-summary {
+      width: 100%;
+      min-height: 50px;
+      padding: 10px 12px;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      background: transparent;
+      color: #dce7f7;
+      text-align: left;
+    }
+    .tool-summary:active { background: rgba(255, 255, 255, 0.045); }
+    .tool-disclosure {
+      color: var(--accent);
+      font-size: 15px;
+      transform-origin: 50% 50%;
+      transition: transform 160ms ease;
+    }
+    .tool-card.expanded .tool-disclosure { transform: rotate(90deg); }
+    .tool-line {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      font-weight: 710;
+    }
+    .tool-line code {
+      font-family: var(--mono);
+      color: var(--accent-2);
+      font-size: 0.92em;
+    }
+    .tool-result {
+      flex: 0 0 auto;
+      min-width: 28px;
+      color: var(--green);
+      text-align: right;
+      font-weight: 900;
+    }
+    .tool-details {
+      display: grid;
+      grid-template-rows: 0fr;
+      transition: grid-template-rows 190ms ease;
+    }
+    .tool-details > div {
+      overflow: hidden;
+      border-top: 1px solid transparent;
+    }
+    .tool-card.expanded .tool-details { grid-template-rows: 1fr; }
+    .tool-card.expanded .tool-details > div { border-top-color: rgba(132, 151, 176, 0.12); }
+    .tool-body { padding: 11px 12px 13px; }
+    .detail-grid {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 6px 10px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .detail-grid code, .terminal-output, .diff-output {
+      font-family: var(--mono);
+      font-size: 12px;
+    }
+    .detail-grid code { color: #dbe7f5; overflow-wrap: anywhere; }
+    .terminal-output, .diff-output {
+      margin: 10px 0 0;
+      padding: 10px;
+      border: 1px solid rgba(132, 151, 176, 0.13);
+      border-radius: 12px;
+      overflow-x: auto;
+      color: #b9c7d9;
+      background: rgba(0, 0, 0, 0.24);
+      line-height: 1.45;
+    }
+    .diff-output .add { color: #76f2ae; }
+    .diff-output .del { color: #ff8c8c; }
+
+    .status-line {
+      position: absolute;
+      left: max(14px, calc(var(--safe-left) + 14px));
+      right: max(14px, calc(var(--safe-right) + 14px));
+      bottom: calc(var(--dock-bottom) + var(--input-height) + 2px);
+      z-index: 7;
+      display: flex;
+      justify-content: center;
+      pointer-events: none;
+    }
+    .status-chip {
+      min-height: var(--status-height);
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      padding: 5px 10px;
+      border: 1px solid rgba(132, 151, 176, 0.13);
+      border-radius: 999px;
+      color: var(--muted);
+      background: rgba(7, 10, 15, 0.74);
+      backdrop-filter: blur(14px);
+      -webkit-backdrop-filter: blur(14px);
+      font-size: 12px;
+    }
+    .status-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 99px;
+      background: var(--green);
+      box-shadow: 0 0 10px rgba(72, 213, 151, 0.55);
+    }
+    .status-chip.working .status-dot {
+      background: var(--accent);
+      animation: blink 1s infinite alternate;
+    }
+    @keyframes blink { from { opacity: 0.35; } to { opacity: 1; } }
+
+    .input-dock {
+      position: absolute;
+      left: max(10px, calc(var(--safe-left) + 10px));
+      right: max(10px, calc(var(--safe-right) + 10px));
+      bottom: var(--dock-bottom);
+      z-index: 8;
+      min-height: var(--input-height);
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 48px 48px;
+      align-items: center;
+      gap: 8px;
+      max-width: 860px;
+      margin-inline: auto;
+      transition: opacity 170ms ease, transform 170ms ease;
+    }
+    body.has-surface .input-dock {
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(10px);
+    }
+    .input-field {
+      min-width: 0;
+      height: 52px;
+      padding: 0 14px;
+      border: 1px solid rgba(132, 151, 176, 0.18);
+      border-radius: 18px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      color: var(--muted);
+      text-align: left;
+      background: rgba(12, 18, 27, 0.94);
+      box-shadow: 0 14px 40px rgba(0, 0, 0, 0.32);
+      backdrop-filter: blur(18px) saturate(130%);
+      -webkit-backdrop-filter: blur(18px) saturate(130%);
+    }
+    .input-field:active { border-color: rgba(255, 138, 42, 0.36); }
+    .input-cursor {
+      width: 2px;
+      height: 18px;
+      border-radius: 2px;
+      background: var(--accent);
+      opacity: 0.85;
+    }
+    .round-btn {
+      width: 48px;
+      height: 48px;
+      border-radius: 17px;
+      display: grid;
+      place-items: center;
+      border: 1px solid rgba(132, 151, 176, 0.17);
+      background: rgba(12, 18, 27, 0.94);
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.26);
+      color: #dce7f7;
+    }
+    .round-btn.primary {
+      color: #09120d;
+      border-color: rgba(84, 229, 151, 0.55);
+      background: linear-gradient(135deg, #6df0aa, #35c77e);
+    }
+    .round-btn:active { transform: translateY(1px); }
+
+    .backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 20;
+      background: rgba(0, 0, 0, 0.54);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 220ms ease;
+    }
+    body.has-surface .backdrop {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .surface-layer {
+      position: fixed;
+      inset: 0;
+      z-index: 30;
+      pointer-events: none;
+    }
+    .side-placeholder { display: none; }
+
+    .sheet, .full-sheet {
+      pointer-events: auto;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(calc(100% + var(--safe-bottom) + 20px));
+      transition: transform 260ms cubic-bezier(.2, .9, .2, 1), opacity 200ms ease, visibility 0s linear 260ms;
+      will-change: transform;
+    }
+    .sheet.active, .full-sheet.active {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+      transition-delay: 0s;
+    }
+    .sheet {
+      position: fixed;
+      left: max(10px, calc(var(--safe-left) + 10px));
+      right: max(10px, calc(var(--safe-right) + 10px));
+      bottom: var(--sheet-bottom);
+      max-height: min(78dvh, calc(100dvh - var(--safe-top) - var(--safe-bottom) - var(--keyboard-bottom) - 18px), 680px);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      border: 1px solid var(--stroke-strong);
+      border-radius: var(--radius);
+      background: linear-gradient(180deg, rgba(18, 26, 38, 0.98), rgba(9, 13, 20, 0.98));
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(26px) saturate(135%);
+      -webkit-backdrop-filter: blur(26px) saturate(135%);
+    }
+    .sheet.nudge { animation: nudge 190ms ease; }
+    @keyframes nudge {
+      0%, 100% { transform: translateY(0); }
+      35% { transform: translateY(5px); }
+      70% { transform: translateY(-2px); }
+    }
+    .sheet-grip {
+      align-self: center;
+      width: 42px;
+      height: 5px;
+      margin: 9px 0 7px;
+      border-radius: 999px;
+      background: rgba(159, 178, 210, 0.38);
+    }
+    .sheet-head {
+      padding: 0 16px 10px;
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+    }
+    .sheet-title { flex: 1; min-width: 0; }
+    .eyebrow {
+      margin: 0 0 2px;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 750;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .sheet h2, .full-sheet h2 {
+      margin: 0;
+      color: var(--text);
+      font-size: 21px;
+      line-height: 1.15;
+      letter-spacing: -0.03em;
+    }
+    .sheet-subtitle {
+      margin: 0;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .close-btn {
+      width: 44px;
+      height: 44px;
+      flex: 0 0 44px;
+      border-radius: 15px;
+      color: var(--muted);
+      background: rgba(255, 255, 255, 0.045);
+      font-size: 20px;
+    }
+    .close-btn:active { background: rgba(255, 255, 255, 0.08); }
+    .sheet-content {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+      padding: 0 16px 14px;
+    }
+
+    .command-box {
+      margin-top: 12px;
+      max-height: 116px;
+      overflow: auto;
+      -webkit-overflow-scrolling: touch;
+      border: 1px solid rgba(255, 138, 42, 0.26);
+      border-radius: 16px;
+      background: rgba(0, 0, 0, 0.30);
+    }
+    .command-box code {
+      display: block;
+      min-width: max-content;
+      padding: 13px;
+      color: #ffe2bd;
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.5;
+      white-space: pre;
+    }
+    .cwd-line, .risk-line {
+      display: flex;
+      gap: 8px;
+      margin: 10px 2px 0;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .cwd-line code {
+      min-width: 0;
+      color: #dce7f7;
+      font-family: var(--mono);
+      overflow-wrap: anywhere;
+    }
+    .risk-line strong { color: #ffddad; }
+    .countdown {
+      margin-top: 14px;
+      padding: 11px;
+      border: 1px solid rgba(255, 209, 102, 0.18);
+      border-radius: 15px;
+      background: rgba(255, 209, 102, 0.06);
+    }
+    .countdown-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      color: #ffdf8d;
+      font-size: 13px;
+      font-weight: 750;
+    }
+    .countdown small { color: var(--muted); font-weight: 600; }
+    .countdown-track {
+      position: relative;
+      height: 5px;
+      margin-top: 9px;
+      border-radius: 999px;
+      overflow: hidden;
+      background: rgba(255, 255, 255, 0.08);
+    }
+    .countdown-fill {
+      position: absolute;
+      inset: 0;
+      transform-origin: left center;
+      transform: scaleX(var(--countdown-pct, 1));
+      border-radius: inherit;
+      background: linear-gradient(90deg, var(--yellow), var(--accent), var(--red));
+      transition: transform 240ms linear;
+    }
+    .raw-link {
+      min-height: 44px;
+      padding: 0;
+      color: var(--blue);
+      background: transparent;
+      text-decoration: underline;
+      text-underline-offset: 3px;
+      font-size: 13px;
+      font-weight: 700;
+    }
+    .raw-box {
+      margin: 0 0 12px;
+      max-height: 150px;
+      overflow: auto;
+      padding: 11px;
+      border: 1px solid rgba(132, 151, 176, 0.16);
+      border-radius: 14px;
+      color: #bdcaDC;
+      background: rgba(0, 0, 0, 0.25);
+      font-family: var(--mono);
+      font-size: 11px;
+      line-height: 1.45;
+      white-space: pre;
+    }
+    .sheet-actions {
+      flex: 0 0 auto;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+      padding: 10px 16px calc(16px + max(0px, var(--safe-bottom)));
+      border-top: 1px solid rgba(132, 151, 176, 0.12);
+      background: rgba(8, 12, 18, 0.86);
+      backdrop-filter: blur(18px);
+      -webkit-backdrop-filter: blur(18px);
+    }
+    .btn {
+      min-height: 50px;
+      border-radius: 16px;
+      border: 1px solid rgba(132, 151, 176, 0.18);
+      background: rgba(255, 255, 255, 0.055);
+      color: var(--text);
+      font-weight: 780;
+      letter-spacing: -0.01em;
+    }
+    .btn:active { transform: translateY(1px); }
+    .btn.safe {
+      color: #07120d;
+      border-color: rgba(98, 236, 162, 0.62);
+      background: linear-gradient(135deg, #80efb4, #3cca82);
+      box-shadow: 0 10px 24px rgba(72, 213, 151, 0.16);
+    }
+    .btn.danger {
+      color: #fff4f4;
+      border-color: rgba(255, 93, 93, 0.60);
+      background: linear-gradient(135deg, #d93540, #8d1b21);
+      box-shadow: 0 12px 28px rgba(255, 93, 93, 0.16);
+    }
+    .btn.primary {
+      color: #07101b;
+      border-color: rgba(119, 183, 255, 0.58);
+      background: linear-gradient(135deg, #9ed0ff, #62a9ff);
+      box-shadow: 0 12px 28px rgba(119, 183, 255, 0.14);
+    }
+    .btn.ghost { color: #dce7f7; background: rgba(255, 255, 255, 0.055); }
+    .btn.warn { color: #140d04; background: linear-gradient(135deg, #ffd889, #ff9b2f); border-color: rgba(255, 209, 102, 0.55); }
+
+    .full-sheet {
+      position: fixed;
+      inset: 0;
+      height: 100dvh;
+      min-height: 100svh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      background: linear-gradient(180deg, #111926, #070a0f 70%);
+      box-shadow: var(--shadow);
+    }
+    .plan-header {
+      flex: 0 0 auto;
+      padding: calc(var(--safe-top) + 10px) max(16px, calc(var(--safe-right) + 16px)) 12px max(16px, calc(var(--safe-left) + 16px));
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      border-bottom: 1px solid rgba(132, 151, 176, 0.14);
+      background: rgba(10, 15, 23, 0.92);
+      backdrop-filter: blur(18px);
+      -webkit-backdrop-filter: blur(18px);
+      z-index: 2;
+    }
+    .plan-header h2 { flex: 1; font-size: 19px; }
+    .plan-scroll {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+      padding: 18px max(16px, calc(var(--safe-right) + 16px)) 18px max(16px, calc(var(--safe-left) + 16px));
+    }
+    .plan-doc {
+      max-width: 760px;
+      margin: 0 auto;
+      color: #dbe6f4;
+    }
+    .plan-doc h3 {
+      margin: 20px 0 8px;
+      color: #fff4df;
+      font-size: 18px;
+      letter-spacing: -0.02em;
+    }
+    .plan-doc h3:first-child { margin-top: 0; }
+    .plan-doc p { margin: 0 0 10px; color: #aebbd0; }
+    .checklist {
+      display: grid;
+      gap: 9px;
+      margin: 12px 0 4px;
+      padding: 0;
+      list-style: none;
+    }
+    .checklist li {
+      display: grid;
+      grid-template-columns: 24px 1fr;
+      gap: 8px;
+      align-items: start;
+      padding: 10px;
+      border: 1px solid rgba(132, 151, 176, 0.13);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.035);
+    }
+    .box-check {
+      width: 20px;
+      height: 20px;
+      margin-top: 1px;
+      display: grid;
+      place-items: center;
+      border-radius: 6px;
+      color: #07120d;
+      background: var(--green);
+      font-size: 13px;
+      font-weight: 900;
+    }
+    .fake-diff {
+      margin: 12px 0 0;
+      overflow: auto;
+      padding: 12px;
+      border: 1px solid rgba(132, 151, 176, 0.16);
+      border-radius: 15px;
+      background: rgba(0, 0, 0, 0.30);
+      color: #b9c8db;
+      font-family: var(--mono);
+      font-size: 12px;
+      line-height: 1.55;
+    }
+    .fake-diff .add { color: #76f2ae; }
+    .fake-diff .context { color: #78869a; }
+    .plan-footer {
+      position: sticky;
+      bottom: 0;
+      z-index: 3;
+      flex: 0 0 auto;
+      display: grid;
+      grid-template-columns: 1fr 1fr 1.1fr;
+      gap: 9px;
+      padding: 10px max(16px, calc(var(--safe-right) + 16px)) calc(12px + var(--safe-bottom)) max(16px, calc(var(--safe-left) + 16px));
+      border-top: 1px solid rgba(132, 151, 176, 0.14);
+      background: rgba(8, 12, 18, 0.92);
+      backdrop-filter: blur(18px);
+      -webkit-backdrop-filter: blur(18px);
+    }
+
+    .option-list {
+      display: grid;
+      gap: 9px;
+      margin: 14px 0 18px;
+    }
+    .option-card {
+      position: relative;
+      display: grid;
+      grid-template-columns: 26px 1fr;
+      gap: 10px;
+      align-items: start;
+      min-height: 58px;
+      padding: 12px;
+      border: 1px solid rgba(132, 151, 176, 0.15);
+      border-radius: 17px;
+      background: rgba(255, 255, 255, 0.035);
+      color: #dbe7f5;
+    }
+    .option-card input {
+      width: 22px;
+      height: 22px;
+      margin: 1px 0 0;
+      accent-color: var(--accent);
+    }
+    .option-card strong { display: block; margin-bottom: 2px; }
+    .option-card span { display: block; color: var(--muted); font-size: 12px; }
+    .option-card.is-selected {
+      border-color: rgba(255, 138, 42, 0.55);
+      background: rgba(255, 138, 42, 0.10);
+      box-shadow: 0 0 0 1px rgba(255, 138, 42, 0.10) inset;
+    }
+    .variant-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-top: 4px;
+    }
+    .variant-title h3 {
+      margin: 0;
+      font-size: 15px;
+      color: #fff4df;
+    }
+    .variant-title small { color: var(--muted); }
+
+    .composer-sheet {
+      max-height: min(70dvh, calc(100dvh - var(--safe-top) - var(--safe-bottom) - var(--keyboard-bottom) - 14px), 560px);
+    }
+    .composer-body { display: grid; gap: 12px; }
+    .composer-textarea {
+      width: 100%;
+      min-height: 132px;
+      max-height: 32dvh;
+      resize: none;
+      padding: 13px;
+      border: 1px solid rgba(132, 151, 176, 0.18);
+      border-radius: 17px;
+      outline: none;
+      background: rgba(0, 0, 0, 0.25);
+      color: var(--text);
+      font-family: var(--sans);
+      line-height: 1.45;
+    }
+    .composer-textarea:focus {
+      border-color: rgba(255, 138, 42, 0.55);
+      box-shadow: 0 0 0 3px rgba(255, 138, 42, 0.12);
+    }
+    .control-row {
+      display: grid;
+      grid-template-columns: 48px 1fr auto;
+      gap: 8px;
+      align-items: center;
+    }
+    .control-btn {
+      min-height: 44px;
+      border: 1px solid rgba(132, 151, 176, 0.15);
+      border-radius: 15px;
+      color: #dce7f7;
+      background: rgba(255, 255, 255, 0.05);
+      font-weight: 750;
+    }
+    .slash-btn { font-family: var(--mono); font-size: 22px; color: var(--accent-2); }
+    .mode-toggle { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 0 12px; }
+    .toggle-light {
+      width: 9px;
+      height: 9px;
+      border-radius: 99px;
+      background: var(--green);
+      box-shadow: 0 0 10px rgba(72, 213, 151, 0.6);
+    }
+    .stop-btn {
+      padding: 0 12px;
+      color: #ffd7d7;
+      border-color: rgba(255, 93, 93, 0.28);
+      background: rgba(255, 93, 93, 0.10);
+    }
+    .composer-actions {
+      display: grid;
+      grid-template-columns: 56px 1fr;
+      gap: 9px;
+    }
+
+    .dev-toolbar {
+      position: fixed;
+      top: calc(var(--safe-top) + 8px);
+      left: max(8px, calc(var(--safe-left) + 8px));
+      z-index: 60;
+      width: min(360px, calc(100vw - var(--safe-left) - var(--safe-right) - 16px));
+      padding: 8px;
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      border-radius: 16px;
+      background: rgba(7, 10, 15, 0.78);
+      box-shadow: 0 18px 44px rgba(0, 0, 0, 0.34);
+      backdrop-filter: blur(18px) saturate(135%);
+      -webkit-backdrop-filter: blur(18px) saturate(135%);
+    }
+    .dev-top {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 6px;
+      color: #ffd29c;
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .dev-top span { flex: 1; }
+    .dev-close {
+      width: 44px;
+      height: 44px;
+      min-height: 44px;
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.06);
+      color: var(--muted);
+    }
+    .dev-buttons {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    .dev-buttons button, .dev-restore {
+      min-height: 44px;
+      padding: 0 10px;
+      border-radius: 12px;
+      border: 1px solid rgba(132, 151, 176, 0.14);
+      color: #dce7f7;
+      background: rgba(255, 255, 255, 0.055);
+      font-size: 12px;
+      font-weight: 740;
+    }
+    .dev-buttons button:active, .dev-restore:active { transform: translateY(1px); }
+    .dev-restore {
+      position: fixed;
+      top: calc(var(--safe-top) + 8px);
+      left: max(8px, calc(var(--safe-left) + 8px));
+      z-index: 60;
+      background: rgba(255, 138, 42, 0.22);
+      color: #ffe4c7;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+    }
+
+    @media (orientation: landscape) and (max-height: 520px) {
+      .topbar { flex-basis: calc(var(--safe-top) + 44px); min-height: calc(var(--safe-top) + 44px); }
+      .topbar-inner { min-height: 44px; }
+      .message-list { padding-top: 10px; }
+      .sheet {
+        left: auto;
+        right: max(10px, calc(var(--safe-right) + 10px));
+        width: min(560px, calc(100vw - var(--safe-left) - var(--safe-right) - 20px));
+        max-height: calc(100dvh - var(--safe-top) - var(--safe-bottom) - var(--keyboard-bottom) - 16px);
+      }
+      .full-sheet {
+        inset: calc(var(--safe-top) + 8px) max(8px, calc(var(--safe-right) + 8px)) calc(var(--safe-bottom) + 8px) max(8px, calc(var(--safe-left) + 8px));
+        height: auto;
+        min-height: 0;
+        border: 1px solid var(--stroke-strong);
+        border-radius: 24px;
+        overflow: hidden;
+      }
+      .plan-header { padding-top: 10px; }
+      .plan-footer { padding-bottom: 10px; }
+      .dev-toolbar { width: min(430px, calc(100vw - var(--safe-left) - var(--safe-right) - 16px)); }
+    }
+
+    @media (min-width: 760px) and (min-height: 620px) {
+      body.has-surface .conversation-pane { filter: none; }
+      .app-shell {
+        display: grid;
+        grid-template-columns: minmax(360px, 0.98fr) minmax(360px, 0.88fr);
+        gap: 16px;
+        padding: max(16px, var(--safe-top)) max(16px, var(--safe-right)) max(16px, var(--safe-bottom)) max(16px, var(--safe-left));
+      }
+      .conversation-pane {
+        position: relative;
+        border: 1px solid rgba(132, 151, 176, 0.16);
+        border-radius: 28px;
+        box-shadow: 0 24px 80px rgba(0, 0, 0, 0.40);
+      }
+      .topbar { flex-basis: var(--header-height); min-height: var(--header-height); padding: 0 14px; }
+      .message-list { padding: 16px 16px 128px; }
+      .needs-pill { top: 62px; right: 18px; }
+      .input-dock { left: 16px; right: 16px; bottom: 14px; }
+      .status-line { left: 16px; right: 16px; bottom: 80px; }
+      .backdrop { display: none; }
+      .surface-layer {
+        position: relative;
+        inset: auto;
+        z-index: 1;
+        display: flex;
+        min-width: 0;
+        overflow: hidden;
+        border: 1px solid rgba(132, 151, 176, 0.16);
+        border-radius: 28px;
+        background: rgba(7, 10, 15, 0.56);
+        box-shadow: 0 24px 80px rgba(0, 0, 0, 0.34);
+        pointer-events: auto;
+      }
+      .side-placeholder {
+        width: 100%;
+        min-height: 100%;
+        display: grid;
+        place-items: center;
+        padding: 28px;
+        color: var(--muted);
+        text-align: center;
+      }
+      body.has-surface .side-placeholder { display: none; }
+      .side-placeholder strong { display: block; margin-bottom: 6px; color: #eaf2ff; font-size: 18px; }
+      .sheet, .full-sheet {
+        position: absolute;
+        inset: 0;
+        width: auto;
+        max-height: none;
+        height: auto;
+        min-height: 0;
+        border: 0;
+        border-radius: 0;
+        box-shadow: none;
+        transform: translateX(18px);
+        background: linear-gradient(180deg, rgba(18, 26, 38, 0.98), rgba(9, 13, 20, 0.98));
+      }
+      .sheet.active, .full-sheet.active { transform: translateX(0); }
+      .sheet-grip { display: none; }
+      .sheet-head { padding-top: 18px; }
+      .sheet-actions { padding-bottom: 16px; }
+      .plan-header { padding: 16px; }
+      .plan-scroll { padding: 18px; }
+      .plan-footer { padding: 12px 16px 16px; }
+      .dev-toolbar { left: calc(50% - min(600px, 48vw)); }
+    }
+
+    body.layout-ipad.has-surface .conversation-pane,
+    body.layout-desktop.has-surface .conversation-pane { filter: none; }
+    body.layout-ipad .app-shell,
+    body.layout-desktop .app-shell {
+      display: grid;
+      grid-template-columns: minmax(0, 0.98fr) minmax(0, 0.88fr);
+      gap: 12px;
+      padding: max(12px, var(--safe-top)) max(10px, var(--safe-right)) max(12px, var(--safe-bottom)) max(10px, var(--safe-left));
+    }
+    body.layout-desktop .app-shell { max-width: 1180px; }
+    body.layout-ipad .conversation-pane,
+    body.layout-desktop .conversation-pane {
+      position: relative;
+      border: 1px solid rgba(132, 151, 176, 0.16);
+      border-radius: 26px;
+      box-shadow: 0 24px 80px rgba(0, 0, 0, 0.40);
+    }
+    body.layout-ipad .topbar,
+    body.layout-desktop .topbar { flex-basis: var(--header-height); min-height: var(--header-height); padding: 0 12px; }
+    body.layout-ipad .message-list,
+    body.layout-desktop .message-list { padding: 14px 12px 126px; }
+    body.layout-ipad .input-dock,
+    body.layout-desktop .input-dock { left: 12px; right: 12px; bottom: 12px; }
+    body.layout-ipad .status-line,
+    body.layout-desktop .status-line { left: 12px; right: 12px; bottom: 78px; }
+    body.layout-ipad .needs-pill,
+    body.layout-desktop .needs-pill { top: 60px; right: 14px; }
+    body.layout-ipad .backdrop,
+    body.layout-desktop .backdrop { display: none; }
+    body.layout-ipad .surface-layer,
+    body.layout-desktop .surface-layer {
+      position: relative;
+      inset: auto;
+      z-index: 1;
+      display: flex;
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid rgba(132, 151, 176, 0.16);
+      border-radius: 26px;
+      background: rgba(7, 10, 15, 0.56);
+      box-shadow: 0 24px 80px rgba(0, 0, 0, 0.34);
+      pointer-events: auto;
+    }
+    body.layout-ipad .side-placeholder,
+    body.layout-desktop .side-placeholder {
+      width: 100%;
+      min-height: 100%;
+      display: grid;
+      place-items: center;
+      padding: 18px;
+      color: var(--muted);
+      text-align: center;
+    }
+    body.layout-ipad.has-surface .side-placeholder,
+    body.layout-desktop.has-surface .side-placeholder { display: none; }
+    body.layout-ipad .sheet,
+    body.layout-ipad .full-sheet,
+    body.layout-desktop .sheet,
+    body.layout-desktop .full-sheet {
+      position: absolute;
+      inset: 0;
+      width: auto;
+      height: auto;
+      min-height: 0;
+      max-height: none;
+      border: 0;
+      border-radius: 0;
+      box-shadow: none;
+      transform: translateX(18px);
+    }
+    body.layout-ipad .sheet.active,
+    body.layout-ipad .full-sheet.active,
+    body.layout-desktop .sheet.active,
+    body.layout-desktop .full-sheet.active { transform: translateX(0); }
+    body.layout-ipad .sheet-grip,
+    body.layout-desktop .sheet-grip { display: none; }
+    body.layout-ipad .plan-header,
+    body.layout-desktop .plan-header { padding: 14px; }
+    body.layout-ipad .plan-scroll,
+    body.layout-desktop .plan-scroll { padding: 14px; }
+    body.layout-ipad .plan-footer,
+    body.layout-desktop .plan-footer { padding: 10px 14px 14px; }
+
+    @media (min-width: 1100px) {
+      .app-shell { max-width: 1180px; }
+      .message-stack { max-width: 780px; }
+      .bubble { max-width: 640px; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 1ms !important;
+        animation-iteration-count: 1 !important;
+        scroll-behavior: auto !important;
+        transition-duration: 1ms !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <div class="app-shell" id="appShell">
+      <section class="conversation-pane" aria-label="Conversation prototype">
+        <header class="topbar">
+          <div class="topbar-inner">
+            <div class="session-mark" aria-hidden="true">&gt;_</div>
+            <div class="session-title">
+              <div class="session-name">mobile-mode spike</div>
+              <div class="session-meta"><span>Claude</span><span>·</span><span id="modeLabel">code mode</span><span>·</span><span class="mode-dot" aria-hidden="true"></span><span>live mock</span></div>
+            </div>
+            <button class="overflow-btn" type="button" aria-label="More options">⋮</button>
+          </div>
+        </header>
+
+        <div class="needs-pill" id="needsPill" aria-live="polite"><span class="pulse" aria-hidden="true"></span><span>Claude needs you</span></div>
+
+        <main class="message-list" id="messageList" aria-label="Messages">
+          <div class="message-stack" id="messageStack">
+            <div class="message-row user">
+              <div class="bubble"><p>Can you prep mobile mode before wiring the backend? I need to feel the permission gates on an iPhone.</p></div>
+            </div>
+            <div class="message-row assistant">
+              <div class="bubble">
+                <div class="message-label">Claude</div>
+                <p>I’ll mock the whole phone flow with canned state: conversation, tool approvals, plan review, questions, and a keyboard-safe composer.</p>
+              </div>
+            </div>
+
+            <article class="tool-card" aria-label="Tool card: npm test">
+              <button class="tool-summary" type="button" aria-expanded="false">
+                <span class="tool-disclosure" aria-hidden="true">▸</span>
+                <span class="tool-line">Ran <code>npm test</code> ✓</span>
+                <span class="tool-result">0</span>
+              </button>
+              <div class="tool-details">
+                <div class="tool-body">
+                  <div class="detail-grid">
+                    <span>cwd</span><code>C:\Users\anikundu\Software\ai-or-die</code>
+                    <span>duration</span><code>18.4s</code>
+                    <span>exit</span><code>0</code>
+                  </div>
+                  <pre class="terminal-output">PASS test/mobile-layout.test.js
+PASS test/tool-permission.test.js
+
+38 passed, 0 failed</pre>
+                </div>
+              </div>
+            </article>
+
+            <article class="tool-card" aria-label="Tool card: edited auth.js">
+              <button class="tool-summary" type="button" aria-expanded="false">
+                <span class="tool-disclosure" aria-hidden="true">▸</span>
+                <span class="tool-line">Edited <code>auth.js</code> +12/-3</span>
+                <span class="tool-result">✓</span>
+              </button>
+              <div class="tool-details">
+                <div class="tool-body">
+                  <div class="detail-grid">
+                    <span>file</span><code>src/public/auth.js</code>
+                    <span>summary</span><code>defer mobile token prompt until unlock</code>
+                  </div>
+                  <pre class="diff-output"><span class="del">- initAuthPrompt();</span>
+<span class="add">+ if (!window.matchMedia('(max-width: 760px)').matches) {</span>
+<span class="add">+   initAuthPrompt();</span>
+<span class="add">+ }</span></pre>
+                </div>
+              </div>
+            </article>
+
+            <div class="message-row assistant">
+              <div class="bubble">
+                <div class="message-label">Claude</div>
+                <p>Prototype state is ready. Use the small trigger toolbar to open every blocking and non-blocking surface without making backend calls.</p>
+              </div>
+            </div>
+          </div>
+        </main>
+
+        <div class="status-line" aria-live="polite">
+          <div class="status-chip" id="statusChip"><span class="status-dot" aria-hidden="true"></span><span id="statusText">Claude idle</span></div>
+        </div>
+
+        <div class="input-dock" aria-label="Message input bar">
+          <button class="input-field" id="openComposer" type="button" aria-haspopup="dialog">
+            <span class="input-cursor" aria-hidden="true"></span>
+            <span>Message…</span>
+          </button>
+          <button class="round-btn" id="dockMic" type="button" aria-label="Start voice input">mic</button>
+          <button class="round-btn primary" id="dockSend" type="button" aria-label="Send message">↑</button>
+        </div>
+      </section>
+
+      <div class="backdrop" id="backdrop" aria-hidden="true"></div>
+
+      <aside class="surface-layer" aria-label="Prototype surfaces">
+        <div class="side-placeholder" aria-hidden="true"><div><strong>Right-side panel</strong><p>On iPad and desktop, approvals and plans live here while the conversation stays visible.</p></div></div>
+
+        <section class="sheet permission-sheet" id="permissionSheet" data-surface="permission" role="dialog" aria-modal="true" aria-labelledby="permissionTitle" aria-hidden="true">
+          <div class="sheet-grip" aria-hidden="true"></div>
+          <div class="sheet-head">
+            <div class="sheet-title">
+              <p class="eyebrow">Tool permission</p>
+              <h2 id="permissionTitle">⚠ Claude wants to run</h2>
+              <p class="sheet-subtitle">Review the exact command before letting it touch this folder.</p>
+            </div>
+          </div>
+          <div class="sheet-content">
+            <div class="command-box" aria-label="Exact command"><code id="permissionCommand">rm -rf build/</code></div>
+            <div class="cwd-line"><span>cwd</span><code id="permissionCwd">C:\Users\anikundu\Software\ai-or-die</code></div>
+            <div class="risk-line"><span>risk</span><strong id="permissionRisk">Destructive filesystem operation</strong></div>
+            <div class="countdown" aria-live="polite">
+              <div class="countdown-row"><span id="countdownText">falls back in 45s</span><small>fail-closed</small></div>
+              <div class="countdown-track" aria-hidden="true"><div class="countdown-fill" id="countdownFill"></div></div>
+            </div>
+            <button class="raw-link" id="rawToggle" type="button">Show raw</button>
+            <pre class="raw-box" id="rawBox" hidden></pre>
+          </div>
+          <div class="sheet-actions">
+            <button class="btn safe" id="denyPermission" type="button">Deny</button>
+            <button class="btn danger" id="approvePermission" type="button">Approve</button>
+          </div>
+        </section>
+
+        <section class="full-sheet plan-sheet" id="planSheet" data-surface="plan" role="dialog" aria-modal="true" aria-labelledby="planTitle" aria-hidden="true">
+          <header class="plan-header">
+            <h2 id="planTitle">Plan — approve to start</h2>
+            <button class="close-btn" type="button" data-close-surface aria-label="Close plan">✕</button>
+          </header>
+          <div class="plan-scroll">
+            <article class="plan-doc">
+              <h3>Goal</h3>
+              <p>Validate the mobile interaction model before any backend, WebSocket, or permission plumbing is connected.</p>
+
+              <h3>Plan</h3>
+              <ul class="checklist">
+                <li><span class="box-check">✓</span><span><strong>Prototype first.</strong><br>Keep all state local and canned so the page can run from <code>/mobile-proto.html</code>.</span></li>
+                <li><span class="box-check">✓</span><span><strong>Make approvals hard to miss.</strong><br>Dim the transcript, show a needs-you pill, and make Deny the safe default.</span></li>
+                <li><span class="box-check">✓</span><span><strong>Respect real iOS dimensions.</strong><br>Use dynamic viewport units, safe-area insets, and the VisualViewport keyboard offset.</span></li>
+                <li><span class="box-check">✓</span><span><strong>Scale up.</strong><br>Switch approval surfaces into a right-side panel on iPad and desktop.</span></li>
+              </ul>
+
+              <h3>Files touched</h3>
+              <pre class="fake-diff"><span class="context">diff --git a/src/public/mobile-proto.html b/src/public/mobile-proto.html</span>
+<span class="add">+ &lt;meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"&gt;</span>
+<span class="add">+ &lt;section class="sheet permission-sheet"&gt;...&lt;/section&gt;</span>
+<span class="add">+ visualViewport.addEventListener('resize', syncVisualViewport)</span></pre>
+
+              <h3>Acceptance checks</h3>
+              <p>Open on an iPhone over LAN or Tailscale, trigger each surface, rotate once, focus the composer, and confirm nothing sits under the notch, Dynamic Island, home indicator, or keyboard.</p>
+            </article>
+          </div>
+          <footer class="plan-footer">
+            <button class="btn ghost" id="rejectPlan" type="button">Reject</button>
+            <button class="btn warn" id="commentPlan" type="button">Comment</button>
+            <button class="btn primary" id="approvePlan" type="button">Approve</button>
+          </footer>
+        </section>
+
+        <section class="sheet question-sheet" id="questionSheet" data-surface="question" role="dialog" aria-modal="true" aria-labelledby="questionTitle" aria-hidden="true">
+          <div class="sheet-grip" aria-hidden="true"></div>
+          <div class="sheet-head">
+            <div class="sheet-title">
+              <p class="eyebrow">Question</p>
+              <h2 id="questionTitle">Which route should Claude take?</h2>
+              <p class="sheet-subtitle">Choose one primary answer, or use the multi-select variant below.</p>
+            </div>
+            <button class="close-btn" type="button" data-close-surface aria-label="Close question">✕</button>
+          </div>
+          <div class="sheet-content">
+            <div class="option-list" role="radiogroup" aria-label="Choose one route">
+              <label class="option-card is-selected"><input type="radio" name="routeChoice" value="Keep prototype local" checked><span><strong>Keep prototype local</strong><span>No backend calls. Use canned permission, plan, and question data.</span></span></label>
+              <label class="option-card"><input type="radio" name="routeChoice" value="Mirror desktop flows"><span><strong>Mirror desktop flows</strong><span>Use the existing desktop mental model, compressed for thumbs.</span></span></label>
+              <label class="option-card"><input type="radio" name="routeChoice" value="Experiment freely"><span><strong>Experiment freely</strong><span>Prioritize iPhone ergonomics even if desktop diverges.</span></span></label>
+            </div>
+
+            <div class="variant-title"><h3>Multi-select variant</h3><small>checkboxes + Send</small></div>
+            <div class="option-list" aria-label="Choose all that apply">
+              <label class="option-card is-selected"><input type="checkbox" name="multiChoice" value="Keyboard-safe composer" checked><span><strong>Keyboard-safe composer</strong><span>Keep the textarea and Send above the iOS keyboard.</span></span></label>
+              <label class="option-card is-selected"><input type="checkbox" name="multiChoice" value="Fail-closed approvals" checked><span><strong>Fail-closed approvals</strong><span>Timeout should deny, never approve.</span></span></label>
+              <label class="option-card"><input type="checkbox" name="multiChoice" value="Two-pane iPad"><span><strong>Two-pane iPad</strong><span>Show the transcript and active decision side-by-side.</span></span></label>
+            </div>
+          </div>
+          <div class="sheet-actions">
+            <button class="btn ghost" type="button" data-close-surface>Cancel</button>
+            <button class="btn primary" id="sendQuestion" type="button">Send</button>
+          </div>
+        </section>
+
+        <section class="sheet composer-sheet" id="composerSheet" data-surface="composer" role="dialog" aria-modal="true" aria-labelledby="composerTitle" aria-hidden="true">
+          <div class="sheet-grip" aria-hidden="true"></div>
+          <div class="sheet-head">
+            <div class="sheet-title">
+              <p class="eyebrow">Input composer</p>
+              <h2 id="composerTitle">Message Claude</h2>
+            </div>
+            <button class="close-btn" type="button" data-close-surface aria-label="Close composer">✕</button>
+          </div>
+          <div class="sheet-content composer-body">
+            <textarea class="composer-textarea" id="composerText" rows="5" placeholder="Ask Claude to change the plan, run a safe command, or stop work…" autocapitalize="sentences" autocomplete="off"></textarea>
+            <div class="control-row" aria-label="Structured composer controls">
+              <button class="control-btn slash-btn" id="slashButton" type="button" aria-label="Slash commands">/</button>
+              <button class="control-btn mode-toggle" id="modeToggle" type="button"><span class="toggle-light" aria-hidden="true"></span><span id="composerModeText">Code mode</span></button>
+              <button class="control-btn stop-btn" id="stopButton" type="button">■ Stop</button>
+            </div>
+            <div class="composer-actions">
+              <button class="round-btn" id="composerMic" type="button" aria-label="Start voice input">mic</button>
+              <button class="btn primary" id="sendComposer" type="button">Send</button>
+            </div>
+          </div>
+        </section>
+      </aside>
+    </div>
+  </div>
+
+  <div class="dev-toolbar" id="devToolbar" aria-label="Prototype trigger toolbar">
+    <div class="dev-top"><span>Prototype triggers</span><button class="dev-close" id="hideToolbar" type="button" aria-label="Dismiss toolbar">×</button></div>
+    <div class="dev-buttons">
+      <button type="button" data-open-surface="permission">Permission</button>
+      <button type="button" data-open-surface="plan">Plan</button>
+      <button type="button" data-open-surface="question">Question</button>
+      <button type="button" data-open-surface="composer">Composer</button>
+      <button type="button" id="toggleCommand">Command: destructive</button>
+      <button type="button" id="toggleLayout">Layout: auto</button>
+    </div>
+  </div>
+  <button class="dev-restore" id="restoreToolbar" type="button" hidden>Proto</button>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var root = document.documentElement;
+      var body = document.body;
+      var messageList = document.getElementById('messageList');
+      var messageStack = document.getElementById('messageStack');
+      var statusChip = document.getElementById('statusChip');
+      var statusText = document.getElementById('statusText');
+      var modeLabel = document.getElementById('modeLabel');
+      var sheets = Array.prototype.slice.call(document.querySelectorAll('[data-surface]'));
+      var backdrop = document.getElementById('backdrop');
+      var composerText = document.getElementById('composerText');
+      var permissionSheet = document.getElementById('permissionSheet');
+      var permissionCommand = document.getElementById('permissionCommand');
+      var permissionCwd = document.getElementById('permissionCwd');
+      var permissionRisk = document.getElementById('permissionRisk');
+      var countdownText = document.getElementById('countdownText');
+      var countdownFill = document.getElementById('countdownFill');
+      var rawToggle = document.getElementById('rawToggle');
+      var rawBox = document.getElementById('rawBox');
+      var approvePermissionBtn = document.getElementById('approvePermission');
+      var denyPermissionBtn = document.getElementById('denyPermission');
+      var toggleCommandBtn = document.getElementById('toggleCommand');
+      var toggleLayoutBtn = document.getElementById('toggleLayout');
+      var devToolbar = document.getElementById('devToolbar');
+      var restoreToolbar = document.getElementById('restoreToolbar');
+      var composerModeText = document.getElementById('composerModeText');
+
+      var commands = {
+        destructive: {
+          command: 'rm -rf build/',
+          cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die',
+          risk: 'Destructive filesystem operation',
+          raw: {
+            tool: 'Bash',
+            command: 'rm -rf build/',
+            cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die',
+            reason: 'Claude wants to clear a stale build directory before rebuilding.',
+            risk: 'Deletes files recursively if the path is wrong.'
+          }
+        },
+        safe: {
+          command: 'npm test -- --watch=false',
+          cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die',
+          risk: 'Read-only-ish test command',
+          raw: {
+            tool: 'Bash',
+            command: 'npm test -- --watch=false',
+            cwd: 'C:\\Users\\anikundu\\Software\\ai-or-die',
+            reason: 'Claude wants to run the test suite after a prototype-only change.',
+            risk: 'May be slow, but should not modify project files.'
+          }
+        }
+      };
+
+      var state = {
+        activeSurface: null,
+        destructive: true,
+        layout: 'auto',
+        countdownTimer: null,
+        countdownDeadline: 0,
+        countdownTotalMs: 45000,
+        composerMode: 'code'
+      };
+
+      function setStatus(text) {
+        statusText.textContent = text;
+        statusChip.classList.toggle('working', /working|waiting|running/i.test(text));
+      }
+
+      function isDecisionSurface(name) {
+        return name === 'permission' || name === 'plan' || name === 'question';
+      }
+
+      function currentCommand() {
+        return state.destructive ? commands.destructive : commands.safe;
+      }
+
+      function syncVisualViewport() {
+        var keyboardBottom = 0;
+        if (window.visualViewport) {
+          var vv = window.visualViewport;
+          keyboardBottom = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+          root.style.setProperty('--visual-viewport-height', Math.round(vv.height) + 'px');
+        }
+        root.style.setProperty('--keyboard-bottom', Math.round(keyboardBottom) + 'px');
+        if (state.activeSurface === 'composer') {
+          scrollMessagesToBottom(true);
+        }
+      }
+
+      function scrollMessagesToBottom(force) {
+        if (!messageList) return;
+        var distance = messageList.scrollHeight - messageList.scrollTop - messageList.clientHeight;
+        if (!force && distance > 180) return;
+        requestAnimationFrame(function () {
+          messageList.scrollTop = messageList.scrollHeight;
+        });
+      }
+
+      function addEventChip(text) {
+        var row = document.createElement('div');
+        row.className = 'message-row event-row';
+        var chip = document.createElement('div');
+        chip.className = 'event-chip';
+        chip.textContent = text;
+        row.appendChild(chip);
+        messageStack.appendChild(row);
+        scrollMessagesToBottom(true);
+      }
+
+      function addUserMessage(text) {
+        var row = document.createElement('div');
+        row.className = 'message-row user';
+        var bubble = document.createElement('div');
+        bubble.className = 'bubble';
+        var p = document.createElement('p');
+        p.textContent = text;
+        bubble.appendChild(p);
+        row.appendChild(bubble);
+        messageStack.appendChild(row);
+        scrollMessagesToBottom(true);
+      }
+
+      function addAssistantMessage(text) {
+        var row = document.createElement('div');
+        row.className = 'message-row assistant';
+        var bubble = document.createElement('div');
+        bubble.className = 'bubble';
+        var label = document.createElement('div');
+        label.className = 'message-label';
+        label.textContent = 'Claude';
+        var p = document.createElement('p');
+        p.textContent = text;
+        bubble.appendChild(label);
+        bubble.appendChild(p);
+        row.appendChild(bubble);
+        messageStack.appendChild(row);
+        scrollMessagesToBottom(true);
+      }
+
+      function stopCountdown() {
+        if (state.countdownTimer) {
+          window.clearInterval(state.countdownTimer);
+          state.countdownTimer = null;
+        }
+      }
+
+      function updateCountdown() {
+        var remainingMs = Math.max(0, state.countdownDeadline - Date.now());
+        var remainingSeconds = Math.ceil(remainingMs / 1000);
+        var pct = state.countdownTotalMs ? remainingMs / state.countdownTotalMs : 0;
+        countdownText.textContent = 'falls back in ' + remainingSeconds + 's';
+        countdownFill.style.setProperty('--countdown-pct', String(Math.max(0, Math.min(1, pct))));
+        if (remainingMs <= 0) {
+          stopCountdown();
+          denyPermission('timeout');
+        }
+      }
+
+      function startCountdown() {
+        stopCountdown();
+        state.countdownDeadline = Date.now() + state.countdownTotalMs;
+        updateCountdown();
+        state.countdownTimer = window.setInterval(updateCountdown, 250);
+      }
+
+      function updatePermissionCopy() {
+        var data = currentCommand();
+        permissionCommand.textContent = data.command;
+        permissionCwd.textContent = data.cwd;
+        permissionRisk.textContent = data.risk;
+        rawBox.textContent = JSON.stringify(data.raw, null, 2);
+        rawBox.hidden = true;
+        rawToggle.textContent = 'Show raw';
+        approvePermissionBtn.classList.toggle('danger', state.destructive);
+        approvePermissionBtn.classList.toggle('primary', !state.destructive);
+        permissionSheet.classList.toggle('destructive-command', state.destructive);
+        toggleCommandBtn.textContent = 'Command: ' + (state.destructive ? 'destructive' : 'safe');
+      }
+
+      function openSurface(name) {
+        if (state.activeSurface === 'permission' && name !== 'permission') {
+          stopCountdown();
+        }
+        state.activeSurface = name;
+        body.classList.toggle('has-surface', Boolean(name));
+        body.classList.toggle('has-decision', isDecisionSurface(name));
+        body.dataset.surface = name || '';
+        sheets.forEach(function (sheet) {
+          var isActive = sheet.getAttribute('data-surface') === name;
+          sheet.classList.toggle('active', isActive);
+          sheet.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+        });
+
+        if (name === 'permission') {
+          updatePermissionCopy();
+          startCountdown();
+          setStatus('working… · waiting for permission');
+          requestAnimationFrame(function () { denyPermissionBtn.focus({ preventScroll: true }); });
+        } else if (name === 'plan') {
+          stopCountdown();
+          setStatus('working… · plan waiting');
+        } else if (name === 'question') {
+          stopCountdown();
+          setStatus('working… · question waiting');
+        } else if (name === 'composer') {
+          stopCountdown();
+          setStatus('Claude idle');
+          requestAnimationFrame(function () {
+            composerText.focus({ preventScroll: true });
+            syncVisualViewport();
+          });
+        }
+        syncVisualViewport();
+      }
+
+      function closeSurface(nextStatus) {
+        if (document.activeElement && typeof document.activeElement.blur === 'function') {
+          document.activeElement.blur();
+        }
+        if (state.activeSurface === 'permission') stopCountdown();
+        state.activeSurface = null;
+        body.classList.remove('has-surface', 'has-decision');
+        body.dataset.surface = '';
+        sheets.forEach(function (sheet) {
+          sheet.classList.remove('active', 'nudge');
+          sheet.setAttribute('aria-hidden', 'true');
+        });
+        if (nextStatus) setStatus(nextStatus);
+        syncVisualViewport();
+      }
+
+      function denyPermission(reason) {
+        var timedOut = reason === 'timeout';
+        var cmd = currentCommand().command;
+        stopCountdown();
+        closeSurface(timedOut ? 'Claude idle · denied by timeout' : 'Claude idle · denied');
+        addEventChip((timedOut ? 'Denied by timeout' : 'Denied') + ' · command was not run: ' + cmd);
+      }
+
+      function approvePermission() {
+        var cmd = currentCommand().command;
+        stopCountdown();
+        closeSurface('working… · running approved command');
+        addEventChip('Approved · mocked run: ' + cmd);
+        window.setTimeout(function () {
+          if (!state.activeSurface) {
+            setStatus('Claude idle');
+            addAssistantMessage('Mock result received. No real command ran; this prototype stayed fully front-end.');
+          }
+        }, 900);
+      }
+
+      function updateOptionCards() {
+        document.querySelectorAll('.option-card').forEach(function (card) {
+          var input = card.querySelector('input');
+          card.classList.toggle('is-selected', Boolean(input && input.checked));
+        });
+      }
+
+      function selectedQuestionSummary() {
+        var route = document.querySelector('input[name="routeChoice"]:checked');
+        var checked = Array.prototype.slice.call(document.querySelectorAll('input[name="multiChoice"]:checked')).map(function (input) {
+          return input.value;
+        });
+        return (route ? route.value : 'No route') + (checked.length ? ' · ' + checked.join(', ') : '');
+      }
+
+      function setLayout(mode) {
+        body.classList.remove('layout-ipad', 'layout-desktop');
+        state.layout = mode;
+        if (mode === 'ipad') body.classList.add('layout-ipad');
+        if (mode === 'desktop') body.classList.add('layout-desktop');
+        toggleLayoutBtn.textContent = 'Layout: ' + mode;
+        syncVisualViewport();
+      }
+
+      function cycleLayout() {
+        var next = state.layout === 'auto' ? 'ipad' : (state.layout === 'ipad' ? 'desktop' : 'auto');
+        setLayout(next);
+        addEventChip('Layout preview: ' + next);
+      }
+
+      document.querySelectorAll('.tool-card').forEach(function (card) {
+        var summary = card.querySelector('.tool-summary');
+        summary.addEventListener('click', function () {
+          var expanded = !card.classList.contains('expanded');
+          card.classList.toggle('expanded', expanded);
+          summary.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        });
+      });
+
+      document.addEventListener('click', function (event) {
+        var openButton = event.target.closest('[data-open-surface]');
+        if (openButton) {
+          openSurface(openButton.getAttribute('data-open-surface'));
+          return;
+        }
+        var closeButton = event.target.closest('[data-close-surface]');
+        if (closeButton) {
+          closeSurface('Claude idle');
+        }
+      });
+
+      backdrop.addEventListener('click', function () {
+        if (state.activeSurface === 'permission') {
+          permissionSheet.classList.remove('nudge');
+          void permissionSheet.offsetWidth;
+          permissionSheet.classList.add('nudge');
+          return;
+        }
+        closeSurface('Claude idle');
+      });
+
+      document.getElementById('openComposer').addEventListener('click', function () { openSurface('composer'); });
+      document.getElementById('dockMic').addEventListener('click', function () {
+        openSurface('composer');
+        addEventChip('Mic tapped · voice capture mocked');
+      });
+      document.getElementById('dockSend').addEventListener('click', function () { openSurface('composer'); });
+      denyPermissionBtn.addEventListener('click', function () { denyPermission('manual'); });
+      approvePermissionBtn.addEventListener('click', approvePermission);
+      rawToggle.addEventListener('click', function () {
+        rawBox.hidden = !rawBox.hidden;
+        rawToggle.textContent = rawBox.hidden ? 'Show raw' : 'Hide raw';
+      });
+      toggleCommandBtn.addEventListener('click', function () {
+        state.destructive = !state.destructive;
+        updatePermissionCopy();
+        addEventChip('Command mode: ' + (state.destructive ? 'destructive' : 'safe'));
+      });
+      toggleLayoutBtn.addEventListener('click', cycleLayout);
+
+      document.getElementById('rejectPlan').addEventListener('click', function () {
+        closeSurface('Claude idle · plan rejected');
+        addEventChip('Plan rejected');
+      });
+      document.getElementById('approvePlan').addEventListener('click', function () {
+        closeSurface('working… · plan approved');
+        addEventChip('Plan approved · mocked run starting');
+        window.setTimeout(function () { if (!state.activeSurface) setStatus('Claude idle'); }, 800);
+      });
+      document.getElementById('commentPlan').addEventListener('click', function () {
+        composerText.value = 'I want to adjust the plan: ';
+        openSurface('composer');
+      });
+      document.getElementById('sendQuestion').addEventListener('click', function () {
+        var summary = selectedQuestionSummary();
+        closeSurface('Claude idle · answered');
+        addEventChip('Answered question · ' + summary);
+      });
+
+      document.querySelectorAll('.option-card input').forEach(function (input) {
+        input.addEventListener('change', updateOptionCards);
+      });
+
+      document.getElementById('modeToggle').addEventListener('click', function () {
+        state.composerMode = state.composerMode === 'code' ? 'plan' : 'code';
+        var label = state.composerMode === 'code' ? 'Code mode' : 'Plan mode';
+        composerModeText.textContent = label;
+        modeLabel.textContent = label.toLowerCase();
+      });
+      document.getElementById('slashButton').addEventListener('click', function () {
+        composerText.value = composerText.value + (composerText.value ? ' ' : '') + '/';
+        composerText.focus({ preventScroll: true });
+      });
+      document.getElementById('stopButton').addEventListener('click', function () {
+        setStatus('Claude idle · interrupted');
+        addEventChip('Stop tapped · mocked interrupt sent');
+      });
+      document.getElementById('composerMic').addEventListener('click', function () {
+        addEventChip('Mic tapped · dictation placeholder');
+      });
+      document.getElementById('sendComposer').addEventListener('click', function () {
+        var text = composerText.value.trim();
+        if (!text) text = 'Prototype message sent from the mobile composer.';
+        addUserMessage(text);
+        composerText.value = '';
+        closeSurface('working…');
+        window.setTimeout(function () {
+          if (!state.activeSurface) {
+            setStatus('Claude idle');
+            addAssistantMessage('Received in mock mode. The composer, controls, and keyboard offset are all local-only.');
+          }
+        }, 650);
+      });
+
+      document.getElementById('hideToolbar').addEventListener('click', function () {
+        devToolbar.hidden = true;
+        restoreToolbar.hidden = false;
+      });
+      restoreToolbar.addEventListener('click', function () {
+        devToolbar.hidden = false;
+        restoreToolbar.hidden = true;
+      });
+
+      document.addEventListener('keydown', function (event) {
+        if (event.key !== 'Escape' || !state.activeSurface) return;
+        if (state.activeSurface === 'permission') {
+          denyPermission('manual');
+          return;
+        }
+        closeSurface('Claude idle');
+      });
+
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener('resize', syncVisualViewport);
+        window.visualViewport.addEventListener('scroll', syncVisualViewport);
+      }
+      window.addEventListener('resize', syncVisualViewport);
+      window.addEventListener('orientationchange', function () {
+        window.setTimeout(function () {
+          syncVisualViewport();
+          scrollMessagesToBottom(true);
+        }, 250);
+      });
+
+      updatePermissionCopy();
+      updateOptionCards();
+      syncVisualViewport();
+      scrollMessagesToBottom(true);
+    }());
+  </script>
+</body>
+</html>

--- a/src/server.js
+++ b/src/server.js
@@ -35,6 +35,7 @@ const MinHeap = require('./utils/eviction-heap');
 const RestartManager = require('./restart-manager');
 const KeepaliveManager = require('./keepalive-manager');
 const { ControlEventBus, EVENT_KINDS: CONTROL_EVENT_KINDS } = require('./control/event-bus');
+const { DecisionStore } = require('./control/decision-store');
 const TranscriptBuffer = require('./sticky-note-transcript');
 const { createControlRouter } = require('./control/routes');
 const { ArtifactReviewStore, createArtifactReviewRouter, createAssetTokenSigner, buildArtifactPushPayload, artifactPushEnabledFromEnv } = require('./artifact-review');
@@ -161,6 +162,7 @@ class ClaudeCodeWebServer {
     this.app = express();
     this.claudeSessions = new Map(); // Persistent sessions (claude, codex, or agent)
     this.controlEventBus = new ControlEventBus();
+    this.decisionStore = new DecisionStore({ eventBus: this.controlEventBus });
     this.artifactReviews = new ArtifactReviewStore();
     this._artifactAssetSecret = crypto.randomBytes(32);
     this._artifactAssetSigner = createAssetTokenSigner(this._artifactAssetSecret);
@@ -4237,6 +4239,8 @@ class ClaudeCodeWebServer {
     return {
       sessions: this.claudeSessions,
       eventBus: this.controlEventBus,
+      decisionStore: this.decisionStore,
+      getSessionViewerCount: (id) => this._controlSessionViewerCount(id),
       getMeshPeers: () => this.meshManager ? this.meshManager.getStatus().peers : [],
       getStatusSignal: (id) => this._controlStatusSignal(id),
       readTail: async (id, lines) => this._controlReadTail(id, lines),
@@ -5615,6 +5619,22 @@ class ClaudeCodeWebServer {
     } catch (_) {
       return false;
     }
+  }
+
+  _controlSessionViewerCount(claudeSessionId) {
+    const session = this.claudeSessions.get(claudeSessionId);
+    if (!session || !session.connections) return 0;
+    let count = 0;
+    session.connections.forEach(wsId => {
+      const wsInfo = this.webSocketConnections.get(wsId);
+      if (wsInfo &&
+          wsInfo.claudeSessionId === claudeSessionId &&
+          wsInfo.ws &&
+          wsInfo.ws.readyState === WebSocket.OPEN) {
+        count++;
+      }
+    });
+    return count;
   }
 
   broadcastToSession(claudeSessionId, data) {
@@ -7100,6 +7120,9 @@ class ClaudeCodeWebServer {
     }
     if (this.diskUsageSampleInterval) {
       clearInterval(this.diskUsageSampleInterval);
+    }
+    if (this.decisionStore && typeof this.decisionStore.close === 'function') {
+      this.decisionStore.close();
     }
 
     // Stop memory monitoring to release the interval timer

--- a/src/server.js
+++ b/src/server.js
@@ -40,6 +40,7 @@ const { createControlRouter } = require('./control/routes');
 const { ArtifactReviewStore, createArtifactReviewRouter, createAssetTokenSigner, buildArtifactPushPayload, artifactPushEnabledFromEnv } = require('./artifact-review');
 const { deriveStatus, awaitingKindForPendingTool, awaitingFromScreen, TRUST_PROMPT_REGEX, DEFAULT_UNBOUND_QUIET_MS } = require('./control/session-status');
 const { detectAwaiting, detectTurnState } = require('./control/jsonl-awaiting');
+const TurnStream = require('./control/turn-stream');
 
 // HOT-08: per-WebSocket-message size cap. Gates JSON.parse so a single
 // large frame can't block the event loop for tens-to-hundreds of ms.
@@ -4239,6 +4240,7 @@ class ClaudeCodeWebServer {
       getMeshPeers: () => this.meshManager ? this.meshManager.getStatus().peers : [],
       getStatusSignal: (id) => this._controlStatusSignal(id),
       readTail: async (id, lines) => this._controlReadTail(id, lines),
+      readMessages: async (id, cursor, limit) => this._controlReadMessages(id, cursor, limit),
       createSession: async (opts) => this._controlCreateSession(opts),
       stopSession: async (id, mode, idempotencyKey) => this._controlStopSession(id, mode, idempotencyKey),
       sendMessage: async (opts) => this._controlSendMessage(opts),
@@ -4538,6 +4540,19 @@ class ClaudeCodeWebServer {
       truncated: (s.outputBuffer && s.outputBuffer.size ? s.outputBuffer.size > lines : false),
       source: 'buffer'
     };
+  }
+
+  async _controlReadMessages(id, cursor, limit) {
+    const binding = this._stickyJsonl && this._stickyJsonl.get(id);
+    if (!binding) {
+      return { bound: false, items: [], cursor: cursor || null, epoch: (cursor && cursor.epoch) || null, reset: false, more: false };
+    }
+    const file = binding.file || binding.pendingTranscriptPath;
+    if (!file) {
+      return { bound: true, items: [], cursor: cursor || null, epoch: (cursor && cursor.epoch) || null, reset: false, more: false };
+    }
+    const out = await TurnStream.readItems(file, cursor, { limit });
+    return { bound: true, items: out.items, cursor: out.cursor, epoch: out.epoch, reset: out.reset, more: out.more };
   }
 
   async _controlCreateSession(opts = {}) {

--- a/src/server.js
+++ b/src/server.js
@@ -64,6 +64,149 @@ const MAX_WS_MESSAGE_BYTES = 1 * 1024 * 1024;
 // required capability is absent.
 const CONTROL_CONTRACT_VERSION = 1;
 
+// Control-plane Origin allowlist (defense-in-depth atop the Bearer/token auth on
+// the control routes + WS). A cross-site page must NOT be able to forge a
+// state-changing control request, read control state, or open the control WS,
+// even if it somehow holds the token. The gate trusts, in order: (1) NO Origin
+// header at all — server-to-server callers (the github-router decision hook, curl,
+// native apps) send none, and the Origin check only defends the browser cross-site
+// case; (2) the server's OWN live public origins (its devtunnel / mesh URL),
+// supplied by the caller and pinned by EXACT origin; (3) loopback + the server's
+// OWN network-interface addresses (so same-host LAN access works, but a DIFFERENT
+// LAN IP an attacker hosts on shared Wi-Fi does not); (4) the AIORDIE_ALLOWED_ORIGINS
+// env allowlist. It deliberately does NOT trust the client-supplied Host header (a
+// DNS-rebinding bypass), a bare *.ts.net / *.devtunnels.ms suffix (shared
+// multi-tenant domains any attacker can provision under), nor blanket RFC-1918
+// space (any same-L2 attacker IP). `trustedOrigins` is an array/Set of the server's
+// own public URL strings; `ownHostnames` is a Set of the server's own hostnames/IPs
+// — both re-read live per request.
+function _isAllowedOrigin(originHeader, trustedOrigins, ownHostnames) {
+  if (originHeader == null) return true;
+  if (Array.isArray(originHeader)) {
+    if (originHeader.length !== 1) return false;
+    originHeader = originHeader[0];
+  }
+
+  const rawOrigin = String(originHeader).trim();
+  if (!rawOrigin) return false;
+
+  let originUrl;
+  try {
+    originUrl = new URL(rawOrigin);
+  } catch (_) {
+    return false;
+  }
+
+  if (originUrl.username || originUrl.password || originUrl.pathname !== '/' || originUrl.search || originUrl.hash) {
+    return false;
+  }
+  if (!originUrl.host) return false;
+  const originHost = originUrl.host.toLowerCase();
+  const originHostname = _normalizeOriginHostname(originUrl.hostname);
+  if (!originHostname) return false;
+
+  const originKey = _originKey(originUrl);
+  if (originKey && _asTrustedOriginSet(trustedOrigins).has(originKey)) return true;
+
+  if (originHostname === 'localhost' || originHostname === '127.0.0.1' || originHostname === '::1') return true;
+  if (ownHostnames && _asHostnameSet(ownHostnames).has(originHostname)) return true;
+  if (_isEnvAllowedOrigin(originUrl, originHost, originHostname)) return true;
+
+  return false;
+}
+
+function _asHostnameSet(hostnames) {
+  if (hostnames instanceof Set) return hostnames;
+  return new Set(Array.isArray(hostnames) ? hostnames : []);
+}
+
+// Canonical compare key for an origin: scheme://hostname[:port], lower-cased, with
+// a single trailing FQDN dot stripped (a browser may send `foo.ts.net.`). Built
+// from the parsed URL so it ignores userinfo/path/query and normalizes default
+// ports identically on both the candidate and the trusted set.
+function _originKey(url) {
+  let u;
+  try {
+    u = typeof url === 'string' ? new URL(url) : url;
+  } catch (_) {
+    return '';
+  }
+  if (!u || !u.protocol) return '';
+  let host = _normalizeOriginHostname(u.hostname);
+  if (host.length > 1 && host.endsWith('.')) host = host.slice(0, -1);
+  if (!host) return '';
+  const hostPart = host.includes(':') ? '[' + host + ']' : host;
+  const port = u.port ? ':' + u.port : '';
+  return (u.protocol + '//' + hostPart + port).toLowerCase();
+}
+
+function _asTrustedOriginSet(trustedOrigins) {
+  if (trustedOrigins instanceof Set) return trustedOrigins;
+  const set = new Set();
+  if (Array.isArray(trustedOrigins)) {
+    for (const entry of trustedOrigins) {
+      const key = _originKey(entry);
+      if (key) set.add(key);
+    }
+  }
+  return set;
+}
+
+function _normalizeOriginHostname(hostname) {
+  const normalized = String(hostname || '').trim().toLowerCase();
+  if (normalized.startsWith('[') && normalized.endsWith(']')) return normalized.slice(1, -1);
+  return normalized;
+}
+
+function _isEnvAllowedOrigin(originUrl, originHost, originHostname) {
+  const rawAllowlist = process.env.AIORDIE_ALLOWED_ORIGINS || '';
+  for (const rawEntry of rawAllowlist.split(',')) {
+    const entry = String(rawEntry || '').trim();
+    if (!entry) continue;
+
+    if (entry.includes('://')) {
+      try {
+        const allowedUrl = new URL(entry);
+        if (allowedUrl.origin.toLowerCase() === originUrl.origin.toLowerCase()) return true;
+      } catch (_) {
+        /* ignore malformed allowlist entries */
+      }
+      continue;
+    }
+
+    const allowedHost = _normalizeAllowedHostEntry(entry);
+    if (!allowedHost) continue;
+    if (allowedHost.hasPort) {
+      if (allowedHost.value === originHost) return true;
+    } else if (allowedHost.value === originHostname) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function _normalizeAllowedHostEntry(entry) {
+  const normalized = String(entry || '').trim().toLowerCase();
+  if (!normalized) return null;
+
+  if (normalized.startsWith('[')) {
+    const close = normalized.indexOf(']');
+    if (close === -1) return null;
+    const hostname = normalized.slice(1, close);
+    const rest = normalized.slice(close + 1);
+    if (!rest) return { value: hostname, hasPort: false };
+    if (/^:\d+$/.test(rest)) return { value: `[${hostname}]${rest}`, hasPort: true };
+    return null;
+  }
+
+  const colonCount = (normalized.match(/:/g) || []).length;
+  if (colonCount > 1) return { value: normalized, hasPort: false };
+
+  const withPort = /^(.*):(\d+)$/.exec(normalized);
+  if (withPort) return { value: `${withPort[1]}:${withPort[2]}`, hasPort: true };
+  return { value: normalized, hasPort: false };
+}
+
 // Inbound binary voice frames (client mic -> server STT) bypass the JSON guard
 // above. Framing + validation (incl. the Buffer[] fragmented-frame normalize)
 // lives in utils/ws-voice-frame so it can be unit-tested without a live socket.
@@ -479,6 +622,51 @@ class ClaudeCodeWebServer {
 
   setMeshManager(mm) {
     this.meshManager = mm;
+  }
+
+  // The server's OWN public origins, read live per request for the control-plane
+  // Origin gate. Sourced from the devtunnel + mesh managers (populated
+  // asynchronously once each tunnel reports its URL); empty until then, which is
+  // safe because the public host is unreachable until its URL exists. Loopback,
+  // private-LAN, and AIORDIE_ALLOWED_ORIGINS are handled inside _isAllowedOrigin.
+  _trustedControlOrigins() {
+    const out = [];
+    const tm = this.tunnelManager;
+    if (tm && tm.publicUrl) out.push(tm.publicUrl);
+    const mm = this.meshManager;
+    if (mm && typeof mm.getStatus === 'function') {
+      try {
+        const status = mm.getStatus();
+        if (status && status.publicUrl) out.push(status.publicUrl);
+      } catch (_) { /* mesh status unavailable — omit */ }
+    }
+    return out;
+  }
+
+  // The server's OWN hostnames/IPs (loopback + every non-internal network-interface
+  // address), for the control-plane Origin gate: same-host LAN access is allowed
+  // (the phone loads the server's own LAN IP), but a DIFFERENT LAN IP an attacker
+  // hosts on the same Wi-Fi is not. Cached ~5s since interfaces change rarely and
+  // this is read on every control request + WS handshake.
+  _ownLanHostnames() {
+    const now = Date.now();
+    if (this._ownLanHostnamesCache && (now - this._ownLanHostnamesCache.at) < 5000) {
+      return this._ownLanHostnamesCache.set;
+    }
+    const set = new Set(['localhost', '127.0.0.1', '::1']);
+    let ifaces;
+    try { ifaces = os.networkInterfaces(); } catch (_) { ifaces = null; }
+    for (const name of Object.keys(ifaces || {})) {
+      for (const addr of ifaces[name] || []) {
+        if (!addr || !addr.address) continue;
+        let host = String(addr.address).toLowerCase();
+        const zone = host.indexOf('%'); // strip IPv6 zone id (fe80::1%eth0)
+        if (zone !== -1) host = host.slice(0, zone);
+        if (host) set.add(host);
+      }
+    }
+    this._ownLanHostnamesCache = { at: now, set };
+    return set;
   }
 
   async saveSessionsToDisk(force = false) {
@@ -1256,6 +1444,7 @@ class ClaudeCodeWebServer {
           req.artifactAssetPathToken = asset.token;
           return next();
         }
+        // Bearer is preferred for mobile HTTP clients; ?token= remains for existing callers.
         const token = req.headers.authorization || req.query.token;
         if (token !== `Bearer ${this.auth}` && token !== this.auth) {
           return res.status(401).json({ error: 'Unauthorized' });
@@ -1272,6 +1461,24 @@ class ClaudeCodeWebServer {
       });
     }
 
+    // Origin-gate EVERY control request (defense-in-depth atop the Bearer/token
+    // auth above) — mutations AND reads. A cross-site browser page sends its
+    // foreign Origin and is rejected; same-origin requests (Origin absent or
+    // matching) and server-to-server callers (no Origin: the decision hook, curl,
+    // native apps) pass. Gating reads too closes the cross-origin state-exfil
+    // channel (terminal output / history / pending decisions), which matters most
+    // under --no-auth where these routes are otherwise public.
+    this.app.use('/api/control', (req, res, next) => {
+      if (_isAllowedOrigin(req.headers.origin, this._trustedControlOrigins(), this._ownLanHostnames())) {
+        return next();
+      }
+      return res.status(403).json({
+        error: {
+          code: 'ORIGIN_FORBIDDEN',
+          message: 'Origin is not allowed for this control request',
+        },
+      });
+    });
     this.app.use('/api/control', createControlRouter(this._buildControlDeps()));
     this.app.use('/api/artifact', createArtifactReviewRouter({
       store: this.artifactReviews,
@@ -3506,9 +3713,9 @@ class ClaudeCodeWebServer {
         if (!this.noAuth && this.auth) {
           const url = new URL(info.req.url, 'ws://localhost');
           const token = url.searchParams.get('token');
-          return token === this.auth;
+          if (token !== this.auth) return false;
         }
-        return true;
+        return _isAllowedOrigin(info.origin, this._trustedControlOrigins(), this._ownLanHostnames());
       }
     });
 
@@ -7703,4 +7910,4 @@ async function startServer(options) {
   return await server.start();
 }
 
-module.exports = { startServer, ClaudeCodeWebServer };
+module.exports = { startServer, ClaudeCodeWebServer, _isAllowedOrigin };

--- a/test/control-origin.test.js
+++ b/test/control-origin.test.js
@@ -1,0 +1,302 @@
+'use strict';
+
+// Control-plane Origin allowlist (defense-in-depth atop Bearer/token auth on the
+// control routes + WS). The gate pins to the server's OWN public origins (its
+// devtunnel / mesh URL) plus loopback / private-LAN / AIORDIE_ALLOWED_ORIGINS. It
+// must NOT trust a bare *.ts.net / *.devtunnels.ms suffix (shared multi-tenant
+// domains any attacker can provision under) nor the client-supplied Host header
+// (a DNS-rebinding bypass). These tests lock in that threat model.
+
+const assert = require('assert');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+const WebSocket = require('ws');
+const { ClaudeCodeWebServer, _isAllowedOrigin } = require('../src/server');
+
+const AUTH_TOKEN = 'control-origin-test-token';
+// The server's own pinned public origin (as the tunnel/mesh manager would report).
+const PINNED_ORIGIN = 'https://myhost-7777.devtunnels.ms';
+
+function withAllowedOrigins(value, fn) {
+  const oldValue = process.env.AIORDIE_ALLOWED_ORIGINS;
+  if (value == null) delete process.env.AIORDIE_ALLOWED_ORIGINS;
+  else process.env.AIORDIE_ALLOWED_ORIGINS = value;
+  try {
+    return fn();
+  } finally {
+    if (oldValue == null) delete process.env.AIORDIE_ALLOWED_ORIGINS;
+    else process.env.AIORDIE_ALLOWED_ORIGINS = oldValue;
+  }
+}
+
+function jsonRequest(url, options = {}) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const headers = Object.assign({}, options.headers || {});
+    let payload = null;
+    if (Object.prototype.hasOwnProperty.call(options, 'body')) {
+      payload = String(options.body);
+      headers['Content-Length'] = Buffer.byteLength(payload);
+    }
+    const req = http.request({
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname + parsed.search,
+      method: options.method || 'GET',
+      headers,
+      agent: false,
+    }, (res) => {
+      let raw = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => { raw += chunk; });
+      res.on('end', () => {
+        let body = null;
+        try { body = raw ? JSON.parse(raw) : null; } catch (_) { body = raw; }
+        resolve({ status: res.statusCode, body });
+      });
+    });
+    req.on('error', reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+// Resolves the connected ws on success. On a rejected handshake it rejects with
+// the definitive `Unexpected server response: <code>` error the ws client emits —
+// a connection TIMEOUT is treated as a distinct failure (NOT a pass), so a server
+// that accepts-then-hangs cannot masquerade as "rejected".
+function connectWs(port, options = {}) {
+  return new Promise((resolve, reject) => {
+    const token = options.token == null ? AUTH_TOKEN : options.token;
+    const url = `ws://127.0.0.1:${port}/?token=${encodeURIComponent(token)}`;
+    const headers = {};
+    if (Object.prototype.hasOwnProperty.call(options, 'origin')) headers.Origin = options.origin;
+
+    const ws = new WebSocket(url, { headers });
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { ws.terminate(); } catch (_) {}
+      reject(new Error('WebSocket handshake timed out (server accepted-then-hung, not a clean reject)'));
+    }, 5000);
+
+    function settle(err, value) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (err) {
+        try { if (ws.readyState !== WebSocket.CLOSED) ws.terminate(); } catch (_) {}
+        reject(err);
+      } else {
+        resolve(value);
+      }
+    }
+
+    ws.on('unexpected-response', (_req, res) => {
+      settle(new Error(`Unexpected server response: ${res.statusCode}`));
+    });
+    ws.on('message', (raw, isBinary) => {
+      if (isBinary) return;
+      let msg;
+      try { msg = JSON.parse(raw.toString()); } catch (err) { return settle(err); }
+      if (msg.type === 'connected') settle(null, ws);
+    });
+    ws.on('error', (err) => settle(err));
+    ws.on('close', (code) => settle(new Error(`WebSocket closed before connected (${code})`)));
+  });
+}
+
+function closeWs(ws) {
+  return new Promise((resolve) => {
+    if (!ws || ws.readyState === WebSocket.CLOSED) return resolve();
+    ws.once('close', () => resolve());
+    try { ws.close(); } catch (_) { return resolve(); }
+    setTimeout(() => {
+      try { if (ws.readyState !== WebSocket.CLOSED) ws.terminate(); } catch (_) {}
+      resolve();
+    }, 2000);
+  });
+}
+
+describe('control Origin allowlist helper', function () {
+  it('pins to the server\'s own origins and rejects shared-suffix / rebinding / foreign-LAN bypasses', function () {
+    withAllowedOrigins(null, () => {
+      // The server's live trusted set (what _trustedControlOrigins() returns).
+      const trusted = [PINNED_ORIGIN, 'https://mybox.tail-scale.ts.net'];
+      // The server's OWN interface addresses (what _ownLanHostnames() returns).
+      const ownHosts = new Set(['localhost', '127.0.0.1', '::1', '10.0.0.5', '192.168.1.10', 'fe80::dead']);
+      const cases = [
+        // (1) No Origin header -> allow (hook / curl / native, server-to-server).
+        { name: 'no origin', origin: undefined, expected: true },
+        // (2) The server's OWN pinned public origins -> allow (exact match).
+        { name: 'own devtunnel origin', origin: PINNED_ORIGIN, expected: true },
+        { name: 'own mesh origin', origin: 'https://mybox.tail-scale.ts.net', expected: true },
+        { name: 'own origin, trailing FQDN dot', origin: 'https://myhost-7777.devtunnels.ms.', expected: true },
+        // CRITICAL #1 — a DIFFERENT tenant under the same shared suffix must be REJECTED.
+        { name: 'cross-tenant devtunnel (attacker-provisioned)', origin: 'https://attacker-9999.devtunnels.ms', expected: false },
+        { name: 'cross-tenant tailscale', origin: 'https://attacker.ts.net', expected: false },
+        { name: 'empty-label .ts.net', origin: 'https://.ts.net', expected: false },
+        { name: 'suffix-smuggle host', origin: 'https://evil.devtunnels.ms.attacker.com', expected: false },
+        // CRITICAL #2 — Host header is no longer consulted; a rebinding origin is rejected.
+        { name: 'DNS-rebinding origin (host no longer trusted)', origin: 'http://evil.com', expected: false },
+        // (3) loopback -> allow (literal, always).
+        { name: 'localhost', origin: 'http://localhost:3000', expected: true },
+        { name: '127.0.0.1', origin: 'http://127.0.0.1:3000', expected: true },
+        { name: '[::1]', origin: 'http://[::1]:3000', expected: true },
+        // IMPORTANT #2 — the server's OWN LAN IPs are allowed (same-host access)...
+        { name: 'own LAN IPv4 (10.0.0.5)', origin: 'http://10.0.0.5:3000', expected: true },
+        { name: 'own LAN IPv4 (192.168.1.10)', origin: 'http://192.168.1.10:3000', expected: true },
+        { name: 'own LAN IPv6', origin: 'http://[fe80::dead]:3000', expected: true },
+        // ...but a DIFFERENT LAN IP an attacker hosts on the same Wi-Fi is REJECTED
+        // (no more blanket RFC-1918 trust).
+        { name: 'FOREIGN LAN 10.1.2.3 (attacker on same L2)', origin: 'http://10.1.2.3:3000', expected: false },
+        { name: 'FOREIGN LAN 172.16.0.1', origin: 'http://172.16.0.1:3000', expected: false },
+        { name: 'FOREIGN LAN 192.168.99.99', origin: 'http://192.168.99.99:3000', expected: false },
+        { name: 'FOREIGN link-local 169.254.10.20', origin: 'http://169.254.10.20:3000', expected: false },
+        // Foreign public origins -> reject.
+        { name: 'foreign public origin', origin: 'https://evil.com', expected: false },
+        // Malformed / not-an-Origin values -> reject.
+        { name: 'userinfo is not a valid Origin', origin: 'https://evil.com@myhost-7777.devtunnels.ms', expected: false },
+        { name: 'path is not a valid Origin', origin: 'https://localhost/path', expected: false },
+        { name: 'query is not a valid Origin', origin: 'https://localhost?x=1', expected: false },
+        { name: 'malformed origin', origin: 'not a url', expected: false },
+        { name: 'null origin string', origin: 'null', expected: false },
+      ];
+
+      for (const testCase of cases) {
+        assert.strictEqual(
+          _isAllowedOrigin(testCase.origin, trusted, ownHosts),
+          testCase.expected,
+          testCase.name
+        );
+      }
+
+      // Multi-value Origin header array is rejected (length !== 1).
+      assert.strictEqual(_isAllowedOrigin(['https://a.com', 'https://b.com'], trusted, ownHosts), false, 'array origin');
+      // Empty trusted set: a would-be tunnel origin is rejected until the URL is known.
+      assert.strictEqual(_isAllowedOrigin(PINNED_ORIGIN, [], ownHosts), false, 'empty trusted set denies tunnel origin');
+      // No ownHosts + no trusted set: only loopback literals + env survive.
+      assert.strictEqual(_isAllowedOrigin('http://10.0.0.5:3000', [], undefined), false, 'no ownHosts denies LAN');
+    });
+  });
+
+  it('reads AIORDIE_ALLOWED_ORIGINS on each call', function () {
+    withAllowedOrigins('https://allowed.example:9443, hostonly.example, hostport.example:8080', () => {
+      assert.strictEqual(_isAllowedOrigin('https://allowed.example:9443', [], new Set()), true);
+      assert.strictEqual(_isAllowedOrigin('https://allowed.example:9444', [], new Set()), false);
+      assert.strictEqual(_isAllowedOrigin('https://hostonly.example:9444', [], new Set()), true);
+      assert.strictEqual(_isAllowedOrigin('https://hostport.example:8080', [], new Set()), true);
+      assert.strictEqual(_isAllowedOrigin('https://hostport.example:9444', [], new Set()), false);
+    });
+  });
+});
+
+describe('control Origin gate on HTTP and WebSocket', function () {
+  this.timeout(15000);
+
+  let server;
+  let port;
+  let tempDir;
+
+  before(async function () {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aiordie-control-origin-'));
+    server = new ClaudeCodeWebServer({
+      port: 0,
+      auth: AUTH_TOKEN,
+      sessionStoreOptions: { storageDir: tempDir },
+    });
+    // Simulate the tunnel having come up: the server now knows its own public
+    // origin, exactly as tunnelManager.publicUrl would report it.
+    server.setTunnelManager({ publicUrl: PINNED_ORIGIN });
+    const httpServer = await server.start();
+    port = httpServer.address().port;
+  });
+
+  after(async function () {
+    if (server) await server.close();
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('lets a control POST from the server\'s OWN pinned Origin past the gate', async function () {
+    const res = await jsonRequest(`http://127.0.0.1:${port}/api/control/sessions/create`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${AUTH_TOKEN}`,
+        Origin: PINNED_ORIGIN,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'pinned-origin-ok' }),
+    });
+    assert.notStrictEqual(res.status, 403, 'own pinned origin must not be origin-forbidden');
+    assert.ok(!res.body || !res.body.error || res.body.error.code !== 'ORIGIN_FORBIDDEN');
+  });
+
+  it('blocks a cross-tenant .devtunnels.ms Origin on a mutating POST (403)', async function () {
+    const res = await jsonRequest(`http://127.0.0.1:${port}/api/control/sessions/create`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${AUTH_TOKEN}`,
+        Origin: 'https://attacker-9999.devtunnels.ms',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'blocked-origin' }),
+    });
+    assert.strictEqual(res.status, 403);
+    assert.deepStrictEqual(res.body, {
+      error: {
+        code: 'ORIGIN_FORBIDDEN',
+        message: 'Origin is not allowed for this control request',
+      },
+    });
+  });
+
+  it('gates control GET reads too: no-Origin passes, foreign Origin is 403', async function () {
+    // no-Origin POST reaches the router (auth + origin passed; session missing -> 404).
+    const post = await jsonRequest(`http://127.0.0.1:${port}/api/control/sessions/nope/message`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${AUTH_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ message: 'no-origin-ok' }),
+    });
+    assert.strictEqual(post.status, 404);
+    assert.strictEqual(post.body.error.code, 'SESSION_NOT_FOUND');
+
+    // no-Origin GET reaches the router (server-to-server read).
+    const getNoOrigin = await jsonRequest(`http://127.0.0.1:${port}/api/control/sessions`, {
+      headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+    });
+    assert.strictEqual(getNoOrigin.status, 200);
+    assert.ok(Array.isArray(getNoOrigin.body.sessions));
+
+    // Foreign-Origin GET is now origin-gated (403) — closes the cross-origin
+    // read/exfil channel for terminal output / history / pending decisions.
+    const getForeign = await jsonRequest(`http://127.0.0.1:${port}/api/control/sessions`, {
+      headers: {
+        Authorization: `Bearer ${AUTH_TOKEN}`,
+        Origin: 'https://evil.com',
+      },
+    });
+    assert.strictEqual(getForeign.status, 403);
+    assert.strictEqual(getForeign.body.error.code, 'ORIGIN_FORBIDDEN');
+  });
+
+  it('rejects a WebSocket upgrade from a foreign Origin (definitive handshake reject, not timeout)', async function () {
+    await assert.rejects(
+      () => connectWs(port, { origin: 'https://attacker-9999.devtunnels.ms' }),
+      /Unexpected server response: 40[13]|closed before connected|socket hang up|ECONNRESET/i
+    );
+  });
+
+  it('accepts WebSocket upgrades with no Origin or the server\'s own pinned Origin', async function () {
+    const noOrigin = await connectWs(port);
+    await closeWs(noOrigin);
+
+    const allowedOrigin = await connectWs(port, { origin: PINNED_ORIGIN });
+    await closeWs(allowedOrigin);
+  });
+});

--- a/test/control/decision.test.js
+++ b/test/control/decision.test.js
@@ -1,0 +1,258 @@
+'use strict';
+
+const assert = require('assert');
+const express = require('express');
+const http = require('http');
+const testApi = global.describe ? { describe: global.describe, it: global.it } : require('node:test');
+const { describe, it } = testApi;
+const { createControlRouter } = require('../../src/control/routes');
+const { ControlEventBus } = require('../../src/control/event-bus');
+const { DecisionStore } = require('../../src/control/decision-store');
+
+function buildServer(deps, opts) {
+  opts = opts || {};
+  const app = express();
+  app.use(express.json());
+  if (opts.auth) {
+    app.use((req, res, next) => {
+      const token = req.headers.authorization || req.query.token;
+      if (token !== `Bearer ${opts.auth}` && token !== opts.auth) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      next();
+    });
+  }
+  app.use('/api/control', createControlRouter(deps));
+  // eslint-disable-next-line no-unused-vars
+  app.use((err, req, res, _next) => res.status(500).json({ error: { code: 'INTERNAL', message: err.message } }));
+  return app;
+}
+
+function listen(app) {
+  return new Promise((resolve) => {
+    const server = http.createServer(app);
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}
+
+function fakeDeps(overrides) {
+  overrides = overrides || {};
+  const eventBus = overrides.eventBus || new ControlEventBus();
+  const decisionStore = overrides.decisionStore || new DecisionStore({
+    eventBus,
+    ttlMs: overrides.decisionTtlMs || 60 * 60 * 1000,
+    cleanupIntervalMs: 0,
+  });
+  return Object.assign({
+    sessions: new Map([
+      ['s1', { id: 's1', name: 'one', workingDir: '/w', active: true, connections: new Set() }],
+    ]),
+    eventBus,
+    decisionStore,
+    getSessionViewerCount: () => 0,
+  }, overrides, { eventBus, decisionStore });
+}
+
+async function getJson(port, pathname, headers) {
+  const r = await fetch(`http://127.0.0.1:${port}${pathname}`, { headers: headers || {} });
+  return { status: r.status, body: await r.json() };
+}
+
+async function postJson(port, pathname, body, headers) {
+  const r = await fetch(`http://127.0.0.1:${port}${pathname}`, {
+    method: 'POST',
+    headers: Object.assign({ 'content-type': 'application/json' }, headers || {}),
+    body: JSON.stringify(body || {}),
+  });
+  return { status: r.status, body: await r.json() };
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('control decision endpoints', function () {
+  it('registers pending decisions, lists them, and emits decision_pending', async function () {
+    const deps = fakeDeps();
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const head = deps.eventBus.headCursor();
+      const first = await postJson(port, '/api/control/sessions/s1/decision', {
+        kind: 'tool_approval',
+        tool: 'Bash',
+        command: 'npm test',
+        cwd: '/w',
+        idempotencyKey: 'same-decision',
+      });
+      const retry = await postJson(port, '/api/control/sessions/s1/decision', {
+        kind: 'tool_approval',
+        tool: 'Bash',
+        command: 'npm test',
+        cwd: '/w',
+        idempotencyKey: 'same-decision',
+      });
+
+      assert.equal(first.status, 200);
+      assert.match(first.body.decisionId, /^dec_[0-9a-f]+$/);
+      assert.equal(retry.status, 200);
+      assert.equal(retry.body.decisionId, first.body.decisionId);
+      assert.equal(retry.body.duplicated, true);
+
+      const events = deps.eventBus.since(head, { sessionIds: ['s1'], kinds: ['decision_pending'] }).events;
+      assert.equal(events.length, 1, 'idempotent retry must not emit a second event');
+      assert.equal(events[0].kind, 'decision_pending');
+      assert.equal(events[0].detail.decisionId, first.body.decisionId);
+      assert.equal(events[0].detail.kind, 'tool_approval');
+      assert.equal(events[0].detail.command, 'npm test');
+      assert.equal(events[0].detail.idempotencyKey, undefined);
+
+      const listed = await getJson(port, '/api/control/sessions/s1/decisions');
+      assert.equal(listed.status, 200);
+      assert.equal(listed.body.decisions.length, 1);
+      assert.equal(listed.body.decisions[0].decisionId, first.body.decisionId);
+      assert.equal(listed.body.decisions[0].tool, 'Bash');
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
+
+  it('register → await blocks → answer resolves the held await with the structured choice', async function () {
+    const deps = fakeDeps();
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const registered = await postJson(port, '/api/control/sessions/s1/decision', {
+        kind: 'choice_question',
+        question: 'Deploy?',
+        options: [{ label: 'approve', description: 'Ship it' }, { label: 'reject' }],
+      });
+      assert.equal(registered.status, 200);
+      const decisionId = registered.body.decisionId;
+
+      const pendingAwait = getJson(port, `/api/control/decisions/${encodeURIComponent(decisionId)}/await?timeoutMs=1000`);
+      await delay(20);
+      const answered = await postJson(port, `/api/control/decisions/${encodeURIComponent(decisionId)}/answer`, {
+        choice: 'approve',
+      });
+      assert.equal(answered.status, 200);
+      assert.deepEqual(answered.body, { ok: true });
+
+      const resolved = await pendingAwait;
+      assert.equal(resolved.status, 200);
+      assert.deepEqual(resolved.body, { answered: true, choice: 'approve' });
+
+      const listed = await getJson(port, '/api/control/sessions/s1/decisions');
+      assert.deepEqual(listed.body.decisions, []);
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
+
+  it('/await timeout returns answered:false with the current session viewer count', async function () {
+    const deps = fakeDeps({
+      getSessionViewerCount: (sessionId) => {
+        assert.equal(sessionId, 's1');
+        return 3;
+      },
+    });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const registered = await postJson(port, '/api/control/sessions/s1/decision', {
+        kind: 'plan_approval',
+        plan: 'Run the migration',
+      });
+      const decisionId = registered.body.decisionId;
+      const awaited = await getJson(port, `/api/control/decisions/${encodeURIComponent(decisionId)}/await?timeoutMs=20`);
+      assert.equal(awaited.status, 200);
+      assert.deepEqual(awaited.body, { answered: false, viewers: 3 });
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
+
+  it('second answer loses with 409; first answer still wins for later await calls', async function () {
+    const deps = fakeDeps();
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const registered = await postJson(port, '/api/control/sessions/s1/decision', {
+        kind: 'tool_approval',
+        tool: 'Bash',
+        command: 'rm -rf build',
+      });
+      const decisionId = registered.body.decisionId;
+      const first = await postJson(port, `/api/control/decisions/${decisionId}/answer`, { choice: 'reject' });
+      const second = await postJson(port, `/api/control/decisions/${decisionId}/answer`, { choice: 'approve' });
+      const awaited = await getJson(port, `/api/control/decisions/${decisionId}/await?timeoutMs=0`);
+
+      assert.equal(first.status, 200);
+      assert.equal(second.status, 409);
+      assert.equal(second.body.error.code, 'PRECONDITION_FAILED');
+      assert.deepEqual(awaited.body, { answered: true, choice: 'reject' });
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
+
+  it('unknown decisionId returns 404 for answer and await', async function () {
+    const deps = fakeDeps();
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const answer = await postJson(port, '/api/control/decisions/nope/answer', { choice: 'approve' });
+      const awaited = await getJson(port, '/api/control/decisions/nope/await?timeoutMs=0');
+      assert.equal(answer.status, 404);
+      assert.equal(answer.body.error.code, 'DECISION_NOT_FOUND');
+      assert.equal(awaited.status, 404);
+      assert.equal(awaited.body.error.code, 'DECISION_NOT_FOUND');
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
+
+  it('session-exit control events clear pending decisions and wake awaiters as 404', async function () {
+    const deps = fakeDeps();
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const registered = await postJson(port, '/api/control/sessions/s1/decision', {
+        kind: 'choice_question',
+        question: 'Continue?',
+      });
+      const decisionId = registered.body.decisionId;
+      const pendingAwait = getJson(port, `/api/control/decisions/${decisionId}/await?timeoutMs=1000`);
+      await delay(20);
+      deps.eventBus.append('s1', 'exited');
+
+      const listed = await getJson(port, '/api/control/sessions/s1/decisions');
+      const awaited = await pendingAwait;
+      assert.deepEqual(listed.body.decisions, []);
+      assert.equal(awaited.status, 404);
+      assert.equal(awaited.body.error.code, 'DECISION_NOT_FOUND');
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
+
+  it('requires the existing control Bearer auth before decision endpoints are reachable', async function () {
+    const deps = fakeDeps();
+    const { server, port } = await listen(buildServer(deps, { auth: 'secret-token' }));
+    try {
+      const unauth = await postJson(port, '/api/control/sessions/s1/decision', { kind: 'choice_question', question: 'OK?' });
+      const authed = await postJson(
+        port,
+        '/api/control/sessions/s1/decision',
+        { kind: 'choice_question', question: 'OK?' },
+        { authorization: 'Bearer secret-token' }
+      );
+      assert.equal(unauth.status, 401);
+      assert.equal(authed.status, 200);
+      assert.match(authed.body.decisionId, /^dec_/);
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
+});

--- a/test/control/decision.test.js
+++ b/test/control/decision.test.js
@@ -255,4 +255,109 @@ describe('control decision endpoints', function () {
       deps.decisionStore.close();
     }
   });
+
+  it('answering a decision injects the mapped keystroke and broadcasts decision_resolved', async function () {
+    const sent = [];
+    const deps = fakeDeps({ sendKeys: async (opts) => { sent.push(opts); return { delivered: true }; } });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const head = deps.eventBus.headCursor();
+      const reg = await postJson(port, '/api/control/sessions/s1/decision', { kind: 'tool_approval', tool: 'Bash', command: 'ls' });
+      const decisionId = reg.body.decisionId;
+
+      // accept -> Enter into the paused native prompt.
+      const ans = await postJson(port, `/api/control/decisions/${decisionId}/answer`, { choice: 'accept' });
+      assert.equal(ans.status, 200);
+      assert.equal(ans.body.ok, true);
+      assert.equal(sent.length, 1);
+      assert.equal(sent[0].sessionId, 's1');
+      assert.equal(sent[0].keys, 'enter');
+
+      // decision_resolved broadcast for that id.
+      const events = deps.eventBus.since(head, { sessionIds: ['s1'], kinds: ['decision_resolved'] }).events;
+      assert.equal(events.length, 1);
+      assert.equal(events[0].detail.decisionId, decisionId);
+
+      // No longer pending.
+      const pending = await getJson(port, '/api/control/sessions/s1/decisions');
+      assert.equal(pending.body.decisions.length, 0);
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
+
+  it('reject answer injects Escape', async function () {
+    const sent = [];
+    const deps = fakeDeps({ sendKeys: async (opts) => { sent.push(opts); return { delivered: true }; } });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const reg = await postJson(port, '/api/control/sessions/s1/decision', { kind: 'tool_approval', tool: 'Bash', command: 'rm -rf build' });
+      await postJson(port, `/api/control/decisions/${reg.body.decisionId}/answer`, { choice: 'reject' });
+      assert.equal(sent.length, 1);
+      assert.equal(sent[0].keys, 'escape');
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
+
+  it('a second answer loses (409) and does not double-inject', async function () {
+    const sent = [];
+    const deps = fakeDeps({ sendKeys: async (opts) => { sent.push(opts); return { delivered: true }; } });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const reg = await postJson(port, '/api/control/sessions/s1/decision', { kind: 'tool_approval', tool: 'Bash', command: 'ls' });
+      const first = await postJson(port, `/api/control/decisions/${reg.body.decisionId}/answer`, { choice: 'accept' });
+      const second = await postJson(port, `/api/control/decisions/${reg.body.decisionId}/answer`, { choice: 'reject' });
+      assert.equal(first.status, 200);
+      assert.equal(second.status, 409);
+      assert.equal(sent.length, 1, 'only the first answer injects');
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
+
+  it('POST /decision-resolved clears pending decisions without injecting (desktop answered natively)', async function () {
+    const sent = [];
+    const deps = fakeDeps({ sendKeys: async (opts) => { sent.push(opts); return { delivered: true }; } });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const head = deps.eventBus.headCursor();
+      const reg = await postJson(port, '/api/control/sessions/s1/decision', { kind: 'tool_approval', tool: 'Bash', command: 'ls' });
+      const decisionId = reg.body.decisionId;
+
+      const resolved = await postJson(port, '/api/control/sessions/s1/decision-resolved', {});
+      assert.equal(resolved.status, 200);
+      assert.equal(resolved.body.resolved, 1);
+      assert.equal(sent.length, 0, 'external resolve must NOT inject a keystroke');
+
+      const events = deps.eventBus.since(head, { sessionIds: ['s1'], kinds: ['decision_resolved'] }).events;
+      assert.equal(events.length, 1);
+      assert.equal(events[0].detail.decisionId, decisionId);
+
+      const pending = await getJson(port, '/api/control/sessions/s1/decisions');
+      assert.equal(pending.body.decisions.length, 0);
+
+      // idempotent: nothing left to resolve.
+      const again = await postJson(port, '/api/control/sessions/s1/decision-resolved', {});
+      assert.equal(again.body.resolved, 0);
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
+
+  it('POST /decision-resolved on an unknown session is 404', async function () {
+    const deps = fakeDeps();
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const r = await postJson(port, '/api/control/sessions/nope/decision-resolved', {});
+      assert.equal(r.status, 404);
+    } finally {
+      server.close();
+      deps.decisionStore.close();
+    }
+  });
 });

--- a/test/control/routes.test.js
+++ b/test/control/routes.test.js
@@ -139,6 +139,101 @@ describe('control/routes /api/control', function () {
     }
   });
 
+  it('GET /sessions/:id/messages streams semantic items and fails softly when unbound', async function () {
+    let seen;
+    const deps = fakeDeps({
+      readMessages: async (id, cursor, limit) => {
+        seen = { id, cursor, limit };
+        if (id === 's2') return { bound: false, items: [], cursor: null, epoch: null, reset: false, more: false };
+        return {
+          bound: true,
+          items: [{ id: 'u1', kind: 'user-text', text: 'hello' }],
+          cursor: { epoch: 'ep', offset: 9 },
+          epoch: 'ep',
+          reset: false,
+          more: true,
+        };
+      },
+    });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const full = await getJson(port, '/api/control/sessions/s1/messages?after=old:7&limit=1');
+      assert.equal(full.status, 200);
+      assert.equal(full.body.bound, true);
+      assert.deepEqual(full.body.items, [{ id: 'u1', kind: 'user-text', text: 'hello' }]);
+      assert.deepEqual(full.body.cursor, { epoch: 'ep', offset: 9 });
+      assert.equal(full.body.more, true);
+      assert.deepEqual(seen, { id: 's1', cursor: { epoch: 'old', offset: 7 }, limit: 1 });
+
+      const unbound = await getJson(port, '/api/control/sessions/s2/messages');
+      assert.equal(unbound.status, 200);
+      assert.equal(unbound.body.bound, false);
+      assert.deepEqual(unbound.body.items, []);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('GET /sessions/:id/messages clamps non-positive limits so clients cannot spin', async function () {
+    const seen = [];
+    const deps = fakeDeps({
+      readMessages: async (id, cursor, limit) => {
+        seen.push(limit);
+        return {
+          bound: true,
+          items: [{ id: `u-${seen.length}`, kind: 'user-text', text: 'hello' }],
+          cursor: { epoch: 'ep', offset: seen.length },
+          epoch: 'ep',
+          reset: false,
+          more: true,
+        };
+      },
+    });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const zero = await getJson(port, '/api/control/sessions/s1/messages?limit=0');
+      const negative = await getJson(port, '/api/control/sessions/s1/messages?limit=-5');
+      assert.equal(zero.status, 200);
+      assert.equal(negative.status, 200);
+      assert.deepEqual(seen, [1, 1]);
+      assert.ok(zero.body.items.length > 0);
+      assert.ok(negative.body.items.length > 0);
+      assert.notDeepEqual(zero.body.cursor, { epoch: 'ep', offset: 0 });
+      assert.notDeepEqual(negative.body.cursor, { epoch: 'ep', offset: 0 });
+    } finally {
+      server.close();
+    }
+  });
+
+  it('GET /sessions/:id/messages clamps excessive limits to the route maximum', async function () {
+    let seen;
+    const deps = fakeDeps({
+      readMessages: async (id, cursor, limit) => {
+        seen = limit;
+        return { bound: true, items: [], cursor: { epoch: 'ep', offset: 0 }, epoch: 'ep', reset: false, more: false };
+      },
+    });
+    const { server, port } = await listen(buildServer(deps));
+    try {
+      const r = await getJson(port, '/api/control/sessions/s1/messages?limit=999999');
+      assert.equal(r.status, 200);
+      assert.equal(seen, 1000);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('GET /sessions/:id/messages rejects a malformed cursor', async function () {
+    const { server, port } = await listen(buildServer(fakeDeps()));
+    try {
+      const r = await getJson(port, '/api/control/sessions/s1/messages?after=not-a-cursor');
+      assert.equal(r.status, 400);
+      assert.equal(r.body.error.code, 'INVALID_ARGUMENT');
+    } finally {
+      server.close();
+    }
+  });
+
   it('POST /sessions/create and /stop', async function () {
     let stopKey;
     const { server, port } = await listen(buildServer(fakeDeps({

--- a/test/control/turn-stream.test.js
+++ b/test/control/turn-stream.test.js
@@ -1,0 +1,278 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const TurnStream = require('../../src/control/turn-stream');
+
+function line(obj) {
+  return JSON.stringify(obj) + '\n';
+}
+
+function userText(uuid, text) {
+  return { type: 'user', uuid, timestamp: `t-${uuid}`, message: { content: text } };
+}
+
+function assistantText(uuid, text) {
+  return { type: 'assistant', uuid, timestamp: `t-${uuid}`, message: { content: [{ type: 'text', text }] } };
+}
+
+describe('control/turn-stream', function () {
+  let dir;
+  let file;
+
+  beforeEach(function () {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'turn-stream-'));
+    file = path.join(dir, 'session-1.jsonl');
+  });
+
+  afterEach(function () {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+  });
+
+  it('resumes from a byte cursor and returns only newly appended items', async function () {
+    fs.writeFileSync(file, [line(userText('u1', 'hello')), line(assistantText('a1', 'hi'))].join(''));
+
+    const first = await TurnStream.readItems(file, null);
+    assert.deepEqual(first.items.map((i) => i.id), ['u1', 'a1']);
+    assert.equal(first.items[0].kind, 'user-text');
+    assert.equal(first.items[1].kind, 'assistant-text');
+    assert.ok(first.cursor.offset > 0);
+
+    fs.appendFileSync(file, line(userText('u2', 'next')));
+    const second = await TurnStream.readItems(file, first.cursor);
+    assert.deepEqual(second.items.map((i) => i.id), ['u2']);
+    assert.equal(second.items[0].text, 'next');
+    assert.equal(second.reset, false);
+    assert.equal(second.epoch, first.epoch);
+  });
+
+  it('detects compact_boundary, resets to the post-compact stream, and bumps epoch', async function () {
+    fs.writeFileSync(file, line(userText('u1', 'before compact')));
+    const before = await TurnStream.readItems(file, null);
+    assert.equal(before.reset, false);
+    assert.deepEqual(before.items.map((i) => i.id), ['u1']);
+
+    fs.appendFileSync(file, [
+      line({ type: 'system', subtype: 'compact_boundary', content: 'Conversation compacted', compactMetadata: { kept: 1 } }),
+      line({ type: 'user', uuid: 'summary-1', message: { content: [{ type: 'text', text: 'summary continuation' }] } }),
+    ].join(''));
+
+    const after = await TurnStream.readItems(file, before.cursor);
+    assert.equal(after.reset, true);
+    assert.notEqual(after.epoch, before.epoch);
+    assert.match(after.epoch, /:compact:/);
+    assert.deepEqual(after.items.map((i) => i.id), ['summary-1']);
+    assert.equal(after.items[0].text, 'summary continuation');
+    assert.equal(after.cursor.epoch, after.epoch);
+  });
+
+  it('does not emit or advance past a trailing partial line until it is complete', async function () {
+    const complete = line(userText('u1', 'complete'));
+    fs.writeFileSync(file, complete + '{"type":"assistant","uuid":"a1","message":{"content":[{"type":"text"');
+
+    const first = await TurnStream.readItems(file, null);
+    assert.deepEqual(first.items.map((i) => i.id), ['u1']);
+    assert.equal(first.cursor.offset, Buffer.byteLength(complete));
+
+    fs.appendFileSync(file, ',"text":"now complete"}]}}\n');
+    const second = await TurnStream.readItems(file, first.cursor);
+    assert.deepEqual(second.items.map((i) => i.id), ['a1']);
+    assert.equal(second.items[0].kind, 'assistant-text');
+    assert.equal(second.items[0].text, 'now complete');
+  });
+
+  it('maps tool calls, tool results, thinking, and text with stable ids and preserved payloads', async function () {
+    fs.writeFileSync(file, [
+      line({
+        type: 'assistant',
+        uuid: 'assistant-1',
+        parentUuid: 'user-1',
+        sessionId: 'claude-session',
+        cwd: '/work',
+        timestamp: '2026-07-07T00:00:00.000Z',
+        message: { content: [
+          { type: 'tool_use', id: 'toolu-1', name: 'Bash', input: { command: 'npm test', timeout: 120000 } },
+          { type: 'text', text: 'I will run the tests.' },
+          { type: 'thinking', thinking: 'Need to verify behavior.', signature: 'sig-1' },
+        ] },
+      }),
+      line({
+        type: 'user',
+        uuid: 'result-1',
+        message: { content: [
+          { type: 'tool_result', tool_use_id: 'toolu-1', content: { stdout: 'ok', code: 0 }, is_error: true },
+        ] },
+        toolUseResult: { stdout: 'ok', code: 0 },
+      }),
+      line({ type: 'assistant', uuid: 'sidechain-1', isSidechain: true, message: { content: [{ type: 'text', text: 'subagent' }] } }),
+    ].join(''));
+
+    const out = await TurnStream.readItems(file, null);
+    assert.deepEqual(out.items.map((i) => i.kind), ['tool-call', 'assistant-text', 'thinking', 'tool-result']);
+    assert.equal(new Set(out.items.map((i) => i.id)).size, out.items.length, 'ids are unique per semantic item');
+    assert.deepEqual(out.items.map((i) => i.id), [
+      'assistant-1:tool-call:toolu-1:0',
+      'assistant-1:assistant-text:1',
+      'assistant-1:thinking:2',
+      'result-1',
+    ]);
+
+    const call = out.items[0];
+    assert.equal(call.toolUseId, 'toolu-1');
+    assert.equal(call.name, 'Bash');
+    assert.deepEqual(call.input, { command: 'npm test', timeout: 120000 });
+    assert.equal(call.parentUuid, 'user-1');
+    assert.equal(call.sessionId, 'claude-session');
+    assert.equal(call.cwd, '/work');
+
+    const thinking = out.items[2];
+    assert.equal(thinking.thinking, 'Need to verify behavior.');
+    assert.equal(thinking.signature, 'sig-1');
+
+    const result = out.items[3];
+    assert.equal(result.toolUseId, 'toolu-1');
+    assert.deepEqual(result.content, { stdout: 'ok', code: 0 });
+    assert.equal(result.isError, true);
+    assert.deepEqual(result.toolUseResult, { stdout: 'ok', code: 0 });
+  });
+
+  it('does not forward-skip after a large offline gap', async function () {
+    const count = 300;
+    const big = 'x'.repeat(3000);
+    const lines = [];
+    for (let i = 0; i < count; i++) lines.push(line(userText(`u-${i}`, `${i}:${big}`)));
+    fs.writeFileSync(file, lines.join(''));
+    assert.ok(fs.statSync(file).size > 512 * 1024, 'fixture exceeds the old sticky-note tail window');
+
+    const epoch = TurnStream.fileEpoch(file, fs.statSync(file));
+    const out = await TurnStream.readItems(file, { epoch, offset: 0 }, { limit: count + 10 });
+    assert.equal(out.items.length, count);
+    assert.equal(out.items[0].id, 'u-0');
+    assert.equal(out.items[count - 1].id, `u-${count - 1}`);
+    assert.equal(out.more, false);
+  });
+
+  it('skips agent-*.jsonl subagent transcript files', async function () {
+    const agentFile = path.join(dir, 'agent-subtask.jsonl');
+    fs.writeFileSync(agentFile, line(userText('u1', 'from subagent')));
+    const out = await TurnStream.readItems(agentFile, null);
+    assert.deepEqual(out.items, []);
+  });
+
+  it('bounds each read window, reports more, and returns a resumable cursor', async function () {
+    const maxBytes = 32 * 1024;
+    const count = 1000;
+    const lines = [];
+    for (let i = 0; i < count; i++) lines.push(line(userText(`u-${i}`, `${i}:${'x'.repeat(200)}`)));
+    fs.writeFileSync(file, lines.join(''));
+    assert.ok(fs.statSync(file).size > maxBytes * 4, 'fixture is much larger than the read window');
+
+    const first = await TurnStream.readItems(file, null, { limit: count, maxBytes });
+    assert.ok(first.items.length > 0, 'returns bounded items from complete lines');
+    assert.equal(first.more, true);
+    assert.ok(first.cursor.offset > 0, 'cursor advances');
+    assert.ok(first.cursor.offset <= maxBytes, 'cursor advances no farther than the configured window');
+
+    const lastFirst = Number(first.items[first.items.length - 1].id.slice(2));
+    const second = await TurnStream.readItems(file, first.cursor, { limit: count, maxBytes });
+    assert.equal(second.reset, false);
+    assert.ok(second.items.length > 0, 'cursor can be resumed');
+    assert.equal(second.items[0].id, `u-${lastFirst + 1}`);
+    assert.ok(second.cursor.offset > first.cursor.offset);
+    assert.ok(second.cursor.offset - first.cursor.offset <= maxBytes, 'resumed read also stays within the window');
+  });
+
+  it('skips an oversized JSONL line without parsing or emitting a giant item', async function () {
+    this.timeout(10000);
+    const oversized = line(userText('huge', 'x'.repeat(5 * 1024 * 1024)));
+    fs.writeFileSync(file, oversized);
+
+    const out = await TurnStream.readItems(file, null);
+    assert.deepEqual(out.items, []);
+    assert.equal(out.cursor.offset, Buffer.byteLength(oversized));
+    assert.equal(out.more, false);
+  });
+
+  it('does not spin on an oversized unterminated trailing line', async function () {
+    const partial = JSON.stringify(userText('huge-partial', 'x'.repeat(128 * 1024)));
+    fs.writeFileSync(file, partial);
+
+    const first = await TurnStream.readItems(file, null, { maxBytes: 32 * 1024, maxLineBytes: 8 * 1024 });
+    assert.deepEqual(first.items, []);
+    assert.equal(first.cursor.offset, 0);
+    assert.equal(first.more, false);
+
+    fs.appendFileSync(file, '\n');
+    const second = await TurnStream.readItems(file, first.cursor, { maxBytes: 32 * 1024, maxLineBytes: 8 * 1024 });
+    assert.deepEqual(second.items, []);
+    assert.equal(second.cursor.offset, Buffer.byteLength(partial) + 1);
+    assert.equal(second.more, false);
+  });
+
+  it('detects a stale cursor after a same-inode in-place rewrite and rereads from zero', async function () {
+    const firstLine = line(userText('u1', 'before rewrite'));
+    fs.writeFileSync(file, firstLine + line(userText('u2', 'second')));
+    const first = await TurnStream.readItems(file, null, { limit: 1 });
+    assert.equal(first.cursor.offset, Buffer.byteLength(firstLine));
+
+    const beforeStat = fs.statSync(file);
+    const rewritten = line(userText('n1', 'reshaped '.repeat(100))) + line(userText('n2', 'after rewrite'));
+    const fd = fs.openSync(file, 'r+');
+    try {
+      fs.ftruncateSync(fd, 0);
+      fs.writeSync(fd, rewritten, 0, 'utf8');
+    } finally {
+      fs.closeSync(fd);
+    }
+    const afterStat = fs.statSync(file);
+    assert.equal(afterStat.ino, beforeStat.ino, 'fixture rewrites the same inode');
+    assert.notEqual(fs.readFileSync(file)[first.cursor.offset - 1], 0x0a, 'old cursor now points into a line');
+
+    const out = await TurnStream.readItems(file, first.cursor);
+    assert.equal(out.reset, true);
+    assert.deepEqual(out.items.map((i) => i.id), ['n1', 'n2']);
+    assert.equal(out.cursor.offset, Buffer.byteLength(rewritten));
+  });
+
+  it('treats forged giant epochs as mismatches and never uses them in emitted ids', async function () {
+    fs.writeFileSync(file, line({ type: 'user', message: { content: 'no uuid fallback' } }));
+    const forged = `deadbeefdeadbeef:compact:${'x'.repeat(1024 * 1024)}`;
+
+    const out = await TurnStream.readItems(file, { epoch: forged, offset: 0 });
+    assert.equal(out.reset, true);
+    assert.match(out.epoch, /^[0-9a-f]{16}$/);
+    assert.equal(out.cursor.epoch, out.epoch);
+    assert.equal(out.items.length, 1);
+    assert.ok(out.items[0].id.length <= 200);
+    assert.ok(!out.items[0].id.includes('deadbeefdeadbeef:compact:'));
+  });
+
+  it('floors non-positive limits so reads make progress instead of spinning', async function () {
+    fs.writeFileSync(file, line(userText('u1', 'one')) + line(userText('u2', 'two')));
+
+    const zero = await TurnStream.readItems(file, null, { limit: 0 });
+    assert.deepEqual(zero.items.map((i) => i.id), ['u1']);
+    assert.equal(zero.more, true);
+    assert.ok(zero.cursor.offset > 0);
+
+    const negative = await TurnStream.readItems(file, null, { limit: -5 });
+    assert.deepEqual(negative.items.map((i) => i.id), ['u1']);
+    assert.equal(negative.more, true);
+    assert.ok(negative.cursor.offset > 0);
+  });
+
+  it('sanitizes and caps uuid-derived ids', async function () {
+    const longUuid = 'a'.repeat(10 * 1024);
+    fs.writeFileSync(file, line(userText('__proto__', 'reserved key')) + line(userText(longUuid, 'long id')));
+
+    const out = await TurnStream.readItems(file, null);
+    assert.equal(typeof out.items[0].id, 'string');
+    assert.equal(out.items[0].id, 'id-__proto__');
+    assert.ok(out.items[0].id.length <= 200);
+    assert.equal(typeof out.items[1].id, 'string');
+    assert.ok(out.items[1].id.length <= 200);
+    assert.equal(out.items[1].id, 'a'.repeat(80));
+  });
+});

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -74,6 +74,101 @@ function collectMessages(ws, type, durationMs = 3000) {
 }
 
 /**
+ * Collect messages of a given type for a duration after the first one arrives.
+ * The listener is installed immediately; firstTimeoutMs gates only the first
+ * arrival so PTY load cannot consume the rate-measurement window.
+ */
+function collectMessagesAfterFirst(ws, type, firstTimeoutMs = 15000, durationMs = 3000) {
+  return new Promise((resolve, reject) => {
+    const collected = [];
+    let collectionTimer = null;
+
+    const firstTimer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for first message type "${type}" after ${firstTimeoutMs}ms`));
+    }, firstTimeoutMs);
+
+    function onMessage(raw, isBinary) {
+      if (isBinary) return;
+      const msg = JSON.parse(raw.toString());
+      if (msg.type !== type) return;
+
+      collected.push(msg);
+      if (!collectionTimer) {
+        clearTimeout(firstTimer);
+        collectionTimer = setTimeout(() => {
+          cleanup();
+          resolve(collected);
+        }, durationMs);
+      }
+    }
+
+    function onClose() {
+      cleanup();
+      reject(new Error(`WebSocket closed while collecting "${type}"`));
+    }
+
+    function cleanup() {
+      clearTimeout(firstTimer);
+      if (collectionTimer) clearTimeout(collectionTimer);
+      ws.removeListener('message', onMessage);
+      ws.removeListener('close', onClose);
+    }
+
+    ws.on('message', onMessage);
+    ws.on('close', onClose);
+  });
+}
+
+/**
+ * Wait until no session_activity for a session has arrived for quietMs. This
+ * synchronizes tests with the server's >1s activity throttle without changing
+ * the post-input assertions.
+ */
+function waitForSessionActivityQuiet(ws, sessionId, quietMs = 1200, timeoutMs = 15000) {
+  return new Promise((resolve, reject) => {
+    let quietTimer = null;
+
+    const timeoutTimer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for quiet session_activity window for "${sessionId}" after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    function resetQuietTimer() {
+      if (quietTimer) clearTimeout(quietTimer);
+      quietTimer = setTimeout(() => {
+        cleanup();
+        resolve();
+      }, quietMs);
+    }
+
+    function onMessage(raw, isBinary) {
+      if (isBinary) return;
+      const msg = JSON.parse(raw.toString());
+      if (msg.type === 'session_activity' && msg.sessionId === sessionId) {
+        resetQuietTimer();
+      }
+    }
+
+    function onClose() {
+      cleanup();
+      reject(new Error(`WebSocket closed while waiting for quiet session_activity window for "${sessionId}"`));
+    }
+
+    function cleanup() {
+      clearTimeout(timeoutTimer);
+      if (quietTimer) clearTimeout(quietTimer);
+      ws.removeListener('message', onMessage);
+      ws.removeListener('close', onClose);
+    }
+
+    ws.on('message', onMessage);
+    ws.on('close', onClose);
+    resetQuietTimer();
+  });
+}
+
+/**
  * Send a JSON message over the WebSocket.
  */
 function wsSend(ws, data) {
@@ -1099,12 +1194,15 @@ describe('E2E: Session activity broadcasting', function () {
     // Client B connects but does NOT join any session (lobby state)
     const { ws: wsB } = await connectWs(port);
 
+    await waitForSessionActivityQuiet(wsB, created.sessionId);
+
     // Send input to session A via client A
     const marker = `ACTIVITY_${Date.now()}`;
+    const activityPromise = waitForMessage(wsB, 'session_activity', 15000);
     wsSend(wsA, { type: 'input', data: `echo ${marker}\n` });
 
     // Client B should receive session_activity (not output)
-    const activity = await waitForMessage(wsB, 'session_activity', 5000);
+    const activity = await activityPromise;
     assert.strictEqual(activity.sessionId, created.sessionId);
     assert.strictEqual(activity.sessionName, 'Active Session');
 
@@ -1204,17 +1302,16 @@ describe('E2E: Session activity broadcasting', function () {
     const { ws: wsB } = await connectWs(port);
 
     wsSend(wsA, { type: 'create_session', name: 'Throttle Test' });
-    await waitForMessage(wsA, 'session_created');
+    const created = await waitForMessage(wsA, 'session_created');
     wsSend(wsA, { type: 'start_terminal' });
     await waitForMessage(wsA, 'terminal_started', 15000);
     await waitForMessage(wsB, 'session_started', 5000).catch(() => {});
     await collectMessages(wsA, 'output', 1500);
 
-    // Wait for throttle window to pass from terminal start
-    await new Promise(r => setTimeout(r, 1100));
+    await waitForSessionActivityQuiet(wsB, created.sessionId);
 
     // Start collecting BEFORE sending input so we don't miss early messages
-    const collectPromise = collectMessages(wsB, 'session_activity', 4000);
+    const collectPromise = collectMessagesAfterFirst(wsB, 'session_activity', 15000, 4000);
 
     // Send 10 rapid echo commands (100ms apart)
     for (let i = 0; i < 10; i++) {
@@ -1247,12 +1344,12 @@ describe('E2E: Session activity broadcasting', function () {
     // Drain any session_started that arrived for session 1
     await collectMessages(wsB, 'session_started', 500);
 
-    // Wait for shell prompts to settle and throttle window to pass
-    await new Promise(r => setTimeout(r, 2000));
+    await waitForSessionActivityQuiet(wsB, created1.sessionId);
 
     // Send input to session 1
+    const activityPromise = waitForMessage(wsB, 'session_activity', 15000);
     wsSend(wsA, { type: 'input', data: `echo CROSS_SESSION\n` });
-    const activity = await waitForMessage(wsB, 'session_activity', 5000);
+    const activity = await activityPromise;
     assert.strictEqual(activity.sessionId, created1.sessionId);
 
     wsSend(wsA, { type: 'stop' });
@@ -1326,11 +1423,12 @@ describe('E2E: Session activity broadcasting', function () {
     await closeWs(wsB);
     const { ws: wsC } = await connectWs(port);
 
+    await waitForSessionActivityQuiet(wsC, created.sessionId);
+
     // Send input — new client C should receive activity
-    // Wait for shell prompts to settle and throttle window to pass
-    await new Promise(r => setTimeout(r, 2000));
+    const activityPromise = waitForMessage(wsC, 'session_activity', 15000);
     wsSend(wsA, { type: 'input', data: `echo RECONNECT\n` });
-    const activity = await waitForMessage(wsC, 'session_activity', 5000);
+    const activity = await activityPromise;
     assert.strictEqual(activity.sessionId, created.sessionId);
 
     wsSend(wsA, { type: 'stop' });
@@ -1355,12 +1453,12 @@ describe('E2E: Session activity broadcasting', function () {
     wsSend(wsB, { type: 'leave_session' });
     await waitForMessage(wsB, 'session_left', 5000);
 
-    // Wait long enough for shell prompts to settle and throttle window to pass
-    await new Promise(r => setTimeout(r, 2000));
+    await waitForSessionActivityQuiet(wsB, created.sessionId);
 
     // Send input — B (now in lobby) should receive session_activity
+    const activityPromise = waitForMessage(wsB, 'session_activity', 15000);
     wsSend(wsA, { type: 'input', data: `echo LOBBY\n` });
-    const activity = await waitForMessage(wsB, 'session_activity', 5000);
+    const activity = await activityPromise;
     assert.strictEqual(activity.sessionId, created.sessionId);
 
     wsSend(wsA, { type: 'stop' });

--- a/test/integration/decision-hook-seam.test.js
+++ b/test/integration/decision-hook-seam.test.js
@@ -1,0 +1,771 @@
+#!/usr/bin/env node
+'use strict';
+
+// Live seam verifier for ai-or-die mobile-mode Channel-1 decisions.
+//
+// This intentionally uses REAL processes on the two checked-out repos:
+//   - ai-or-die: node bin/ai-or-die.js --port <ephemeral> --auth <token>
+//   - github-router: node dist/main.js internal-decision-hook
+//
+// Run directly from the ai-or-die repo after building github-router:
+//   node test/integration/decision-hook-seam.test.js
+//
+// Mocha integration is opt-in because this test depends on a sibling checkout of
+// github-router and spawns cross-repo binaries:
+//   AIORDIE_DECISION_HOOK_SEAM=1 npx mocha --timeout 60000 test/integration/decision-hook-seam.test.js
+
+const assert = require('assert');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const AI_OR_DIE_ROOT = path.resolve(__dirname, '..', '..');
+const GITHUB_ROUTER_ROOT = process.env.GITHUB_ROUTER_ROOT
+  ? path.resolve(process.env.GITHUB_ROUTER_ROOT)
+  : path.resolve(AI_OR_DIE_ROOT, '..', 'github-router');
+const HOOK_MAIN = process.env.GITHUB_ROUTER_HOOK_MAIN
+  ? path.resolve(process.env.GITHUB_ROUTER_HOOK_MAIN)
+  : path.join(GITHUB_ROUTER_ROOT, 'dist', 'main.js');
+
+// CI-safe live seam requirement: github-router must be checked out on branch
+// feat/mobile-mode-decision-hook and built via its build step producing dist/main.js.
+let githubRouterRepoPresent = false;
+try { githubRouterRepoPresent = fs.statSync(GITHUB_ROUTER_ROOT).isDirectory(); } catch (_) {}
+if (!githubRouterRepoPresent) {
+  console.log(`SKIP: github-router repo not found at ${GITHUB_ROUTER_ROOT}; requires the github-router sibling repo on branch feat/mobile-mode-decision-hook, built via its build step producing dist/main.js`);
+  process.exit(0);
+}
+if (!fs.existsSync(HOOK_MAIN)) {
+  console.log(`SKIP: github-router built binary not found at ${HOOK_MAIN}; requires the github-router sibling repo on branch feat/mobile-mode-decision-hook, built via its build step`);
+  process.exit(0);
+}
+
+const WebSocket = require('ws');
+
+const AUTH_TOKEN = 'decision-seam-token';
+const CASE_WALL_MS = 12000;
+const NO_VIEWER_WALL_MS = 7000;
+const VIEWER_TIMEOUT_WALL_MS = 8000;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function pickFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = address && address.port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function readJsonResponse(response) {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    err.responseText = text;
+    throw err;
+  }
+}
+
+async function requestJson(baseUrl, method, pathname, body) {
+  const headers = { Authorization: `Bearer ${AUTH_TOKEN}` };
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+  const response = await fetch(`${baseUrl}${pathname}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  let json = {};
+  if (text) {
+    try { json = JSON.parse(text); }
+    catch (_) { json = { nonJsonBody: text }; }
+  }
+  if (!response.ok) {
+    const err = new Error(`${method} ${pathname} -> HTTP ${response.status}: ${text.slice(0, 500)}`);
+    err.status = response.status;
+    err.body = json;
+    throw err;
+  }
+  return json;
+}
+
+function captureProcess(child, name) {
+  const chunks = { stdout: [], stderr: [] };
+  child.stdout && child.stdout.on('data', (buf) => chunks.stdout.push(Buffer.from(buf)));
+  child.stderr && child.stderr.on('data', (buf) => chunks.stderr.push(Buffer.from(buf)));
+  const exit = new Promise((resolve) => {
+    child.once('exit', (code, signal) => {
+      resolve({
+        name,
+        code,
+        signal,
+        stdout: Buffer.concat(chunks.stdout).toString('utf8'),
+        stderr: Buffer.concat(chunks.stderr).toString('utf8'),
+      });
+    });
+  });
+  return { chunks, exit };
+}
+
+async function waitForHealth(baseUrl, serverCapture, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr = null;
+  while (Date.now() < deadline) {
+    const exited = await Promise.race([
+      serverCapture.exit.then((result) => ({ exited: true, result })),
+      sleep(1).then(() => ({ exited: false })),
+    ]);
+    if (exited.exited) {
+      throw new Error(`ai-or-die exited before health was ready: code=${exited.result.code} signal=${exited.result.signal}\nstdout=${exited.result.stdout}\nstderr=${exited.result.stderr}`);
+    }
+    try {
+      const response = await fetch(`${baseUrl}/api/health`, {
+        headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+      });
+      if (response.ok) {
+        const json = await readJsonResponse(response);
+        if (json && json.status === 'ok') return json;
+      } else {
+        lastErr = new Error(`health HTTP ${response.status}: ${(await response.text()).slice(0, 200)}`);
+      }
+    } catch (err) {
+      lastErr = err;
+    }
+    await sleep(100);
+  }
+  throw new Error(`timed out waiting for /api/health${lastErr ? `; last error: ${lastErr.message}` : ''}`);
+}
+
+async function startAiOrDie() {
+  const scratchRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'aiordie-decision-seam-'));
+  const childHome = path.join(scratchRoot, 'home');
+  const localAppData = path.join(scratchRoot, 'localappdata');
+  const appData = path.join(scratchRoot, 'appdata');
+  fs.mkdirSync(childHome, { recursive: true });
+  fs.mkdirSync(localAppData, { recursive: true });
+  fs.mkdirSync(appData, { recursive: true });
+
+  const port = await pickFreePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const args = [
+    'bin/ai-or-die.js',
+    '--port', String(port),
+    '--auth', AUTH_TOKEN,
+    '--no-stt',
+    '--no-sticky-notes',
+    '--no-keepalive',
+  ];
+  const child = spawn(process.execPath, args, {
+    cwd: AI_OR_DIE_ROOT,
+    env: {
+      ...process.env,
+      HOME: childHome,
+      USERPROFILE: childHome,
+      LOCALAPPDATA: localAppData,
+      APPDATA: appData,
+      CI: '1',
+      STT_DISABLED: '1',
+      AIORDIE_DISABLE_STICKY_NOTES: '1',
+      AIORDIE_DISABLE_KEEPALIVE: '1',
+      NO_COLOR: '1',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  const capture = captureProcess(child, 'ai-or-die');
+
+  await waitForHealth(baseUrl, capture, 30000);
+
+  return {
+    port,
+    baseUrl,
+    child,
+    capture,
+    scratchRoot,
+    command: `${process.execPath} ${args.join(' ')}`,
+    async stop() {
+      if (child.exitCode == null && child.signalCode == null) {
+        try { child.kill('SIGTERM'); } catch (_) {}
+        const done = await Promise.race([
+          capture.exit.then((result) => ({ result })),
+          sleep(5000).then(() => ({ timeout: true })),
+        ]);
+        if (done.timeout && child.exitCode == null && child.signalCode == null) {
+          try { child.kill('SIGKILL'); } catch (_) {}
+          await Promise.race([capture.exit, sleep(2000)]);
+        }
+      }
+      try { fs.rmSync(scratchRoot, { recursive: true, force: true }); } catch (_) {}
+    },
+  };
+}
+
+async function createAiOrDieSession(baseUrl, name) {
+  const created = await requestJson(baseUrl, 'POST', '/api/sessions/create', { name });
+  if (!created || typeof created.sessionId !== 'string' || !created.sessionId) {
+    throw new Error(`create session returned no sessionId: ${JSON.stringify(created)}`);
+  }
+  return created.sessionId;
+}
+
+function writeMirror(claudeConfigDir, baseUrl, sessionId) {
+  fs.mkdirSync(claudeConfigDir, { recursive: true });
+  const mirror = {
+    baseUrl,
+    token: AUTH_TOKEN,
+    sessionId,
+    insecureTLS: false,
+  };
+  const mirrorPath = path.join(claudeConfigDir, '.aiordie-artifact.json');
+  fs.writeFileSync(mirrorPath, JSON.stringify(mirror, null, 2));
+  return { mirror, mirrorPath };
+}
+
+function startHookProcess({ stdin, claudeConfigDir, sessionId, wallMs, extraEnv }) {
+  const startedAt = Date.now();
+  const child = spawn(process.execPath, [HOOK_MAIN, 'internal-decision-hook'], {
+    cwd: GITHUB_ROUTER_ROOT,
+    env: {
+      ...process.env,
+      AIORDIE_SESSION_ID: sessionId,
+      CLAUDE_CONFIG_DIR: claudeConfigDir,
+      NO_COLOR: '1',
+      NO_PROXY: '127.0.0.1,localhost',
+      no_proxy: '127.0.0.1,localhost',
+      ...extraEnv,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  const capture = captureProcess(child, 'internal-decision-hook');
+  child.stdin.end(stdin);
+
+  let timedOut = false;
+  const wall = setTimeout(() => {
+    timedOut = true;
+    try { child.kill('SIGKILL'); } catch (_) {}
+  }, wallMs);
+  if (typeof wall.unref === 'function') wall.unref();
+
+  const result = capture.exit.then((out) => {
+    clearTimeout(wall);
+    return { ...out, timedOut, durationMs: Date.now() - startedAt };
+  });
+
+  return { child, result };
+}
+
+async function waitForDecision(baseUrl, sessionId, predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    const listed = await requestJson(baseUrl, 'GET', `/api/control/sessions/${encodeURIComponent(sessionId)}/decisions`);
+    last = listed;
+    const decisions = Array.isArray(listed.decisions) ? listed.decisions : [];
+    const match = decisions.find(predicate || (() => true));
+    if (match) return match;
+    await sleep(25);
+  }
+  throw new Error(`timed out waiting for decision; last=${JSON.stringify(last)}`);
+}
+
+async function listDecisions(baseUrl, sessionId) {
+  const listed = await requestJson(baseUrl, 'GET', `/api/control/sessions/${encodeURIComponent(sessionId)}/decisions`);
+  return Array.isArray(listed.decisions) ? listed.decisions : [];
+}
+
+async function answerDecision(baseUrl, decisionId, choice) {
+  return requestJson(baseUrl, 'POST', `/api/control/decisions/${encodeURIComponent(decisionId)}/answer`, { choice });
+}
+
+async function awaitDecisionStatus(baseUrl, decisionId, timeoutMs) {
+  return requestJson(baseUrl, 'GET', `/api/control/decisions/${encodeURIComponent(decisionId)}/await?timeoutMs=${encodeURIComponent(String(timeoutMs))}`);
+}
+
+function waitForWsMessage(ws, type, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for WebSocket message ${type}`));
+    }, timeoutMs);
+    if (typeof timer.unref === 'function') timer.unref();
+
+    function cleanup() {
+      clearTimeout(timer);
+      ws.removeListener('message', onMessage);
+      ws.removeListener('close', onClose);
+      ws.removeListener('error', onError);
+    }
+
+    function onMessage(raw, isBinary) {
+      if (isBinary) return;
+      let msg;
+      try { msg = JSON.parse(raw.toString()); }
+      catch (err) {
+        cleanup();
+        reject(err);
+        return;
+      }
+      if (msg.type === type) {
+        cleanup();
+        resolve(msg);
+      } else if (msg.type === 'error' && type !== 'error') {
+        cleanup();
+        reject(new Error(`WebSocket error while waiting for ${type}: ${msg.message || JSON.stringify(msg)}`));
+      }
+    }
+
+    function onClose() {
+      cleanup();
+      reject(new Error(`WebSocket closed while waiting for ${type}`));
+    }
+
+    function onError(err) {
+      cleanup();
+      reject(err);
+    }
+
+    ws.on('message', onMessage);
+    ws.on('close', onClose);
+    ws.on('error', onError);
+  });
+}
+
+async function closeWebSocket(ws) {
+  if (!ws || ws.readyState === WebSocket.CLOSED) return;
+  await new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { ws.terminate(); } catch (_) {}
+      resolve();
+    }, 2000);
+    if (typeof timer.unref === 'function') timer.unref();
+    ws.once('close', () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    });
+    try { ws.close(); } catch (_) {
+      try { ws.terminate(); } catch (__) {}
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      }
+    }
+  });
+}
+
+async function joinSessionViewer(ctx, sessionId) {
+  const url = `ws://127.0.0.1:${ctx.port}/?token=${encodeURIComponent(AUTH_TOKEN)}`;
+  const ws = new WebSocket(url);
+  try {
+    const connected = await waitForWsMessage(ws, 'connected', 5000);
+    ws.send(JSON.stringify({ type: 'join_session', sessionId }));
+    const joined = await waitForWsMessage(ws, 'session_joined', 5000);
+    assert.strictEqual(joined.sessionId, sessionId, 'viewer joined the target session');
+    return { ws, url, connected, joined };
+  } catch (err) {
+    await closeWebSocket(ws);
+    throw err;
+  }
+}
+
+function parseDenyStdout(stdout) {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    const hookOutput = parsed && parsed.hookSpecificOutput;
+    if (hookOutput && hookOutput.permissionDecision === 'deny') return hookOutput;
+    return null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function bashPayload(command) {
+  return JSON.stringify({
+    session_id: 'claude-hook-session-id-does-not-key-aiordie',
+    tool_name: 'Bash',
+    tool_input: { command },
+    cwd: AI_OR_DIE_ROOT,
+  });
+}
+
+function planPayload(plan) {
+  return JSON.stringify({
+    session_id: 'claude-hook-session-id-does-not-key-aiordie',
+    tool_name: 'ExitPlanMode',
+    tool_input: { plan },
+    cwd: AI_OR_DIE_ROOT,
+  });
+}
+
+const NORMAL_HOOK_ENV = {
+  GH_ROUTER_DECISION_HOOK_MAX_HUMAN_WAIT_MS: '10000',
+  GH_ROUTER_DECISION_HOOK_POLL_TIMEOUT_MS: '5000',
+  GH_ROUTER_DECISION_HOOK_SELF_DEADLINE_MS: '12000',
+};
+
+const NO_VIEWER_HOOK_ENV = {
+  GH_ROUTER_DECISION_HOOK_MAX_HUMAN_WAIT_MS: '3000',
+  GH_ROUTER_DECISION_HOOK_POLL_TIMEOUT_MS: '200',
+  GH_ROUTER_DECISION_HOOK_SELF_DEADLINE_MS: '5000',
+};
+
+const VIEWER_TIMEOUT_HOOK_ENV = {
+  GH_ROUTER_DECISION_HOOK_MAX_HUMAN_WAIT_MS: '2000',
+  GH_ROUTER_DECISION_HOOK_POLL_TIMEOUT_MS: '250',
+  GH_ROUTER_DECISION_HOOK_SELF_DEADLINE_MS: '6000',
+};
+
+async function runCase(ctx, spec) {
+  const caseScratch = fs.mkdtempSync(path.join(ctx.scratchRoot, `${spec.name.toLowerCase()}-`));
+  const sessionId = await createAiOrDieSession(ctx.baseUrl, `decision-hook-seam-${spec.name}`);
+  const claudeConfigDir = path.join(caseScratch, 'claude-config');
+  const { mirrorPath } = writeMirror(claudeConfigDir, ctx.baseUrl, sessionId);
+
+  const hook = startHookProcess({
+    stdin: spec.stdin,
+    claudeConfigDir,
+    sessionId,
+    wallMs: spec.wallMs || CASE_WALL_MS,
+    extraEnv: spec.extraEnv || NORMAL_HOOK_ENV,
+  });
+
+  let decision = null;
+  let answerResult = null;
+  let caseError = null;
+
+  try {
+    if (spec.answerChoice) {
+      decision = await waitForDecision(ctx.baseUrl, sessionId, spec.decisionPredicate, 5000);
+      answerResult = await answerDecision(ctx.baseUrl, decision.decisionId, spec.answerChoice);
+    } else {
+      // Observe the live create path without answering. If the hook wins the race
+      // and returns first, the pending decision remains listable and is checked
+      // after the hook result below.
+      try {
+        decision = await waitForDecision(ctx.baseUrl, sessionId, spec.decisionPredicate, 1000);
+      } catch (_) {
+        // Deliberately ignored until after the hook exits.
+      }
+    }
+  } catch (err) {
+    caseError = err;
+  }
+
+  const hookResult = await hook.result;
+
+  if (!decision) {
+    try {
+      const decisions = await listDecisions(ctx.baseUrl, sessionId);
+      decision = decisions.find(spec.decisionPredicate || (() => true)) || decisions[0] || null;
+    } catch (err) {
+      if (!caseError) caseError = err;
+    }
+  }
+
+  const deny = parseDenyStdout(hookResult.stdout);
+  const allow = hookResult.code === 0 && !hookResult.timedOut && !deny;
+
+  let pass = false;
+  const assertions = [];
+  try {
+    assert.strictEqual(hookResult.timedOut, false, 'hook exceeded wall-clock cap');
+    assert.strictEqual(hookResult.code, 0, 'hook exit code');
+    assert.ok(decision, 'decision was registered and listable');
+    if (spec.expectedKind) assert.strictEqual(decision.kind, spec.expectedKind, 'decision kind');
+    if (spec.expectedPlan !== undefined) assert.strictEqual(decision.plan, spec.expectedPlan, 'decision plan');
+    if (spec.expectedTool !== undefined) assert.strictEqual(decision.tool, spec.expectedTool, 'decision tool');
+    if (spec.expectedCommand !== undefined) assert.strictEqual(decision.command, spec.expectedCommand, 'decision command');
+    if (spec.answerChoice) assert.deepStrictEqual(answerResult, { ok: true }, 'answer route result');
+    if (spec.expectAllow) assert.ok(allow, 'expected allow (exit 0 and no deny JSON)');
+    if (spec.expectDeny) {
+      assert.ok(deny, 'expected deny JSON on stdout');
+      if (spec.expectedDenyReasonIncludes) {
+        assert.ok(String(deny.permissionDecisionReason || '').includes(spec.expectedDenyReasonIncludes), `deny reason includes ${spec.expectedDenyReasonIncludes}`);
+      }
+    }
+    if (caseError) throw caseError;
+    pass = true;
+  } catch (err) {
+    assertions.push(err.message || String(err));
+  }
+
+  return {
+    name: spec.name,
+    pass,
+    sessionId,
+    mirrorPath,
+    decision,
+    answerResult,
+    hook: {
+      command: `${process.execPath} ${HOOK_MAIN} internal-decision-hook`,
+      exitCode: hookResult.code,
+      signal: hookResult.signal,
+      timedOut: hookResult.timedOut,
+      durationMs: hookResult.durationMs,
+      stdout: hookResult.stdout,
+      stderr: hookResult.stderr,
+      deny,
+    },
+    assertions,
+  };
+}
+
+async function runViewerTimeoutCase(ctx) {
+  const name = 'VIEWER-TIMEOUT';
+  const caseScratch = fs.mkdtempSync(path.join(ctx.scratchRoot, `${name.toLowerCase()}-`));
+  const sessionId = await createAiOrDieSession(ctx.baseUrl, `decision-hook-seam-${name}`);
+  const claudeConfigDir = path.join(caseScratch, 'claude-config');
+  const { mirrorPath } = writeMirror(claudeConfigDir, ctx.baseUrl, sessionId);
+
+  let viewer = null;
+  let hook = null;
+  let decision = null;
+  let awaitStatus = null;
+  let caseError = null;
+
+  try {
+    viewer = await joinSessionViewer(ctx, sessionId);
+
+    hook = startHookProcess({
+      stdin: bashPayload('echo SEAM'),
+      claudeConfigDir,
+      sessionId,
+      wallMs: VIEWER_TIMEOUT_WALL_MS,
+      extraEnv: VIEWER_TIMEOUT_HOOK_ENV,
+    });
+
+    try {
+      decision = await waitForDecision(ctx.baseUrl, sessionId, null, 5000);
+      awaitStatus = await awaitDecisionStatus(ctx.baseUrl, decision.decisionId, 1);
+    } catch (err) {
+      caseError = err;
+    }
+
+    const hookResult = await hook.result;
+    const deny = parseDenyStdout(hookResult.stdout);
+    const denyReason = deny && deny.permissionDecisionReason ? String(deny.permissionDecisionReason) : '';
+
+    if (!decision) {
+      try {
+        const decisions = await listDecisions(ctx.baseUrl, sessionId);
+        decision = decisions[0] || null;
+      } catch (err) {
+        if (!caseError) caseError = err;
+      }
+    }
+
+    const assertions = [];
+    let pass = false;
+    try {
+      assert.strictEqual(hookResult.timedOut, false, 'hook exceeded wall-clock cap');
+      assert.strictEqual(hookResult.code, 0, 'hook exit code');
+      assert.ok(decision, 'decision was registered and listable');
+      assert.strictEqual(decision.kind, 'tool_approval', 'decision kind');
+      assert.strictEqual(decision.tool, 'Bash', 'decision tool');
+      assert.strictEqual(decision.command, 'echo SEAM', 'decision command');
+      assert.ok(awaitStatus && awaitStatus.answered === false, `decision await should still be unanswered: ${JSON.stringify(awaitStatus)}`);
+      assert.ok(awaitStatus.viewers > 0, `viewer count should be >0 after join_session: ${JSON.stringify(awaitStatus)}`);
+      assert.ok(deny, 'expected deny JSON on stdout');
+      assert.ok(/wait|deadline|timeout|timed out/i.test(denyReason), `deny reason mentions wait/deadline/timeout: ${denyReason}`);
+      assert.ok(!denyReason.includes('no mobile reviewer connected'), `deny reason must not be no-reviewer branch: ${denyReason}`);
+      if (caseError) throw caseError;
+      pass = true;
+    } catch (err) {
+      assertions.push(err.message || String(err));
+    }
+
+    return {
+      name,
+      pass,
+      sessionId,
+      mirrorPath,
+      decision,
+      answerResult: null,
+      viewer: viewer ? {
+        url: viewer.url,
+        connectionId: viewer.connected && viewer.connected.connectionId,
+        joined: viewer.joined,
+        awaitStatus,
+        registeredViewers: awaitStatus && typeof awaitStatus.viewers === 'number' ? awaitStatus.viewers : null,
+      } : null,
+      hook: {
+        command: `${process.execPath} ${HOOK_MAIN} internal-decision-hook`,
+        exitCode: hookResult.code,
+        signal: hookResult.signal,
+        timedOut: hookResult.timedOut,
+        durationMs: hookResult.durationMs,
+        stdout: hookResult.stdout,
+        stderr: hookResult.stderr,
+        deny,
+      },
+      env: VIEWER_TIMEOUT_HOOK_ENV,
+      assertions,
+    };
+  } catch (err) {
+    const hookResult = hook ? await hook.result : null;
+    const deny = hookResult ? parseDenyStdout(hookResult.stdout) : null;
+    return {
+      name,
+      pass: false,
+      sessionId,
+      mirrorPath,
+      decision,
+      answerResult: null,
+      viewer: viewer ? {
+        url: viewer.url,
+        connectionId: viewer.connected && viewer.connected.connectionId,
+        joined: viewer.joined,
+        awaitStatus,
+        registeredViewers: awaitStatus && typeof awaitStatus.viewers === 'number' ? awaitStatus.viewers : null,
+      } : null,
+      hook: hookResult ? {
+        command: `${process.execPath} ${HOOK_MAIN} internal-decision-hook`,
+        exitCode: hookResult.code,
+        signal: hookResult.signal,
+        timedOut: hookResult.timedOut,
+        durationMs: hookResult.durationMs,
+        stdout: hookResult.stdout,
+        stderr: hookResult.stderr,
+        deny,
+      } : {
+        command: `${process.execPath} ${HOOK_MAIN} internal-decision-hook`,
+        exitCode: null,
+        signal: null,
+        timedOut: false,
+        durationMs: null,
+        stdout: '',
+        stderr: '',
+        deny: null,
+      },
+      env: VIEWER_TIMEOUT_HOOK_ENV,
+      assertions: [err && err.message ? err.message : String(err)],
+    };
+  } finally {
+    if (viewer && viewer.ws) await closeWebSocket(viewer.ws);
+  }
+}
+
+async function runHarness() {
+  const ctx = await startAiOrDie();
+  const planText = '# Plan\n- prove the live decision seam\n- report the result';
+  try {
+    const cases = [];
+    cases.push(await runCase(ctx, {
+      name: 'ACCEPT',
+      stdin: bashPayload('echo SEAM'),
+      answerChoice: 'accept',
+      expectedKind: 'tool_approval',
+      expectedTool: 'Bash',
+      expectedCommand: 'echo SEAM',
+      expectAllow: true,
+    }));
+    cases.push(await runCase(ctx, {
+      name: 'REJECT',
+      stdin: bashPayload('echo SEAM'),
+      answerChoice: 'reject',
+      expectedKind: 'tool_approval',
+      expectedTool: 'Bash',
+      expectedCommand: 'echo SEAM',
+      expectDeny: true,
+      expectedDenyReasonIncludes: 'choice=reject',
+    }));
+    cases.push(await runCase(ctx, {
+      name: 'NO-VIEWER',
+      stdin: bashPayload('echo SEAM'),
+      expectedKind: 'tool_approval',
+      expectedTool: 'Bash',
+      expectedCommand: 'echo SEAM',
+      expectDeny: true,
+      expectedDenyReasonIncludes: 'no mobile reviewer connected',
+      extraEnv: NO_VIEWER_HOOK_ENV,
+      wallMs: NO_VIEWER_WALL_MS,
+    }));
+    cases.push(await runViewerTimeoutCase(ctx));
+    cases.push(await runCase(ctx, {
+      name: 'PLAN',
+      stdin: planPayload(planText),
+      answerChoice: 'accept',
+      expectedKind: 'plan_approval',
+      expectedPlan: planText,
+      expectAllow: true,
+    }));
+
+    return {
+      ok: cases.every((c) => c.pass),
+      aiOrDie: {
+        command: ctx.command,
+        baseUrl: ctx.baseUrl,
+      },
+      hook: {
+        root: GITHUB_ROUTER_ROOT,
+        main: HOOK_MAIN,
+        command: `${process.execPath} ${HOOK_MAIN} internal-decision-hook`,
+      },
+      contract: {
+        mirror: 'CLAUDE_CONFIG_DIR/.aiordie-artifact.json with {baseUrl, token, sessionId, insecureTLS}',
+        envGate: 'AIORDIE_SESSION_ID must be non-empty; hook uses mirror.sessionId for the ai-or-die /api/control session id',
+        auth: 'hook sends Authorization: Bearer <token>; harness ran ai-or-die with --auth and used the same token',
+        endpoints: [
+          'GET /api/health',
+          'POST /api/sessions/create',
+          'POST /api/control/sessions/:id/decision',
+          'GET /api/control/sessions/:id/decisions',
+          'POST /api/control/decisions/:decisionId/answer',
+          'GET /api/control/decisions/:decisionId/await?timeoutMs=',
+        ],
+      },
+      cases,
+    };
+  } finally {
+    await ctx.stop();
+  }
+}
+
+async function main() {
+  const report = await runHarness();
+  for (const c of report.cases) {
+    console.log(`${c.name}: ${c.pass ? 'PASS' : 'FAIL'} exit=${c.hook.exitCode} stdout=${JSON.stringify(c.hook.stdout)}`);
+    if (c.hook.stderr) console.log(`${c.name}: stderr=${JSON.stringify(c.hook.stderr)}`);
+    if (c.decision) console.log(`${c.name}: decision=${JSON.stringify(c.decision)}`);
+    if (c.assertions.length) console.log(`${c.name}: assertions=${JSON.stringify(c.assertions)}`);
+  }
+  console.log('SEAM_REPORT_JSON ' + JSON.stringify(report));
+  if (!report.ok) process.exitCode = 1;
+}
+
+if (typeof describe === 'function') {
+  const suite = process.env.AIORDIE_DECISION_HOOK_SEAM === '1' ? describe : describe.skip;
+  suite('github-router internal-decision-hook ↔ ai-or-die decision seam', function () {
+    this.timeout(60000);
+    it('round-trips accept, reject, no-viewer, and plan approval through live HTTP', async function () {
+      const report = await runHarness();
+      assert.strictEqual(report.ok, true, JSON.stringify(report.cases, null, 2));
+    });
+  });
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err && err.stack ? err.stack : String(err));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Mobile Mode — a transparent "user proxy" for driving Claude Code from a phone

Adds a phone/tablet experience where the user treats the terminal as **read-only** and interacts through structured surfaces. The Claude instance only ever sees its **native** channels (a tool result, or terminal stdin) — it spends no turn/token on panel lifecycle and cannot tell a phone tap from a keystroke. Opt-in and off by default: activate with `?mobileMode=1` (or the `cc-mobile-mode` sessionStorage flag); legacy touch-driving remains the default.

### The four surfaces
- **Conversation (read):** a durable turn-stream over the JSONL (stable ids, cursor+epoch, reset on compact/resume), collapsible tool-call/result cards. All content rendered via `textContent`.
- **Decision cards — Channel 1 (blocking):** a `PreToolUse` hook holds the tool; permission / plan / question sheets answer `allow`/`deny`/choice straight back to the hook. Wait-for-human, **fail-closed** (never auto-allow), trusted rendering from structured `tool_input` (no agent HTML → sidesteps the artifact-XSS / forged-approval path).
- **Input + interrupt — Channel 2:** the composer injects to stdin only when `idle_at_prompt` (queued while busy); interrupt is the one immediate injection.
- **Artifact panel:** height cap removed so it can grow to the full viewport.

### Security — the control plane is a remote input API
A 3-lab adversarial review (codex + gemini ×2) treated the phone-facing control plane as a remote command-injection / exfil surface. Findings closed and re-verified (7 dedicated origin tests):
- **[Critical]** Dropped wildcard `*.ts.net` / `*.devtunnels.ms` suffix trust (shared multi-tenant domains) → **exact-pin** to the server's own live tunnel/mesh origin.
- **[Critical]** Stopped trusting the client `Host` header for same-origin (a DNS-rebinding bypass).
- **[Important]** Origin-gate **every** control method incl. reads (closes cross-origin exfil under `--no-auth`).
- **[Important]** Replaced blanket RFC-1918 trust with the server's **own** interface addresses (lateral keystroke-injection on shared Wi-Fi).

No-Origin callers (the decision hook, curl, native apps) always pass; Bearer/token auth remains the primary gate, Origin is defense-in-depth. Non-tunnel public deploys set `AIORDIE_ALLOWED_ORIGINS`.

### Verification
| Gate | Result |
|---|---|
| Full `npm test` (unit + control + e2e) | **1879 passing, 0 failing** |
| Mobile e2e (Playwright WebKit, iPhone 16 + iPad 11 portrait) | **12/12** (incl. 2 XSS-literal invariants) |
| Desktop e2e (golden-path + functional-core) | **15/0** — origin gate does not disturb the main app |
| Decision-hook seam (real github-router binary ↔ live `/decision`) | **5/5** |
| Security — cross-lab review | **GO-final**, all findings closed |

Also deflaked two pre-existing failures at the source (not papered over): `session_activity` e2e (event-driven sync — register-before-trigger + throttle-quiet wait, replacing blind sleeps) and an iPad-landscape sheet-interaction flake (reduced-motion determinism).

### Cross-repo dependency
Channel 1 requires the companion `internal-decision-hook` + policy in **github-router** (separate PR). The seam test (`test/integration/decision-hook-seam.test.js`) drives the real hook binary against a live `/decision` server and skips cleanly if the binary is absent.

### Docs
ADR-0038 (decision), `docs/planning/mobile-mode.md` (plan), `docs/specs/mobile-mode-ui.md` (UI spec), `src/public/mobile-proto.html` (reference mock), `docs/planning/mobile-mode-mvp-go-no-go.html` (go/no-go).

### Remaining human gate
On-device dimension parity cannot be asserted from Windows (no iOS simulator; Playwright-WebKit verifies logic, not real-Safari layout). Verify on a real iPhone over the mesh/tunnel: launch `ai-or-die --tunnel`, open `https://<host>.devtunnels.ms/?mobileMode=1`, and drive a session (permission sheet shows exact command / Deny-default / red-on-destructive; Approve→runs, Deny→cancelled; plan + question sheets; idle-gated composer; immediate interrupt).
