### PR TITLE
fix(mesh): accept Authorization header for WebSocket auth

### DIFF
--- a/docs/history/mesh-ws-auth-header-2026.md
+++ b/docs/history/mesh-ws-auth-header-2026.md
@@ -1,0 +1,19 @@
+# Mesh WebSocket Authorization Header Auth
+
+**Date:** 2026-07-08
+**Files:** `src/server.js`, `test/ws-auth-header.test.js`, `docs/specs/mesh.md`
+**Tests:** `test/ws-auth-header.test.js`
+
+## Problem
+
+The mesh sidecar injects `Authorization: Bearer <token>` on the tailnet-to-loopback hop for both HTTP requests and WebSocket upgrade requests. HTTP routes already accepted either that bearer header or `?token=`, but the WebSocket server's `verifyClient` checked only the query token.
+
+A browser that reached an authenticated instance through the sidecar without a `?token=` query string could load HTTP routes but fail to open the WebSocket.
+
+## Fix
+
+WebSocket authentication now mirrors the HTTP middleware: when auth is enabled, a socket upgrade is accepted if either `?token=<token>` matches or `Authorization: Bearer <token>` matches. The query-token path remains supported, and `--disable-auth` still accepts unauthenticated sockets.
+
+## Verification
+
+`test/ws-auth-header.test.js` starts real loopback servers on ephemeral ports and covers bearer-header success, wrong-header rejection, query-token regression, and auth-disabled success.

--- a/docs/specs/authentication.md
+++ b/docs/specs/authentication.md
@@ -83,13 +83,14 @@ The server implements authentication directly rather than using the `AuthManager
    - `?token=<token>` query parameter (raw token, no Bearer prefix)
    - `Authorization: <token>` header (raw token, matched directly)
 
-3. **WebSocket auth** -- The `verifyClient` callback on the `ws.Server`:
+3. **WebSocket auth** -- The `verifyClient` callback on the `ws.Server` accepts the bearer token via **either** the `?token=` query parameter **or** an `Authorization: Bearer <token>` header (parity with the HTTP middleware, so a reverse proxy / mesh sidecar that injects the header authenticates the upgrade):
    ```js
    verifyClient: (info) => {
      if (!this.noAuth && this.auth) {
        const url = new URL(info.req.url, 'ws://localhost');
        const token = url.searchParams.get('token');
-       return token === this.auth;
+       const header = info.req.headers && info.req.headers['authorization'];
+       return token === this.auth || header === `Bearer ${this.auth}`;
      }
      return true;
    }

--- a/docs/specs/mesh.md
+++ b/docs/specs/mesh.md
@@ -108,9 +108,11 @@ invisible to the browser, and the terminal client derives `ws`/`wss` from
 ## Auth
 
 `--mesh` keeps the Bearer token ON (mesh ACL + token, layered), overriding the
-anonymous default of `--tunnel`. With both flags the tunnel URL carries
-`?token=` so it still works. Ship the default-deny `tag:aiordie` ACL from
-`docs/mesh-acl.example.hujson`.
+anonymous default of `--tunnel`. WebSocket upgrades accept the same credential
+forms as HTTP routes: either `?token=<token>` or `Authorization: Bearer <token>`,
+so the sidecar-injected header authenticates sockets on the tailnet-to-loopback
+hop. With both flags the tunnel URL carries `?token=` so it still works. Ship
+the default-deny `tag:aiordie` ACL from `docs/mesh-acl.example.hujson`.
 
 ## Egress (conductor → peers) — ADR-0036
 

--- a/src/server.js
+++ b/src/server.js
@@ -3503,7 +3503,11 @@ class ClaudeCodeWebServer {
         if (!this.noAuth && this.auth) {
           const url = new URL(info.req.url, 'ws://localhost');
           const token = url.searchParams.get('token');
-          return token === this.auth;
+          // Parity with the HTTP auth middleware: accept the bearer token via the
+          // Authorization header too, so a reverse proxy / mesh sidecar that injects
+          // `Authorization: Bearer <token>` on the WS upgrade authenticates the socket.
+          const header = info.req.headers && info.req.headers['authorization'];
+          return token === this.auth || header === `Bearer ${this.auth}`;
         }
         return true;
       }

--- a/test/ws-auth-header.test.js
+++ b/test/ws-auth-header.test.js
@@ -1,0 +1,209 @@
+'use strict';
+
+const assert = require('assert');
+const WebSocket = require('ws');
+const { ClaudeCodeWebServer } = require('../src/server');
+
+async function startServer(options) {
+  const server = new ClaudeCodeWebServer(Object.assign({
+    port: 0,
+    bindHost: '127.0.0.1',
+  }, options));
+  const httpServer = await server.start();
+  return { server, port: httpServer.address().port };
+}
+
+function wsUrl(port, suffix) {
+  return `ws://127.0.0.1:${port}${suffix || '/'}`;
+}
+
+function expectWebSocketOpen(url, options) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, options);
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      fail(new Error(`WebSocket connection timed out: ${url}`));
+    }, 5000);
+
+    function cleanup() {
+      clearTimeout(timer);
+      ws.removeListener('message', onMessage);
+      ws.removeListener('error', onError);
+      ws.removeListener('close', onClose);
+    }
+
+    function fail(err) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      ws.removeListener('message', onMessage);
+      ws.removeListener('close', onClose);
+      ws.once('close', () => ws.removeListener('error', onError));
+      try { ws.terminate(); } catch (_) { /* ignore */ }
+      reject(err);
+    }
+
+    function onMessage(raw, isBinary) {
+      if (isBinary) return;
+      let msg;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch (err) {
+        fail(err);
+        return;
+      }
+      if (msg.type !== 'connected') {
+        fail(new Error(`expected connected frame, got ${msg.type}`));
+        return;
+      }
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(ws);
+    }
+
+    function onError(err) {
+      fail(err);
+    }
+
+    function onClose() {
+      fail(new Error('WebSocket closed before connected frame'));
+    }
+
+    ws.on('message', onMessage);
+    ws.on('error', onError);
+    ws.on('close', onClose);
+  });
+}
+
+function expectWebSocketRejected(url, options) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, options);
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      fail(new Error(`Timed out waiting for WebSocket rejection: ${url}`));
+    }, 5000);
+
+    function cleanup() {
+      clearTimeout(timer);
+      ws.removeListener('open', onOpen);
+      ws.removeListener('error', onError);
+      ws.removeListener('close', onClose);
+    }
+
+    function pass(err) {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve({ error: err });
+    }
+
+    function fail(err) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      ws.removeListener('open', onOpen);
+      ws.removeListener('close', onClose);
+      ws.once('close', () => ws.removeListener('error', onError));
+      try { ws.terminate(); } catch (_) { /* ignore */ }
+      reject(err);
+    }
+
+    function onOpen() {
+      try { ws.close(); } catch (_) { /* ignore */ }
+      fail(new Error('Expected WebSocket handshake to be rejected, but it opened'));
+    }
+
+    function onError(err) {
+      if (/Unexpected server response/.test(err.message)) {
+        pass(err);
+        return;
+      }
+      fail(err);
+    }
+
+    function onClose() {
+      fail(new Error('WebSocket closed before a rejection error was reported'));
+    }
+
+    ws.on('open', onOpen);
+    ws.on('error', onError);
+    ws.on('close', onClose);
+  });
+}
+
+function closeWs(ws) {
+  return new Promise((resolve) => {
+    if (!ws || ws.readyState === WebSocket.CLOSED) {
+      resolve();
+      return;
+    }
+
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { ws.terminate(); } catch (_) { /* ignore */ }
+      resolve();
+    }, 2000);
+
+    ws.once('close', () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    });
+
+    try { ws.close(); } catch (_) { /* ignore */ }
+  });
+}
+
+describe('WebSocket auth: Authorization header parity', function () {
+  this.timeout(15000);
+
+  const AUTH_TOKEN = 'ws-auth-header-secret';
+  let authServer;
+  let authPort;
+  let noAuthServer;
+  let noAuthPort;
+
+  before(async function () {
+    ({ server: authServer, port: authPort } = await startServer({ auth: AUTH_TOKEN }));
+    ({ server: noAuthServer, port: noAuthPort } = await startServer({ noAuth: true }));
+  });
+
+  after(async function () {
+    if (authServer) await authServer.close();
+    if (noAuthServer) await noAuthServer.close();
+  });
+
+  it('accepts a bearer token in the Authorization header without a query token', async function () {
+    const ws = await expectWebSocketOpen(wsUrl(authPort), {
+      headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+    });
+    assert.strictEqual(ws.readyState, WebSocket.OPEN);
+    await closeWs(ws);
+  });
+
+  it('rejects a wrong Authorization header when no query token is present', async function () {
+    const result = await expectWebSocketRejected(wsUrl(authPort), {
+      headers: { Authorization: 'Bearer wrong-token' },
+    });
+
+    assert.match(result.error.message, /Unexpected server response: 401/);
+  });
+
+  it('still accepts the existing query-token authentication path', async function () {
+    const ws = await expectWebSocketOpen(wsUrl(authPort, `/?token=${encodeURIComponent(AUTH_TOKEN)}`));
+    assert.strictEqual(ws.readyState, WebSocket.OPEN);
+    await closeWs(ws);
+  });
+
+  it('accepts an unauthenticated socket when auth is disabled', async function () {
+    const ws = await expectWebSocketOpen(wsUrl(noAuthPort));
+    assert.strictEqual(ws.readyState, WebSocket.OPEN);
+    await closeWs(ws);
+  });
+});


### PR DESCRIPTION
## What

WebSocket `verifyClient` now accepts the bearer token via an `Authorization: Bearer <token>` header **in addition to** the existing `?token=` query param, matching the HTTP auth middleware.

## Why

In `--mesh` mode the tsnet sidecar (`newEdgeProxy`) injects `Authorization: Bearer <token>` on the tailnet→loopback hop for **both** HTTP requests and WebSocket upgrades. HTTP routes already honored that header, but the WS `verifyClient` looked only at `?token=`. So a browser that reaches an instance through the sidecar (or any reverse proxy that authenticates via the header) without a `?token=` query string loads the app over HTTP but **fails to open the terminal WebSocket**.

This is a latent inconsistency between HTTP and WS auth. Making them symmetric is what lets a front-end proxy keep the per-node token on while the browser stays token-less.

## Change

`src/server.js` — `verifyClient`:

```js
const token = url.searchParams.get('token');
const header = info.req.headers && info.req.headers['authorization'];
return token === this.auth || header === `Bearer ${this.auth}`;
```

The `?token=` path and `--disable-auth` behavior are unchanged.

## Tests

`test/ws-auth-header.test.js` drives real loopback servers on ephemeral ports:
- bearer header, no query token → **accepted**
- wrong `Authorization` header, no query token → **rejected** (401)
- existing `?token=` path → still **accepted** (regression)
- `--disable-auth` → unauthenticated socket **accepted**

Existing auth/WebSocket e2e coverage continues to pass.

## Docs

- `docs/specs/mesh.md` — WS accepts the same credential forms as HTTP; the sidecar-injected header authenticates sockets.
- `docs/specs/authentication.md` — updated the `verifyClient` description.
- `docs/history/mesh-ws-auth-header-2026.md` — problem/fix/verification note.
