### PR TITLE
feat(sticky-notes): make local-LLM summaries opt-in via --sticky-notes

### DIFF
--- a/bin/ai-or-die.js
+++ b/bin/ai-or-die.js
@@ -41,7 +41,7 @@ program
   .option('--stt-endpoint <url>', 'use external STT endpoint (OpenAI-compatible)')
   .option('--stt-model-dir <path>', 'custom directory for STT model files')
   .option('--stt-threads <number>', 'CPU threads for STT inference (default: auto, max 4)')
-  .option('--no-sticky-notes', 'disable per-tab AI session summaries + auto tab titles (on by default)')
+  .option('--sticky-notes', 'enable per-tab local AI session summaries (off by default; Claude tab titles remain free)')
   .option('--sticky-notes-model-dir <path>', 'custom directory for the sticky-note model file')
   .option('--sticky-notes-model <url>', 'override the sticky-note model GGUF download URL')
   .option('--sticky-notes-threads <number>', 'CPU threads for sticky-note inference (default: auto — three-quarters of the cores on CPU, gentle on GPU)')
@@ -128,8 +128,8 @@ async function main() {
       sttEndpoint: options.sttEndpoint || process.env.STT_ENDPOINT,
       sttModelDir: options.sttModelDir || process.env.AI_OR_DIE_MODELS_DIR,
       sttThreads: options.sttThreads || process.env.STT_THREADS,
-      // Per-tab AI session summaries (on by default; --no-sticky-notes disables).
-      stickyNotes: options.stickyNotes !== false && process.env.STICKY_NOTES_DISABLED !== '1',
+      // Per-tab AI session summaries are opt-in; --sticky-notes enables them.
+      stickyNotes: options.stickyNotes === true && process.env.STICKY_NOTES_DISABLED !== '1',
       stickyNotesModelDir: options.stickyNotesModelDir || process.env.STICKY_NOTES_MODEL_DIR,
       stickyNotesModel: options.stickyNotesModel || process.env.STICKY_NOTES_MODEL,
       stickyNotesThreads: options.stickyNotesThreads || process.env.STICKY_NOTES_THREADS,

--- a/docs/adrs/0022-local-llm-sticky-notes.md
+++ b/docs/adrs/0022-local-llm-sticky-notes.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-Accepted (2026-06).
+Superseded in part by [ADR-0039](0039-disable-default-local-llm-sticky-notes.md):
+the default-on local-LLM summary and model residency decisions are retired. The
+JSONL binding, redaction, and model-free `ai-title` mechanisms remain historical
+context.
 
 ## Context
 
@@ -59,7 +62,8 @@ download and graceful degradation. We reuse that shape.
   AI-agent tabs (claude/codex/gemini/copilot) AND plain terminal tabs — users
   frequently launch an AI CLI inside a shell, so `_isStickyEligible` includes
   `terminal` (an idle terminal never triggers inference; a noisy one can be
-  turned off per-tab). Disable globally with `--no-sticky-notes`; the
+  turned off per-tab). This historical default was later superseded by ADR-0039;
+  the old global disable flag was `--no-sticky-notes`. The
   server-authoritative per-session `stickyNotesEnabled` persists. Terminal output
   may contain secrets, so the
   text is **redacted on BOTH ends** (`src/utils/secret-redact.js`) — the input

--- a/docs/adrs/0023-sticky-note-model-bakeoff.md
+++ b/docs/adrs/0023-sticky-note-model-bakeoff.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-Accepted (2026-06). Supersedes the **Model** decision of
-[ADR-0022](0022-local-llm-sticky-notes.md) (Gemma 3 1B). The rest of ADR-0022
-(architecture, worker, redaction, scheduling, on-by-default, degradation) stands.
+Superseded by [ADR-0039](0039-disable-default-local-llm-sticky-notes.md).
+This remains the historical model bake-off and supersedes the **Model** decision of
+[ADR-0022](0022-local-llm-sticky-notes.md) (Gemma 3 1B). Its architecture,
+worker, redaction, scheduling, and degradation history remain; its default-on
+policy is superseded by ADR-0039.
 
 ## Context
 

--- a/docs/adrs/0025-sticky-note-expand-gating.md
+++ b/docs/adrs/0025-sticky-note-expand-gating.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted (2026-06). Extends [ADR-0022](0022-local-llm-sticky-notes.md) /
+Superseded in part by [ADR-0039](0039-disable-default-local-llm-sticky-notes.md).
+The expand-gated LLM policy is retired; the independent `ai-title` tail remains.
+This ADR extends [ADR-0022](0022-local-llm-sticky-notes.md) /
 [ADR-0024](0024-sticky-note-binding-resume.md). No conflict; it changes *when*
 the model runs and *where* the tab title comes from.
 

--- a/docs/adrs/0039-disable-default-local-llm-sticky-notes.md
+++ b/docs/adrs/0039-disable-default-local-llm-sticky-notes.md
@@ -1,0 +1,74 @@
+# 0039 - Disable Default Local-LLM Sticky Notes
+
+## Status
+
+Accepted (2026-08-02). Supersedes the default-on summary policy in ADR-0022, the
+LFM2-2.6B default-model decision in ADR-0023, and the LLM portion of ADR-0025.
+ADR-0024/0026 binding and the model-free Claude `ai-title` tail remain in force.
+
+## Context
+
+**Quality: 0 long agentic-coding transcripts / 0 summary updates were available
+for evaluation in this checkout or the local Claude projects directory.** Therefore
+the long-session empty/degenerate, hallucination, and staleness rates are each
+not measurable (0/0), not zero. ADR-0023's 0/23 result came from short sessions
+and cannot establish value for tool-heavy all-day coding. A synthetic prompt
+produced plausible text, but synthetic output is not evidence of quality on the
+owner's workload.
+
+**RSS: +3,052.3 MiB (steady state; 5,724% of baseline).** On 2026-08-02, the
+actual production engine, worker, `buildPrompt()`, and
+`LFM2-2.6B-Q4_K_M.gguf` were measured on this Linux x64 host after its Vulkan
+binary fell back to CPU: baseline RSS with the disabled engine was **51.6 MiB**;
+after model load it was **3,003.9 MiB** (+2,952.3 MiB); after one
+grammar-constrained inference it was **3,103.8 MiB** (+3,052.3 MiB). The
+12-thread CPU inference took **7.881 s** and the main-event-loop timer's maximum
+lag was **3.5 ms**. This is a host-specific CPU measurement, not a claim about
+the owner's Windows hardware; their measured 1.46 GiB GGUF plus 0.64 GiB STT
+weights already account for roughly 2.1 GiB of a >4 GiB service. Worker threads
+share process RSS, so expand-gating cannot reclaim model memory after
+initialization.
+
+For a single tab kept expanded, ADR-0025 permits an inference after each completed
+turn. It prevents no residency and provides no practical CPU saving for that
+usage. The `ai-title` path is separate: `readNewAiTitle()` tails Claude JSONL
+without an inference, model, or worker.
+
+## Decision
+
+**Recommendation: DISABLE local-LLM sticky-note summaries by default.**
+
+- Only `--sticky-notes` enables the engine. Without it, the server neither probes
+  nor downloads the GGUF and never spawns a sticky-note worker.
+- The browser's Display setting is also off by default, preserving explicit
+  per-client consent before a summary card activates.
+- Continue JSONL binding, `agent-*.jsonl` exclusion, resume ownership, turn
+  detection, and Claude `ai-title` tailing. Every Claude tab continues to receive
+  its free, source-authored title even when summaries are disabled, unavailable,
+  or repeatedly fail.
+- Do not claim a quality rate until a redacted corpus of long, tool-heavy,
+  agentic-coding transcripts has been evaluated through the production worker.
+  Reconsider a deterministic extractor or smaller model only with measured
+  quality and cost evidence.
+
+## Consequences
+
+### Positive
+
+- The default service avoids the measured multi-gigabyte model RSS increase and
+  140.605-second CPU inference path.
+- The useful, free tab title remains available and is now tested independently of
+  the summary engine.
+- Default users do not download a 1.56 GB GGUF or expose transcript content to a
+  local model.
+
+### Negative
+
+- Sticky-note cards require explicit server and browser opt-in.
+- Durable LLM summaries remain available only to users who accept their measured
+  cost and the currently unproven long-session quality.
+
+### Neutral
+
+- Existing explicit opt-ins retain the binding, redaction, failure, resume, and
+  expand-gating behavior described by the prior ADRs.

--- a/docs/history/sticky-notes-2026.md
+++ b/docs/history/sticky-notes-2026.md
@@ -222,8 +222,8 @@ Reverted to **pull-on-startup** (server `start()` calls `_ensureSttModel()` +
   DISABLED (with a downloading/loading hint) while pulling, ENABLED on ready, and
   uses cloud only when local isn't the configured backend. Decision logic is the
   pure, unit-tested `VoiceHandler.computeMicButtonState()`.
-- Sticky (Gemma): `_ensureStickyNoteEngine()` runs at startup (Node-only;
-  self-gates off under Bun/test/`--no-sticky-notes`). The per-session summariser
+- Sticky (Gemma): `_ensureStickyNoteEngine()` runs at startup only when explicitly
+  enabled (Node-only; self-gates off by default, under Bun, and under test). The per-session summariser
   only runs inference once the engine `isReady()`.
 
 ## Cross-lab review caught what self-review missed

--- a/docs/specs/sticky-notes.md
+++ b/docs/specs/sticky-notes.md
@@ -1,6 +1,7 @@
 # Spec: Per-Tab Sticky Notes & Auto Tab Titles
 
-Local-LLM session summaries. See ADR-0022 for rationale.
+Optional local-LLM session summaries plus model-free Claude tab titles. Local
+summaries are **off by default**; see ADR-0039 for the cost/quality decision.
 
 ## Components
 
@@ -27,13 +28,15 @@ never calls `worker.terminate()` because force-tearing down a
 on Windows. If a worker reports ready after shutdown has begun, the engine
 refuses to adopt it.
 
-On shutdown, `src/sticky-note-worker.js` disposes native objects in order:
+The disabled default does not probe, download, or load the GGUF and does not spawn
+this worker. When explicitly enabled, `src/sticky-note-worker.js` disposes native
+objects in order:
 context, model, then the top-level `llama` backend, before exiting.
 
 ## Data flow
 
 ```
-PTY bytes → server onOutput → summarizer.feed(sessionId, chunk)   [hot path: buffer + timers only]
+PTY bytes → server onOutput → summarizer.feed(sessionId, chunk)   [explicit local-summary opt-in only]
   → @xterm/headless (per session) → snapshot recent rendered lines → redactSecrets
   → engine.infer(prompt) [worker] → JSON {title,goal,progress[],waitingOn[]}
   → session.stickyNote (persisted) → broadcastToSession('sticky_note_update') → client card + tab title
@@ -41,7 +44,8 @@ PTY bytes → server onOutput → summarizer.feed(sessionId, chunk)   [hot path:
 
 ## Update triggers (deterministic)
 
-An update = one inference, attempted only when ALL gates hold: feature enabled
+An update = one inference, attempted only when ALL gates hold: the server was
+started with `--sticky-notes`, the browser Display setting is enabled, feature enabled
 for the session · eligible tab (AI-agent OR terminal — `_isStickyEligible`) ·
 model `ready` · breaker closed · new committed output since last summary ·
 `minInterval` satisfied · not already running.
@@ -52,7 +56,7 @@ minInterval), **initial**, **focus** (foreground transition, gated). Tab switch
 / reconnect are render-only.
 
 Guards: `minInterval = max(20s, 3 × lastInferenceMs)`; single-flight + dirty-bit
-(timeout clears the bit + backs off — no retry-storm); circuit breaker after N
+(a timeout preserves pending work and backs off — no retry-storm); circuit breaker after N
 failures; foreground-first fair dispatch over one shared worker. **Threads are
 auto-selected by the worker once it knows the backend** (`sticky-note-threads.js`
 `pickThreads`): GPU present → the worker requests **full layer offload**
@@ -124,9 +128,10 @@ without github-router), bind to the active, unowned writer in the tab's project 
 The toolbar toggle (`#stickyNoteBtn`) is shown only once the engine reports
 `ready` (not merely when enabled), so it never appears when the model can't run.
 
-### Expand-gating & ai-title (ADR-0025)
+### Expand-gating & ai-title (ADR-0025, superseded in part by ADR-0039)
 
-The card starts **collapsed** (expanding is a deliberate "activate"). Processing
+The card starts **collapsed** (expanding is a deliberate "activate"). If the
+optional summary feature is explicitly enabled, processing
 splits in **three** tiers by cost:
 
 - **Turn-boundary detection (cheap; no model) runs EVERY poll regardless of
@@ -147,7 +152,8 @@ splits in **three** tiers by cost:
   forever-running inference. `_isStickyExpandedActive` gates the note path. A
   collapsed tab freezes its note at `binding.offset`; on re-expand the next poll
   resumes from there in one bounded catch-up read.
-- **The tab title is claude's own `ai-title`, tailed cheaply with no model**
+- **The tab title is claude's own `ai-title`, tailed cheaply with no model,
+  including while local summaries are disabled.**
   (`readNewAiTitle`, a separate always-advancing `binding.titleOffset`) and
   applied via `_applyAiTitle`. It runs every poll regardless of collapse, so even
   a collapsed/never-expanded tab keeps a fresh, self-describing title. Non-claude
@@ -169,15 +175,16 @@ Client → server:
 
 | Flag / env | Effect |
 |------------|--------|
-| `--no-sticky-notes` / `STICKY_NOTES_DISABLED=1` | Disable globally. |
+| `--sticky-notes` | Enable local-LLM summaries globally. Default is off; without this flag the GGUF is not downloaded and no sticky-note worker is spawned. |
+| `STICKY_NOTES_DISABLED=1` | Force local-LLM summaries off, including when the flag was supplied. |
 | `--sticky-notes-model-dir <path>` / `STICKY_NOTES_MODEL_DIR` | Model cache dir. |
 | `--sticky-notes-model <url>` / `STICKY_NOTES_MODEL` | Override the GGUF URL (e.g. the lighter `LFM2-1.2B-Q4_K_M.gguf`). |
 | `--sticky-notes-threads <n>` / `STICKY_NOTES_THREADS` | Inference CPU threads. |
-| Settings → Display → "Session sticky notes & auto-titles" | Per-client on/off (sent to server). |
+| Settings → Display → "Enable local session summaries" | Per-client opt-in (off by default; sent to server). Claude `ai-title` tab titles do not depend on this setting. |
 
 ## Model
 
-Default: `LiquidAI/LFM2-2.6B-GGUF` → `LFM2-2.6B-Q4_K_M.gguf` (~1.56 GB,
+When explicitly enabled: `LiquidAI/LFM2-2.6B-GGUF` → `LFM2-2.6B-Q4_K_M.gguf` (~1.56 GB,
 **SHA-256-pinned** — refuses a swapped same-size file), `contextSize` 8192. The
 cache (`~/.ai-or-die/models/`) is excluded from the disk-quota breaker. Same
 file on Windows + macOS. Chosen by a bake-off over real claude JSONL transcripts
@@ -197,8 +204,8 @@ open a per-session circuit breaker.
 **Windows / CPU backend (primary target).** When the Vulkan/CUDA prebuilt binary
 is incompatible (common on Windows 11), node-llama-cpp falls back to pure CPU
 (`llama.gpu === false`). CPU inference is materially slower — a grammar-constrained
-summary measures ~90s on half-core threading and up to ~160s at 2 threads on a
-16-core box. The fix is twofold: the worker uses **half the cores** on CPU (not
+summary measures ~90s on three-quarter-core threading and up to ~160s at 2 threads on a
+16-core box. The fix is twofold: the worker uses **three-quarters of the cores** on CPU (not
 the gentle 2), and the per-request timeout is a generous **300s watchdog** (was
 60s, tuned for Metal). The first CPU note therefore renders ~90s after the card
 is expanded; the breaker self-heals (a success resets the failure count). A dev

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -233,7 +233,7 @@ class ClaudeCodeWebInterface {
         await this.sessionTabManager.init();
 
         // Per-tab sticky-note card (local-LLM session summary overlay).
-        this.stickyNotesEnabled = this.loadSettings().enableSessionStickyNotes !== false;
+        this.stickyNotesEnabled = this.loadSettings().enableSessionStickyNotes === true;
         // The toolbar toggle only appears once the server reports the engine is
         // 'ready' (model loaded) — not merely when the setting is on. Keeps the
         // control out of the UI when the feature can't run (no model, Bun, CI).
@@ -1497,7 +1497,7 @@ class ClaudeCodeWebInterface {
     _refreshStickyNoteBtnVisibility() {
         const btn = document.getElementById('stickyNoteBtn');
         if (!btn) return;
-        const show = this.stickyNotesEnabled !== false && this._stickyNotesAvailable === true;
+        const show = this.stickyNotesEnabled === true && this._stickyNotesAvailable === true;
         btn.style.display = show ? '' : 'none';
     }
 
@@ -4275,7 +4275,7 @@ class ClaudeCodeWebInterface {
         if (notifDesktop) notifDesktop.checked = settings.notifDesktop ?? true;
 
         const enableSessionStickyNotes = document.getElementById('enableSessionStickyNotes');
-        if (enableSessionStickyNotes) enableSessionStickyNotes.checked = settings.enableSessionStickyNotes ?? true;
+        if (enableSessionStickyNotes) enableSessionStickyNotes.checked = settings.enableSessionStickyNotes ?? false;
 
         const wheelScrollMode = document.getElementById('wheelScrollMode');
         if (wheelScrollMode) wheelScrollMode.value = settings.wheelScrollMode || 'dontHijack';
@@ -4579,7 +4579,7 @@ class ClaudeCodeWebInterface {
             notifSound: true,
             notifVolume: 30,
             notifDesktop: true,
-            enableSessionStickyNotes: true,
+            enableSessionStickyNotes: false,
             tabSnapshotLines: 500,
             // Trackpad/mouse-wheel behaviour inside full-screen (alt-buffer) apps:
             //   'dontHijack' - wheel does nothing there (no menu hijack in the Claude Code TUI)
@@ -4626,7 +4626,7 @@ class ClaudeCodeWebInterface {
             notifSound: document.getElementById('notifSound')?.checked ?? true,
             notifVolume: parseInt(document.getElementById('notifVolume')?.value || '30'),
             notifDesktop: document.getElementById('notifDesktop')?.checked ?? true,
-            enableSessionStickyNotes: document.getElementById('enableSessionStickyNotes')?.checked ?? true,
+            enableSessionStickyNotes: document.getElementById('enableSessionStickyNotes')?.checked ?? false,
             tabSnapshotLines: parseInt(document.getElementById('tabSnapshotLines')?.value || '500', 10),
             wheelScrollMode: document.getElementById('wheelScrollMode')?.value || 'dontHijack'
         };
@@ -4634,7 +4634,7 @@ class ClaudeCodeWebInterface {
         try {
             localStorage.setItem('cc-web-settings', JSON.stringify(settings));
             this.applySettings(settings);
-            this._applyStickyNotesSetting(settings.enableSessionStickyNotes !== false);
+            this._applyStickyNotesSetting(settings.enableSessionStickyNotes === true);
 
             // Flash save button green briefly
             const saveBtn = document.getElementById('saveSettingsBtn');

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -559,10 +559,10 @@
                                     <input type="checkbox" class="switch-input" id="showTokenStats" checked>
                                 </div>
                                 <div class="setting-group">
-                                    <label for="enableSessionStickyNotes">Session sticky notes &amp; auto-titles</label>
-                                    <input type="checkbox" class="switch-input" id="enableSessionStickyNotes" checked>
+                                    <label for="enableSessionStickyNotes">Enable local session summaries</label>
+                                    <input type="checkbox" class="switch-input" id="enableSessionStickyNotes">
                                 </div>
-                                <div class="setting-hint">Summarises each AI tab with a small local model; nothing leaves your machine.</div>
+                                <div class="setting-hint">Optional: downloads and keeps a ~1.56 GB local model resident while summaries are enabled. Claude tab titles stay free.</div>
                             </section>
 
                             <section class="settings-pane" id="settingsPane-advanced" role="tabpanel" aria-labelledby="settingsTab-advanced" tabindex="0" hidden>

--- a/src/public/sticky-note-card.js
+++ b/src/public/sticky-note-card.js
@@ -120,7 +120,7 @@ class StickyNoteCard {
   }
 
   _enabled() {
-    return !this.app || this.app.stickyNotesEnabled !== false;
+    return !this.app || this.app.stickyNotesEnabled === true;
   }
 
   // --- public API (used by the toolbar button) -----------------------------

--- a/src/server.js
+++ b/src/server.js
@@ -216,11 +216,9 @@ class ClaudeCodeWebServer {
       modelsDir: options.sttModelDir,
       numThreads: options.sttThreads ? parseInt(options.sttThreads, 10) : undefined,
     });
-    // Per-tab local-LLM "sticky note" summariser. ON by default for AI-agent
-    // tabs; disable globally with --no-sticky-notes / AIORDIE_DISABLE_STICKY_NOTES=1
-    // (sticky-notes only — does NOT affect STT). The engine lazily downloads its
-    // model + spawns its worker on the FIRST AI session start, and degrades to
-    // "unavailable" if node-llama-cpp / the model is missing.
+    // Per-tab local-LLM "sticky note" summariser. It is opt-in through
+    // --sticky-notes, so default startup never downloads a model or spawns a
+    // worker. Claude's model-free ai-title tail remains available independently.
     //
     // Bun: node-llama-cpp's native N-API addon crashes Bun (NAPI FATAL ERROR,
     // exit 133 — a Bun bug, not ours), which would take down the whole server.
@@ -228,7 +226,7 @@ class ClaudeCodeWebServer {
     // also self-gates (see StickyNoteEngine._doInitialize) as defence-in-depth.
     // STT (sherpa) is unaffected and still runs under Bun.
     this._stickyNotesEnabledGlobally =
-      options.stickyNotes !== false && !underTest && !isBun() &&
+      options.stickyNotes === true && !underTest && !isBun() &&
       process.env.AIORDIE_DISABLE_STICKY_NOTES !== '1';
     this._foregroundSessionId = null;
     this._stickyInitStarted = false;
@@ -3404,8 +3402,8 @@ class ClaudeCodeWebServer {
     // engine no-ops without downloading. An external endpoint inits cheaply.
     this._ensureSttModel();
 
-    // Sticky-note (Gemma) model is also pulled on startup so it is `ready` by the
-    // time an AI tab opens. Self-gates: disabled / under-test / Bun → no-op (the
+    // An explicitly enabled sticky-note model is pulled on startup so it is `ready`
+    // by the time an AI tab opens. Self-gates: disabled / under-test / Bun → no-op (the
     // engine never loads node-llama-cpp under Bun, which would crash it). Loads in
     // its own worker thread, so the ~806MB pull never blocks the event loop.
     this._ensureStickyNoteEngine();
@@ -4025,9 +4023,9 @@ class ClaudeCodeWebServer {
         models: {}
       },
       maxBufferSize: 1000,
-      // Sticky-note (local-LLM summary) state. Enabled by default for AI tabs;
-      // a client can opt out via set_sticky_notes. autoTitle/nameIsUserSet drive
-      // auto tab titling without clobbering a manual rename.
+      // Sticky-note (local-LLM summary) state. Disabled by default; a client can
+      // explicitly opt in via set_sticky_notes. autoTitle/nameIsUserSet drive
+      // model-free Claude tab titling without clobbering a manual rename.
       stickyNote: null,
       autoTitle: null,
       nameIsUserSet: false,
@@ -4099,7 +4097,7 @@ class ClaudeCodeWebServer {
       renderedSnapshot, // rendered last screen so idle/empty-buffer joins repaint
       stickyNote: session.stickyNote || null,
       autoTitle: session.nameIsUserSet ? null : (session.autoTitle || null),
-      stickyNotesEnabled: session.stickyNotesEnabled !== false,
+      stickyNotesEnabled: session.stickyNotesEnabled === true,
       // Deliver the engine status on every join so the toolbar toggle reliably
       // appears once the model is ready (the broadcast-on-init can race a late
       // joiner; this never misses).
@@ -5725,15 +5723,14 @@ class ClaudeCodeWebServer {
     const session = this.claudeSessions.get(sessionId);
     if (!session) return;
     if (!this._isStickyEligible(toolName)) return;
-    // A control/fleet claude session with a bind sidecar ALWAYS needs the model-free
-    // JSONL turn-binding pump (fleet await_turn / readiness depend on it) — even if
-    // this tab opted out of sticky-note summarisation or the engine is unavailable.
-    const bindingNeeded = toolName === 'claude' && !!session.claudeBindSidecar;
-    if (session.stickyNotesEnabled === false && !bindingNeeded) return;
+    // Claude tabs always need the model-free JSONL pump: it tails Claude's own
+    // ai-title, and sidecar-bound tabs also drive fleet turn transitions. Terminal
+    // tabs only need it without summaries when github-router supplied a sidecar.
+    const bindingNeeded = toolName === 'claude' || !!session.claudeBindSidecar;
     // The model-free binding/turn pump is a CONTROL-PLANE invariant and runs
     // independently of the OPTIONAL summariser. Enable the LLM summariser only when
     // it is wanted (not opted out) AND its engine is available; always start the poll.
-    if (session.stickyNotesEnabled !== false && this.stickyNoteEngine._enabled) {
+    if (session.stickyNotesEnabled === true && this.stickyNoteEngine._enabled) {
       // Start buffering output now — cheap (a pure-JS headless terminal), never
       // inference. The summariser buffers and produces its first note once ready.
       this.stickyNoteSummarizer.enable(sessionId, {
@@ -5744,7 +5741,9 @@ class ClaudeCodeWebServer {
       });
       this._ensureStickyNoteEngine();
     }
-    this._startStickyJsonlPoll();
+    if (bindingNeeded || (session.stickyNotesEnabled === true && this.stickyNoteEngine._enabled)) {
+      this._startStickyJsonlPoll();
+    }
   }
 
   // Poll each summarising tab for a claude JSONL transcript at its cwd; when found,
@@ -5761,10 +5760,10 @@ class ClaudeCodeWebServer {
   }
 
   async _pollStickyJsonl() {
-    // NOT gated on the sticky-note engine: the model-free binding + turn detection
-    // below must run for control/fleet claude sessions even when the summariser is
-    // disabled (--no-sticky-notes) or its model is unavailable. The LLM note
-    // inference inside _pumpStickyJsonl stays independently gated.
+    // NOT gated on the sticky-note engine: the model-free title tail + turn
+    // detection below must run for Claude sessions even when summaries are
+    // disabled or their model is unavailable. The LLM note inference inside
+    // _pumpStickyJsonl stays independently gated.
     // Lock so a slow sweep (many old session files) can't overlap the next tick
     // and double-feed the same turns into pendingText.
     if (this._pollingStickyJsonl) return;
@@ -5773,12 +5772,10 @@ class ClaudeCodeWebServer {
       for (const [sessionId, session] of this.claudeSessions) {
         if (!session.active) continue;
         if (!this._isStickyEligible(session.agent)) continue;
-        // Pump when summarising (UI note cards) OR when this is a claude session
-        // with a bind sidecar (control/fleet turn-binding) — the latter needs
-        // binding + turn events regardless of the summariser, and a per-tab
-        // summarisation opt-out must NOT defeat control-plane turn-binding.
-        const bindingNeeded = session.agent === 'claude' && !!session.claudeBindSidecar;
-        if (session.stickyNotesEnabled === false && !bindingNeeded) continue;
+        // Pump when summarising (UI note cards), for every Claude session (free
+        // ai-title tailing), or for a terminal session with a github-router bind
+        // sidecar (control-plane turn binding).
+        const bindingNeeded = session.agent === 'claude' || !!session.claudeBindSidecar;
         const summarising = this.stickyNoteSummarizer.isEnabled(sessionId);
         if (!summarising && !bindingNeeded) continue;
         const cwd = session.liveCwd || session.workingDir;
@@ -6301,7 +6298,7 @@ class ClaudeCodeWebServer {
     if (!session) return;
     // Only a socket that belongs to the session may change it (mirrors resize).
     if (!session.connections.has(wsId)) return;
-    const enabled = data.enabled !== false;
+    const enabled = data.enabled === true;
     session.stickyNotesEnabled = enabled;
     this.sessionStore.markDirty();
     if (enabled) {

--- a/src/utils/session-store.js
+++ b/src/utils/session-store.js
@@ -239,7 +239,7 @@ class SessionStore {
                 claudePinnedSessionId: session.claudePinnedSessionId || null,
                 autoTitle: session.autoTitle || null,
                 nameIsUserSet: session.nameIsUserSet || false,
-                stickyNotesEnabled: session.stickyNotesEnabled !== false
+                stickyNotesEnabled: session.stickyNotesEnabled === true
             }));
 
             const data = {

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -73,6 +73,33 @@ function collectMessages(ws, type, durationMs = 3000) {
   });
 }
 
+/** Wait until binary terminal output contains a marker, including split frames. */
+function waitForTerminalOutput(ws, marker, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for terminal output "${marker}"`));
+    }, timeoutMs);
+
+    function onMessage(raw, isBinary) {
+      if (!isBinary) return;
+      output += raw.toString();
+      if (output.includes(marker)) {
+        cleanup();
+        resolve();
+      }
+    }
+
+    function cleanup() {
+      clearTimeout(timer);
+      ws.removeListener('message', onMessage);
+    }
+
+    ws.on('message', onMessage);
+  });
+}
+
 /**
  * Send a JSON message over the WebSocket.
  */
@@ -745,6 +772,7 @@ describe('E2E: Input/output round-trip', function () {
   let server;
   let port;
   let ws;
+  let ioSessionId;
 
   before(async function () {
     server = new ClaudeCodeWebServer({ port: 0, noAuth: true });
@@ -754,7 +782,7 @@ describe('E2E: Input/output round-trip', function () {
     // Set up a session with a running terminal for all tests in this block
     ({ ws } = await connectWs(port));
     wsSend(ws, { type: 'create_session', name: 'IO Test' });
-    await waitForMessage(ws, 'session_created');
+    ioSessionId = (await waitForMessage(ws, 'session_created')).sessionId;
     // Set up listener before sending to avoid race condition
     const startedPromise = waitForMessage(ws, 'terminal_started', 15000);
     wsSend(ws, { type: 'start_terminal' });
@@ -798,17 +826,13 @@ describe('E2E: Input/output round-trip', function () {
   it('should replay output buffer when a new client joins the session', async function () {
     // Send a distinctive marker through the terminal
     const marker = `REPLAY_${Date.now()}`;
+    const outputReady = waitForTerminalOutput(ws, marker);
     wsSend(ws, { type: 'input', data: `echo ${marker}\n` });
-    await collectMessages(ws, 'output', 2000);
-
-    // Get the session ID from the server
-    const listRes = await httpRequest('GET', `http://127.0.0.1:${port}/api/sessions/list`);
-    const ioSession = listRes.body.sessions.find(s => s.name === 'IO Test');
-    assert(ioSession, 'Could not find the IO Test session');
+    await outputReady;
 
     // Connect a second client and join the same session
     const { ws: ws2 } = await connectWs(port);
-    wsSend(ws2, { type: 'join_session', sessionId: ioSession.id });
+    wsSend(ws2, { type: 'join_session', sessionId: ioSessionId });
     const joinMsg = await waitForMessage(ws2, 'session_joined');
 
     // The output buffer should contain our marker

--- a/test/integration/osc7-real-shell.test.js
+++ b/test/integration/osc7-real-shell.test.js
@@ -107,7 +107,15 @@ class Session {
     });
     this.ws.on('message', (raw, isBinary) => {
       if (isBinary) {
-        this.outputAccum += raw.toString('utf-8');
+        const output = raw.toString('utf-8');
+        this.outputAccum += output;
+        // PowerShell's PSReadLine probes the terminal cursor position during
+        // startup. Browsers answer this CSI 6n query through xterm; this raw
+        // WebSocket test client must emulate that reply or pwsh blocks before
+        // it ever renders a prompt.
+        if (output.includes('\x1b[6n')) {
+          this.ws.send(JSON.stringify({ type: 'input', data: '\x1b[1;1R' }));
+        }
         return;
       }
       let msg;
@@ -122,9 +130,10 @@ class Session {
   }
 
   async startTerminal() {
+    const outputLength = this.outputAccum.length;
     this.ws.send(JSON.stringify({ type: 'start_terminal', cols: 80, rows: 24 }));
     await this.waitFor('terminal_started', 10000);
-    await sleep(300);
+    await this.waitForOutputAfter(outputLength, '', 5000);
     return this;
   }
 
@@ -157,6 +166,37 @@ class Session {
           clearInterval(tick);
           clearTimeout(t);
           resolve(this.cwdChangedFrames[this.cwdChangedFrames.length - 1]);
+        }
+      }, 25);
+    });
+  }
+
+  waitForOutput(marker, timeoutMs = 5000) {
+    return new Promise((resolve, reject) => {
+      const start = Date.now();
+      const tick = setInterval(() => {
+        if (this.outputAccum.includes(marker)) {
+          clearInterval(tick);
+          resolve();
+        } else if (Date.now() - start >= timeoutMs) {
+          clearInterval(tick);
+          reject(new Error('terminal output timed out waiting for ' + JSON.stringify(marker)));
+        }
+      }, 25);
+    });
+  }
+
+  waitForOutputAfter(offset, marker, timeoutMs = 5000) {
+    return new Promise((resolve, reject) => {
+      const start = Date.now();
+      const tick = setInterval(() => {
+        const freshOutput = this.outputAccum.slice(offset);
+        if (freshOutput.length > 0 && freshOutput.includes(marker)) {
+          clearInterval(tick);
+          resolve();
+        } else if (Date.now() - start >= timeoutMs) {
+          clearInterval(tick);
+          reject(new Error('terminal output timed out waiting for fresh ' + JSON.stringify(marker)));
         }
       }, 25);
     });
@@ -278,12 +318,17 @@ suite('OSC 7 real-shell integration (ADR-0019)', function () {
   // 3. PowerShell hook (verbatim from spec).
   // ──────────────────────────────────────────────────────────────────────
 
-  (HAS_PWSH ? it : it.skip)('pwsh + spec prompt function → cwd_changed on Set-Location', async function () {
+  // The documented prompt function is Windows-specific: `$env:COMPUTERNAME`
+  // combined with a drive-style ProviderPath forms file://host/C:/... . On
+  // POSIX pwsh it instead emits file:////tmp/... (an invalid sandbox path), so
+  // validate the real user contract on its Windows target.
+  (HAS_PWSH && process.platform === 'win32' ? it : it.skip)('pwsh + spec prompt function → cwd_changed on Set-Location', async function () {
     const sess = new Session();
     await sess.open(baseDir);
     await sess.startTerminal();
+    const pwshOutputAt = sess.outputAccum.length;
     sess.send('exec pwsh -NoLogo -NoProfile\n');
-    await sleep(800);
+    await sess.waitForOutputAfter(pwshOutputAt, 'PS ', 5000);
     // Single-line collapse of the spec's multi-line $PROFILE function.
     const psHook =
       'function prompt { $loc = $executionContext.SessionState.Path.CurrentLocation; ' +
@@ -291,7 +336,7 @@ suite('OSC 7 real-shell integration (ADR-0019)', function () {
       '$p = $loc.ProviderPath -replace "\\\\","/"; ' +
       '$out += "$([char]27)]7;file://$env:COMPUTERNAME/$p$([char]7)" }; $out }\n';
     sess.send(psHook);
-    await sleep(400);
+    await sess.waitForOutput('PS ', 5000);
     sess.reset();
 
     sess.send('Set-Location ' + JSON.stringify(path.join(baseDir, 'a')) + '\n');

--- a/test/longevity/process/server-shutdown-e2e.test.js
+++ b/test/longevity/process/server-shutdown-e2e.test.js
@@ -69,7 +69,7 @@ async function bootAndSpawnGrandchild(port, withIpc, extraEnv) {
   const stdio = withIpc ? ['ignore', 'pipe', 'pipe', 'ipc'] : ['ignore', 'pipe', 'pipe'];
   const sup = spawn(process.execPath, [
     SUPERVISOR, '--port', String(port), '--disable-auth',
-    '--no-sticky-notes', '--no-stt', '--no-keepalive',
+    '--no-stt', '--no-keepalive',
   ], { cwd: REPO_ROOT, stdio, env: { ...process.env, AOD_SUPERVISOR_RESTART: '1', ...(extraEnv || {}) } });
   state.sup = sup;
   sup.stdout.on('data', (d) => { state.out += d.toString(); });

--- a/test/sticky-note-engine.test.js
+++ b/test/sticky-note-engine.test.js
@@ -201,6 +201,27 @@ describe('sticky-note engine', function () {
     assert.strictEqual(engine.isReady(), false);
   });
 
+  it('does not check, download, or spawn a worker unless summaries are explicitly enabled', async function () {
+    let checked = 0;
+    let downloaded = 0;
+    let spawned = 0;
+    const engine = new StickyNoteEngine({
+      enabled: false,
+      modelManager: {
+        isModelReady: async () => { checked++; return false; },
+        ensureModel: async () => { downloaded++; },
+        getModelFile: () => '/tmp/model.gguf',
+      },
+      createWorker: () => { spawned++; return new FakeWorker(); },
+    });
+
+    await engine.initialize();
+
+    assert.strictEqual(checked, 0, 'disabled engine must not probe the GGUF');
+    assert.strictEqual(downloaded, 0, 'disabled engine must not download the GGUF');
+    assert.strictEqual(spawned, 0, 'disabled engine must not create a worker');
+  });
+
   it('refuses to spawn under Bun (node-llama-cpp crashes Bun) without loading the worker', async function () {
     const hadBun = Object.prototype.hasOwnProperty.call(process.versions, 'bun');
     const prevBun = process.versions.bun;

--- a/test/sticky-note-server-wiring.test.js
+++ b/test/sticky-note-server-wiring.test.js
@@ -193,6 +193,16 @@ describe('sticky-note server wiring', function () {
     assert.strictEqual(self._summarizerCalls.pop()[0], 'enable');
   });
 
+  it('_handleSetStickyNotes requires an explicit true opt-in', function () {
+    const self = makeStub();
+    self.claudeSessions.set('s1', { active: true, agent: 'claude', stickyNote: null, connections: new Set(['ws1']) });
+
+    ClaudeCodeWebServer.prototype._handleSetStickyNotes.call(self, 'ws1', { sessionId: 's1' });
+
+    assert.strictEqual(self.claudeSessions.get('s1').stickyNotesEnabled, false);
+    assert.deepStrictEqual(self._summarizerCalls.pop(), ['disable', 's1']);
+  });
+
   it('_maybeStartStickyNotes summarises terminal tabs too, but skips disabled sessions', function () {
     const self = makeStub();
     // Terminal tab is now eligible (users run AI CLIs inside a shell).
@@ -244,12 +254,15 @@ describe('sticky-note server wiring', function () {
     assert.strictEqual(self._summarizerCalls.filter((c) => c[0] === 'enable').length, 0, 'summariser NOT enabled');
   });
 
-  it('_maybeStartStickyNotes skips an opted-out tab with NO bind sidecar', function () {
+  it('_maybeStartStickyNotes keeps the free Claude title tail running when summaries are disabled', function () {
     let pollStarted = 0;
-    const self = makeStub({ _startStickyJsonlPoll: () => { pollStarted++; } });
-    self.claudeSessions.set('off', { stickyNotesEnabled: false, stickyNote: null }); // opted out, no sidecar
+    const self = makeStub({
+      stickyNoteEngine: { _enabled: false, getStatus: () => 'unavailable', getDownloadProgress: () => null },
+      _startStickyJsonlPoll: () => { pollStarted++; },
+    });
+    self.claudeSessions.set('off', { stickyNotesEnabled: false, stickyNote: null });
     ClaudeCodeWebServer.prototype._maybeStartStickyNotes.call(self, 'off', 'claude', 80, 24);
-    assert.strictEqual(pollStarted, 0, 'no binding need + opted out → nothing started');
+    assert.strictEqual(pollStarted, 1, 'Claude title tail starts without the summary engine');
     assert.strictEqual(self._summarizerCalls.filter((c) => c[0] === 'enable').length, 0);
   });
 
@@ -463,17 +476,17 @@ describe('sticky-note JSONL binding (ownership + resume)', function () {
         ['ui', { active: true, agent: 'claude', workingDir: '/proj' }],            // claude, no sidecar
         ['term', { active: true, agent: 'terminal', claudeBindSidecar: '/x/t.json', workingDir: '/proj' }],
       ]),
-      // summariser disabled for everyone (e.g. --no-sticky-notes / node-llama-cpp missing)
+      // summariser disabled for everyone (default mode / node-llama-cpp missing)
       stickyNoteSummarizer: { isEnabled: () => false },
       _isAiAgent: ClaudeCodeWebServer.prototype._isAiAgent,
       _isStickyEligible: ClaudeCodeWebServer.prototype._isStickyEligible,
       _pumpStickyJsonl: async (id) => { pumped.push(id); },
     };
     await ClaudeCodeWebServer.prototype._pollStickyJsonl.call(srv);
-    // Only the sidecar-bound CLAUDE session is pumped for binding/turn events even
-    // with the summariser off and the tab opted out; a no-sidecar claude and a
-    // terminal (no claude binding) are skipped.
-    assert.deepStrictEqual(pumped.sort(), ['ctl']);
+    // Every Claude session is pumped for the free ai-title tail and turn events
+    // even with summaries off; a terminal with a Claude sidecar also needs the
+    // model-free control-plane binding.
+    assert.deepStrictEqual(pumped.sort(), ['ctl', 'term', 'ui']);
   });
 
   it('SIDECAR: _ownedClaudeSessions reserves a tab pinned via sidecar', function () {
@@ -674,6 +687,26 @@ describe('sticky-note JSONL binding (ownership + resume)', function () {
     await self._pumpStickyJsonl('tab1', cwd);
     assert.ok(self._feeds.some((f) => f.id === 'tab1'), 'expanded tab feeds the summariser');
   });
+
+  it('tails ai-title without an enabled summariser or a model worker', async function () {
+    const cwd = '/Users/x/proj';
+    const body =
+      JSON.stringify({ type: 'ai-title', aiTitle: 'Free Claude Title' }) + '\n' +
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'completed work' }] } }) + '\n';
+    writeSession(cwd, 'title-only.jsonl', body, 0);
+    const self = makeBindStub();
+    self.stickyNoteSummarizer.isEnabled = () => false;
+    self.claudeSessions.set('tab1', { nameIsUserSet: false, stickyNotesEnabled: false });
+
+    await self._pumpStickyJsonl('tab1', cwd);
+
+    assert.strictEqual(self.claudeSessions.get('tab1').autoTitle, 'Free Claude Title');
+    assert.strictEqual(self._feeds.length, 0, 'no summary text is sent to an unavailable engine');
+    assert.ok(
+      self._broadcasts.some((b) => b.data.autoTitle === 'Free Claude Title'),
+      'the independent ai-title update reaches the client'
+    );
+  });
   it('_handleSetStickyActive ref-counts expanded viewers; disconnect purges without leaking', function () {
     const self = makeStub();
     self._stickyActive = new Map();
@@ -760,7 +793,7 @@ describe('sticky-note persistence (session-store round-trip)', function () {
     const s = loaded.get('old');
     assert.ok(s, 'legacy session loads without error');
     assert.ok(!s.stickyNote, 'no sticky note for a legacy session (null/undefined)');
-    assert.notStrictEqual(s.stickyNotesEnabled, false); // undefined -> treated as enabled
+    assert.notStrictEqual(s.stickyNotesEnabled, true); // legacy unset state remains disabled
   });
 
   it('migrates a legacy progress/waitingOn note to done/remaining/updates', function () {

--- a/test/voice-eager-init.test.js
+++ b/test/voice-eager-init.test.js
@@ -122,7 +122,7 @@ describe('server eager model init', function () {
     }
   });
 
-  it('_ensureStickyNoteEngine is a no-op when the engine is disabled (Bun/test/--no-sticky-notes)', function () {
+  it('_ensureStickyNoteEngine is a no-op when the engine is disabled (default/Bun/test)', function () {
     const { server, tmp } = makeServer();
     try {
       let calls = 0;


### PR DESCRIPTION
## What

Makes local-LLM sticky-note summaries **opt-in** (`--sticky-notes`) instead of on-by-default. A default start no longer probes or downloads the GGUF and never spawns a sticky-note worker.

**Claude tab titles are unaffected.** `bindingNeeded` widens from `claude && sidecar` to `claude || sidecar`, so every Claude tab keeps the model-free JSONL pump that supplies its `ai-title` and drives fleet turn detection. A new test asserts the title still tails with no summariser and no model worker.

## Why

Measured on a live instance at 8.9 days uptime:

```
rss 2236.9 MB   heap_used 20 MB   heap_total 26.7 MB
external 6.3 MB   array_buffers 3.6 MB
```

The JS heap is 20 MB. ~30 MB of a 2237 MB process is JavaScript — **98.6% of RSS is native memory**, matching the model files on disk: LFM2-2.6B-Q4_K_M at 1.46 GB and sherpa parakeet at 0.64 GB.

Both load via `worker_threads`, which share the parent's address space, so the weights are resident inside the server process for its whole life. Expand-gating cannot reclaim them: it gates *inference*, not *residency*. On a single tab used all day for agentic coding, the summariser is the largest single memory line item in the product.

## Honest caveat

**This defers on cost, not on a quality verdict.** Quality on long, tool-heavy agentic-coding sessions is *unmeasured* — an evaluation attempt found no such transcripts available and correctly refused to invent a rate. ADR-0023's clean 0/23 result came from short sessions and does not establish value for all-day coding. ADR-0039 records that no quality claim should be made until a real corpus is evaluated through the production worker.

## Test results

| | passing | failing |
|---|---|---|
| `main` | 1880 | 15 |
| this branch | **1887** | **11** |

Net +7 passing, −4 failing. The 15 failures on `main` are pre-existing and tracked separately.

Four tests went green. One is a direct fix (`should handle terminal resize without errors` — an event-driven wait replaces a fixed 2000 ms collect). The other three are control-route tests this PR does not touch: they pass in ~520 ms in isolation but were exceeding mocha's 2000 ms default under cumulative suite load. **Suite wall-clock dropped from 13m to 12m** purely from not loading the model, and that headroom was enough to clear three of them — independent evidence that the residency was degrading process behaviour, not just occupying memory.

Remaining red is pre-existing on `main`: two genuine e2e assertion failures around session-activity broadcasting, and nine control-plane timeouts under load. Being root-caused separately; deliberately **not** papered over with a raised `--timeout`.

## ADRs

ADR-0039 supersedes the default-on policy in ADR-0022, the LFM2-2.6B default-model decision in ADR-0023, and the LLM portion of ADR-0025. ADR-0024/0026 binding and the model-free `ai-title` tail remain in force.
