### PR TITLE
Contain the Windows ConPTY worker crash, and record that the backend swap is not the fix

### DIFF
--- a/docs/history/windows-8dot3-filewatcher-canonicalization-2026.md
+++ b/docs/history/windows-8dot3-filewatcher-canonicalization-2026.md
@@ -1,0 +1,90 @@
+# Windows 8.3 short names silently voided the HOT-02 watcher test (2026)
+
+## Symptom
+
+`Longevity Smoke (PR-blocking)` → `smoke (windows-latest)` failed at the
+"Longevity regression tests" step, before the soak ever ran:
+
+```
+1) HOT-02: FileWatcher sync MD5 on hot path (event-loop block under bulk edits)
+   AssertionError [ERR_ASSERTION]: expected >= 20 flush events; got 0
+     — debounce window misconfigured?
+```
+
+Ubuntu and macOS passed. The failure is Windows-only and reproduces on the
+unrelated `fix/ci-signal-integrity` branch (run 30882481148), so it predates the
+client-shell work, which touches neither `test/longevity/` nor
+`src/utils/file-watcher.js`.
+
+## Root cause
+
+The assertion that fired is the test's own **sanity** check, not its
+load-bearing one. Zero flush events means every synthetic change event was
+dropped before reaching `_flush()`.
+
+Two canonicalization paths disagree on Windows:
+
+- `FileWatcher._canonicalize()` (`src/utils/file-watcher.js:386`) resolves
+  through `_realpathStrict()` (`:80`), which uses **`fs.realpathSync.native`**
+  and strips a `\\?\` prefix. `.native` **expands 8.3 short names**.
+- `FileWatcher.hasSubscription()` (`:549`) only calls **`path.resolve`**. It does
+  no realpath and therefore no 8.3 expansion.
+
+The test seeded its subscription set with `w._canonicalize(p)` but built its
+paths from `fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), ...)))`. Plain
+`fs.realpathSync` does not expand 8.3 names, and GitHub's Windows runners report
+`os.tmpdir()` as `C:\Users\RUNNER~1\AppData\Local\Temp`. So:
+
+- stored key: `C:\Users\runneradmin\...\f0.bin`  (expanded by `.native`)
+- lookup key: `C:\Users\RUNNER~1\...\f0.bin`     (unexpanded by `path.resolve`)
+
+No match → `_onChokidar` returned at the `hasSubscription` guard (`:587`) → no
+debounce, no flush, zero events.
+
+This is exactly the trap `CLAUDE.md` calls out: canonicalize via
+`realpathSync.native` (handles 8.3 expansion) and strip `\\?\` **on both sides**
+before any lexical compare.
+
+## Fix
+
+`test/longevity/event-loop/hot-02-filewatcher-hash.test.js` now canonicalizes
+`tmpRoot` with a local `realpathNative()` that mirrors the product's
+`_realpathStrict` — `fs.realpathSync.native` plus the `\\?\` strip, falling back
+to `fs.realpathSync`. The subscription key and the lookup key now agree on every
+platform.
+
+This **strengthens** the test rather than relaxing it. Previously, both
+assertions in the file were vacuous on Windows: with zero events, no
+`fs.readFileSync` could be counted and no event-loop lag could accumulate, so the
+second test passed for the wrong reason. Only the sanity assertion, doing its
+job, kept that from being a silent false green.
+
+A third case was added ahead of the two burst tests. It asserts directly that a
+key produced by `_canonicalize()` is reachable via `hasSubscription()`, so a
+future regression of this class fails with a precise message instead of
+resurfacing as "got 0".
+
+## Latent product issue — recorded, deliberately NOT fixed here
+
+The same `_canonicalize` / `hasSubscription` asymmetry exists in the product. A
+path subscribed in short-name form is stored expanded, while events arriving in
+short-name form are looked up unexpanded, so watching a short-name path on
+Windows would silently observe nothing. It did not surface as a product failure
+because chokidar derives event paths from the watch root the application already
+canonicalized.
+
+It is not fixed here on purpose. The obvious repair — canonicalizing inside
+`hasSubscription()` — puts a `realpathSync.native` syscall on the per-event hot
+path, which is precisely the hot path HOT-02 exists to keep unblocked, and the
+file watcher sits on the do-not-break list. A correct fix caches the
+canonicalization or normalizes the watch root once, and belongs in its own change
+with Windows verification. Windows is the primary target, so this should not be
+left indefinitely.
+
+## Honest limitation
+
+Verified on Linux only: the three tests pass, and the full
+`npm run test:longevity:server` suite goes from 119 to 120 passing with no other
+change. The Windows path could not be executed — this work was done in a Linux
+container with no Windows runner — so the 8.3 mechanism is established from the
+runner logs and the two source paths above, not from a local reproduction.

--- a/docs/history/windows-conpty-worker-crash-2026.md
+++ b/docs/history/windows-conpty-worker-crash-2026.md
@@ -108,10 +108,28 @@ Escalation paths, in order of preference:
    child process instead of the worker, and it closes the whole class rather than
    this instance. It rewrites the harness shared by most specs across every
    browser job, so it needs its own change and a Windows verification run.
-2. **Bypass the crashing branch.** Passing `useConptyDll: true` when spawning on
-   Windows takes the other branch of `kill()` and never forks the agent. This
-   switches the ConPTY backend on the primary production target and touches PTY
-   streaming, so it requires an ADR and Windows verification — not a ride-along.
+2. **Bypass the crashing branch.** ~~Passing `useConptyDll: true` when spawning
+   on Windows takes the other branch of `kill()` and never forks the agent.~~
+   **TRIED AND DISPROVEN — do not attempt again without new information.**
+
+   This was implemented and pushed (`604b93a`) and had to be reverted
+   (`06752ae`). The mechanism works exactly as predicted here: the agent is never
+   forked and the `AttachConsole failed` flood goes from dozens of lines per run
+   to **zero**, with `02-terminal-io` still passing 3/3 locally.
+
+   But it breaks Windows broadly. CI on `604b93a` failed **every** Windows job:
+   `test (windows-latest)` at 1988 passing / 4 failing (3 of those are
+   pre-existing) plus all five Windows browser buckets, including a clipboard
+   test that had been passing. The three runs before it were 31/31 green and the
+   PTY backend was the only difference; reverting restored 31/31 green on
+   attempt 1, confirming attribution. Why the DLL backend breaks Windows here was
+   not investigated.
+
+   This closes the gap in the "Honest limitation" below for this path
+   specifically: it has now been exercised on a real Windows machine and on the
+   Windows runners. Escalation path 1 (boot the server out-of-process) remains
+   unexercised and is now the preferred route — it also closes the whole class
+   rather than this instance.
 3. **Report upstream** the un-awaited `fork()` in `kill()` and the unguarded
    `getConsoleProcessList` call in the agent.
 

--- a/docs/history/windows-conpty-worker-crash-2026.md
+++ b/docs/history/windows-conpty-worker-crash-2026.md
@@ -1,0 +1,122 @@
+# Windows ConPTY teardown crashes the Playwright worker (2026)
+
+Status: contained, not fixed. The defect lives in `node_modules`.
+
+## Symptom
+
+A single Windows browser job goes red while every sibling job passes. The
+reported failure is not an assertion — it is the test runner losing its worker:
+
+```
+[functional-extended] > e2e\tests\06-large-paste.spec.js:60:3 >
+  paste via Ctrl+V with clipboard API works for moderate text
+  Error: worker process exited unexpectedly (code=3221225477, signal=null)
+28 passed (1.4m)
+```
+
+`3221225477` is `0xC0000005`, a Windows access violation. The job log is flooded
+beforehand with repeated uncaught crashes of a node-pty helper process:
+
+```
+node_modules\@lydell\node-pty-win32-x64\lib\conpty_console_list_agent.js:13
+var consoleProcessList = getConsoleProcessList(shellPid);
+Error: AttachConsole failed
+```
+
+The failing test title moves between runs and suites. It has been observed in
+`test-browser-functional-extended`, and the earlier triage note recorded the same
+`AttachConsole failed` crash in `test-browser-sticky-notes`. Any suite that boots
+a real server with PTYs can reach it.
+
+## Root cause
+
+Traced by reading the installed `@lydell/node-pty` 1.2.0-beta.10 sources.
+
+1. `e2e/helpers/server-factory.js` `createServer()` instantiates
+   `ClaudeCodeWebServer` **in-process**. The Playwright worker therefore hosts
+   node-pty itself, so a native crash in PTY teardown kills the worker rather
+   than an isolated child. (`spawnCli()`, next to it, is the out-of-process
+   pattern.)
+2. `lib/windowsPtyAgent.js:102-129` — `WindowsPtyAgent.prototype.kill()`. When
+   `_useConptyDll` is false (the default) it calls `_getConsoleProcessList()` and
+   then, **without awaiting the returned promise**, immediately runs
+   `_ptyNative.kill(this._pty, this._useConptyDll)` and disposes the conout
+   socket worker.
+3. `lib/windowsPtyAgent.js:130-144` — `_getConsoleProcessList()` `fork()`s
+   `conpty_console_list_agent`. By the time that child runs, step 2 has already
+   killed the pty, so `AttachConsole(shellPid)` fails. The agent has no error
+   handling (`lib/conpty_console_list_agent.js:13`), throws uncaught, and dies.
+   That is the log flood.
+4. Because the agent never `process.send`s, the promise only settles via the 5s
+   timeout, which resolves with the stale shell pid. The `.then()` then calls
+   `process.kill()` on a pid Windows may already have recycled.
+5. The access violation arises from this unsynchronised teardown — native kill
+   and conout-worker disposal racing the forked agent — inside third-party code.
+
+Our own teardown is not implicated. `BaseBridge.stopSession()`
+(`src/base-bridge.js:700-787`) already disposes PTY listeners before killing,
+closes the per-PTY kill-on-close Job Object, and bounds the wait;
+`src/utils/process-tree.js` is `taskkill`-only with no FFI.
+
+## Evidence that it predates the change it blocked
+
+- The client-redesign branch touches neither `e2e/tests/06-large-paste.spec.js`
+  nor the `functional-extended` project definition nor any server/PTY code.
+- The same job flakes on the unrelated `fix/ci-signal-integrity` branch, where
+  Windows browser jobs fail intermittently with shifting job names run to run.
+- `docs/history/ci-flakiness-triage-2026.md` already recorded this crash as a
+  known node-pty/Windows issue living in `node_modules`.
+
+## Containment
+
+`e2e/playwright.config.js` now uses:
+
+```js
+retries: process.env.CI && process.platform === 'win32' ? 1 : 0,
+```
+
+Why this boundary and not another:
+
+- **Not per-project.** Scoping to whichever suite is red today would be shaped by
+  the symptom, not the cause, and would simply relocate the red.
+- **Not global.** The crashing agent ships only in the `win32` binary package.
+  POSIX cannot execute that code path, so retrying ~30 Ubuntu jobs would absorb
+  genuine flakes that have no such excuse.
+- **Not local.** Developers keep `retries: 0` and see flakes raw.
+- **One retry, not two or three.** A deterministic failure still fails both
+  attempts, so this cannot turn a real Windows regression green. Playwright's
+  GitHub reporter marks a retried-then-passed test `flaky`, distinct from
+  `passed`, so the signal stays visible.
+
+Note that `docs/history/ci-flakiness-triage-2026.md` advised "reduce that suite's
+Playwright retries". That advice was written while retries were non-zero, when
+the crash cost wall-clock time by triggering retries near the 20-minute cap.
+Retries were later set to 0 globally, which inverted the trade-off: the crash now
+costs correctness instead of time. The older note is stale on this point.
+
+## Exit criteria
+
+This containment must be escalated, not extended, if either holds:
+
+- any Windows job fails on **both** attempts with this signature; or
+- the `flaky` outcome becomes routine rather than occasional.
+
+Escalation paths, in order of preference:
+
+1. **Fix the harness.** Make `createServer()` boot the server out-of-process the
+   way `spawnCli()` already does. This contains any third-party native crash to a
+   child process instead of the worker, and it closes the whole class rather than
+   this instance. It rewrites the harness shared by most specs across every
+   browser job, so it needs its own change and a Windows verification run.
+2. **Bypass the crashing branch.** Passing `useConptyDll: true` when spawning on
+   Windows takes the other branch of `kill()` and never forks the agent. This
+   switches the ConPTY backend on the primary production target and touches PTY
+   streaming, so it requires an ADR and Windows verification — not a ride-along.
+3. **Report upstream** the un-awaited `fork()` in `kill()` and the unguarded
+   `getConsoleProcessList` call in the agent.
+
+## Honest limitation
+
+This diagnosis is from source reading and CI logs. It was not reproduced on a
+Windows machine — the work was done in a Linux container with no Windows runner
+available, so no Windows-specific behaviour here was observed locally.

--- a/docs/specs/e2e-testing.md
+++ b/docs/specs/e2e-testing.md
@@ -131,8 +131,16 @@ For the initial test suite, browser-level tests are **deferred**. The server E2E
 - **Mock the tools, not the infrastructure** -- Use bash/echo as the "tool" instead of Claude/Copilot
 - **Cross-platform** -- Tests must pass on Linux and Windows CI; use `TerminalBridge` (shell) as the universal tool
 - **Deterministic** -- Avoid timing-dependent assertions; use event-driven waits with timeouts
-- **Retry-free browser gate** -- Playwright retries are disabled in CI; failures
-  retain traces, screenshots, and video rather than being hidden by a green retry.
+- **Retry-free browser gate** -- Playwright retries are disabled in CI on POSIX;
+  failures retain traces, screenshots, and video rather than being hidden by a
+  green retry. Windows CI is the single exception, at exactly one retry, because
+  `@lydell/node-pty-win32-x64` can take the whole Playwright worker down with an
+  access violation (`code=3221225477`) during ConPTY teardown -- a third-party
+  native crash, reachable only from the win32 binary package, in a harness that
+  hosts the server in-process. One retry cannot rescue a deterministic failure,
+  and a retried-then-passed test is reported as `flaky` rather than `passed`, so
+  the signal survives. Diagnosis and the exit criteria that force escalation:
+  `docs/history/windows-conpty-worker-crash-2026.md`.
 - **Isolated** -- Each test suite starts its own server on an ephemeral port
 - **Checkout-path independent** -- Playwright regular-expression `testMatch` entries are anchored to the test basename/path suffix so digits in a parent checkout directory cannot reassign specs between projects.
 - **No hidden integration red** -- `npm run test:integration` runs in the Ubuntu and Windows CI matrix alongside `npm test`.

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -22,7 +22,20 @@ module.exports = defineConfig({
   testDir: './tests',
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
-  retries: 0,
+  // Retry-free everywhere except Windows CI, where ONE retry contains a
+  // third-party native crash we do not own: `@lydell/node-pty-win32-x64`'s
+  // `WindowsPtyAgent.kill()` forks `conpty_console_list_agent` without awaiting
+  // it, the agent's `AttachConsole` fails against the just-killed shell, and the
+  // teardown race can take the whole Playwright worker down with an access
+  // violation (`code=3221225477`). `createServer()` hosts the server — and so
+  // node-pty — inside the worker, which is why a native crash is fatal here.
+  // The agent ships only in the win32 binary package, so POSIX cannot reach the
+  // code path and stays at 0. This is CONTAINMENT, NOT a licence for flaky
+  // tests: one retry cannot rescue a deterministic failure, and Playwright still
+  // reports a retried-then-passed test as `flaky`, not `passed`. Full diagnosis
+  // and the exit criteria that force escalation live in
+  // docs/history/windows-conpty-worker-crash-2026.md.
+  retries: process.env.CI && process.platform === 'win32' ? 1 : 0,
   workers: process.env.CI ? 2 : 1,
   timeout: 60000,
   updateSnapshots: 'missing',

--- a/test/longevity/event-loop/hot-02-filewatcher-hash.test.js
+++ b/test/longevity/event-loop/hot-02-filewatcher-hash.test.js
@@ -51,6 +51,27 @@ function busyWait(ms) {
   while (Date.now() < end) { /* spin */ }
 }
 
+// Mirror FileWatcher's own canonicalization (`_realpathStrict` in
+// src/utils/file-watcher.js): `realpathSync.native` plus the `\\?\` strip.
+// Plain `fs.realpathSync` is NOT enough on Windows — it leaves 8.3 short names
+// intact, and GitHub's Windows runners hand back an `os.tmpdir()` of
+// `C:\Users\RUNNER~1\AppData\Local\Temp`. `_canonicalize` would then store the
+// expanded `runneradmin` form in `_subscriptions` while `hasSubscription()`
+// (which only does `path.resolve`) looks up the unexpanded `RUNNER~1` form, so
+// every event is silently dropped and the burst never reaches `_flush` — the
+// "expected >= 20 flush events; got 0" sanity failure. Canonicalizing the same
+// way the product does makes this test actually exercise the hot path on
+// Windows instead of asserting against zero work.
+function realpathNative(p) {
+  let out;
+  try {
+    out = fs.realpathSync.native(p);
+  } catch (_) {
+    out = fs.realpathSync(p);
+  }
+  return typeof out === 'string' && out.startsWith('\\\\?\\') ? out.slice(4) : out;
+}
+
 describe('HOT-02: FileWatcher sync MD5 on hot path (event-loop block under bulk edits)', function () {
   this.timeout(20000);
 
@@ -62,11 +83,11 @@ describe('HOT-02: FileWatcher sync MD5 on hot path (event-loop block under bulk 
   beforeEach(() => {
     // Use a unique tmpdir per test to avoid cross-test contamination if
     // mocha is later configured to run files in parallel.
-    // Canonicalize via realpath so /var → /private/var on macOS matches
-    // FileWatcher._canonicalize (which also realpaths). Without this,
-    // hasSubscription() (which uses path.resolve, NOT realpath) misses
-    // and every event is silently dropped.
-    tmpRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'hot02-fw-')));
+    // Canonicalize exactly as FileWatcher._canonicalize does, so /var →
+    // /private/var on macOS AND `RUNNER~1` → `runneradmin` on Windows both
+    // match. Without this, hasSubscription() (which uses path.resolve, NOT
+    // realpath) misses and every event is silently dropped.
+    tmpRoot = realpathNative(fs.mkdtempSync(path.join(os.tmpdir(), 'hot02-fw-')));
     filePaths = [];
     for (let i = 0; i < 20; i++) {
       const p = path.join(tmpRoot, `f${i}.bin`);
@@ -95,6 +116,26 @@ describe('HOT-02: FileWatcher sync MD5 on hot path (event-loop block under bulk 
   afterEach(() => {
     fs.readFileSync = origReadFileSync;
     try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch (_) {}
+  });
+
+  it('canonicalizes tmpRoot the same way FileWatcher does, so events are not silently dropped', () => {
+    const w = new FileWatcher({ watchRoot: tmpRoot, includeHash: true });
+    for (const p of filePaths) {
+      // The key subscribe() would store...
+      const stored = w._canonicalize(p);
+      // ...must be the key hasSubscription() looks up. On Windows these
+      // diverge whenever the path carries an 8.3 short name and the caller
+      // canonicalized with plain realpathSync: _canonicalize expands it via
+      // realpathSync.native, hasSubscription's path.resolve does not.
+      w._subscriptions.add(stored);
+      assert.ok(
+        w.hasSubscription(p),
+        `subscription key ${stored} is unreachable from hasSubscription(${p}) — `
+          + '8.3 / realpath canonicalization mismatch would drop every event '
+          + 'and make the burst assertions below vacuous'
+      );
+      w._subscriptions.delete(stored);
+    }
   });
 
   it('does not call fs.readFileSync synchronously inside _flush() under a 20-file change burst', async () => {

--- a/test/playwright-retry-policy.test.js
+++ b/test/playwright-retry-policy.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+const CONFIG_PATH = require.resolve('../e2e/playwright.config');
+
+// Reload the Playwright config with `process.platform` and `process.env.CI`
+// forced to the requested combination. The config computes `retries` at module
+// evaluation time, so it has to be re-required for each case.
+function loadConfig({ platform, ci }) {
+  const realPlatform = process.platform;
+  const hadCi = Object.prototype.hasOwnProperty.call(process.env, 'CI');
+  const realCi = process.env.CI;
+
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+  if (ci) process.env.CI = 'true';
+  else delete process.env.CI;
+
+  delete require.cache[CONFIG_PATH];
+  try {
+    return require(CONFIG_PATH);
+  } finally {
+    Object.defineProperty(process, 'platform', {
+      value: realPlatform,
+      configurable: true,
+    });
+    if (hadCi) process.env.CI = realCi;
+    else delete process.env.CI;
+    delete require.cache[CONFIG_PATH];
+  }
+}
+
+// The browser gate is retry-free everywhere the crash cannot happen. The single
+// exception is Windows CI, where node-pty's ConPTY teardown can kill the
+// Playwright worker outright (access violation 3221225477). See
+// docs/history/windows-conpty-worker-crash-2026.md.
+describe('Playwright retry policy', function () {
+  it('allows exactly one retry on Windows CI', function () {
+    const config = loadConfig({ platform: 'win32', ci: true });
+    assert.strictEqual(
+      config.retries,
+      1,
+      'Windows CI contains the node-pty worker crash with one retry — never more, '
+        + 'so a deterministic failure still fails both attempts'
+    );
+  });
+
+  it('stays retry-free on POSIX CI, which cannot reach the crashing code path', function () {
+    for (const platform of ['linux', 'darwin']) {
+      const config = loadConfig({ platform, ci: true });
+      assert.strictEqual(
+        config.retries,
+        0,
+        `${platform} CI must stay retry-free: conpty_console_list_agent ships only `
+          + 'in the win32 binary package, so a flake there has no third-party excuse'
+      );
+    }
+  });
+
+  it('stays retry-free for local runs on every platform', function () {
+    for (const platform of ['win32', 'linux', 'darwin']) {
+      const config = loadConfig({ platform, ci: false });
+      assert.strictEqual(
+        config.retries,
+        0,
+        `local ${platform} runs must surface flakes raw`
+      );
+    }
+  });
+
+  it('keeps forbidOnly and the project list intact across the reload', function () {
+    const config = loadConfig({ platform: 'win32', ci: true });
+    assert.strictEqual(config.forbidOnly, true, 'CI must still reject test.only');
+    assert.ok(
+      Array.isArray(config.projects) && config.projects.length > 0,
+      'projects must survive the platform override'
+    );
+    assert.ok(
+      config.projects.some((p) => p.name === 'functional-extended'),
+      'the project that surfaced the crash must still be defined'
+    );
+  });
+
+  it('restores the real platform and CI value after loading', function () {
+    const before = process.platform;
+    loadConfig({ platform: 'win32', ci: true });
+    assert.strictEqual(process.platform, before, 'process.platform must be restored');
+    assert.strictEqual(
+      path.basename(CONFIG_PATH),
+      'playwright.config.js',
+      'the config under test must be the e2e one'
+    );
+  });
+});


### PR DESCRIPTION
Picks up two commits that landed on #153 **after** #154 was integrated, so they
are not on `main`, plus one addition of my own.

## What was missing from main

| commit | |
| --- | --- |
| `698dbd8` | contain the Windows ConPTY worker crash with one diagnosed retry |
| `e623dff` | canonicalize the HOT-02 tmpRoot with `realpathSync.native` for Windows 8.3 |

Files that existed on #153 and nowhere on `main`:
`docs/history/windows-conpty-worker-crash-2026.md`,
`docs/history/windows-8dot3-filewatcher-canonicalization-2026.md`,
`test/playwright-retry-policy.test.js`.

## Why the retry is legitimate here

This repo's rules allow a diagnosed retry only once the root cause is understood
and recorded, and that bar is met. The writeup traces the crash to node-pty:
`kill()` calls `_getConsoleProcessList()` **without awaiting it** and then
immediately runs `_ptyNative.kill()`, so the forked agent finds the pty already
dead, `AttachConsole` fails, and the unsynchronised teardown produces an access
violation (`0xC0000005`). Because `createServer()` hosts `ClaudeCodeWebServer`
**in-process**, that native crash takes the Playwright worker with it instead of
a child.

The boundary is argued rather than assumed: `retries: CI && win32 ? 1 : 0`. Not
per-project (that chases the symptom), not global (POSIX cannot execute the
crashing binary), not local (developers should see flakes raw), and exactly one
retry so a deterministic failure still fails both attempts. Playwright reports a
retried-then-passed test as `flaky`, not `passed`, so the signal stays visible.
`test/playwright-retry-policy.test.js` pins all four combinations.

Explicit exit criteria are recorded: escalate if any Windows job fails on **both**
attempts with this signature, or if `flaky` becomes routine.

## My addition: escalation path 2 is disproven

The writeup ends with an honest limitation — the diagnosis was source-reading and
CI logs from a Linux container, never reproduced on Windows. I have that missing
evidence for one of its three escalation paths.

Path 2 was "pass `useConptyDll: true`". I implemented it (`604b93a`) and reverted
it (`06752ae`) earlier tonight. The predicted mechanism is correct — the agent is
never forked and the `AttachConsole` flood goes from dozens of lines to **zero**,
with `02-terminal-io` still 3/3 locally. It is still the wrong fix: CI failed
**every** Windows job, unit suite at 1988 passing / 4 failing (3 pre-existing)
plus all five Windows browser buckets. The three runs before it were 31/31 green
with the PTY backend the only difference, and reverting restored 31/31 green on
attempt 1.

That path is now marked disproven **with the numbers**, rather than deleted, so
nobody rediscovers it. Path 1 — boot the server out-of-process the way
`spawnCli()` already does — becomes the preferred route, and it closes the whole
class rather than this instance.

Their diagnosis is also sharper than mine on the point that matters: I had found
the crashing fork and the non-unref'd 5s timer, but not the **un-awaited race**
that causes them.

## Verification

- `test/playwright-retry-policy.test.js` 5/5 passing.
- `hot-02-filewatcher-hash` 3/3 passing.
- `retries` resolves to 0 for a local Windows run, confirming developers still see
  flakes raw.