### PR TITLE
fix(server): harden Windows paths, sweeps, and session recovery

### DIFF
--- a/docs/history/server-call-site-drift-2026.md
+++ b/docs/history/server-call-site-drift-2026.md
@@ -37,10 +37,11 @@ Fail-first coverage observed zero process launches and zero warnings when the
 Windows path was injected on a non-Windows test host.
 
 Review of the now-visible launch failure also found that the entrypoint regex used
-an invalid backslash-escaped quote inside a PowerShell double-quoted string. The
-operand now uses a PowerShell single-quoted string, and Windows coverage submits
-the generated command to the in-box PowerShell 5.1 parser without executing the
-sweep.
+an invalid backslash-escaped quote inside a PowerShell double-quoted string, and
+the builder inserted statement separators after continuation operators. The
+operand now uses a PowerShell single-quoted string, the builder follows the
+repository's newline-joined script pattern, and Windows coverage submits the
+generated command to the in-box PowerShell 5.1 parser without executing the sweep.
 
 ## Invalid session structure
 

--- a/docs/history/server-call-site-drift-2026.md
+++ b/docs/history/server-call-site-drift-2026.md
@@ -36,6 +36,12 @@ so startup remains non-fatal but never silent.
 Fail-first coverage observed zero process launches and zero warnings when the
 Windows path was injected on a non-Windows test host.
 
+Review of the now-visible launch failure also found that the entrypoint regex used
+an invalid backslash-escaped quote inside a PowerShell double-quoted string. The
+operand now uses a PowerShell single-quoted string, and Windows coverage submits
+the generated command to the in-box PowerShell 5.1 parser without executing the
+sweep.
+
 ## Invalid session structure
 
 Malformed JSON was preserved before recovery, but valid JSON with the wrong

--- a/docs/history/server-call-site-drift-2026.md
+++ b/docs/history/server-call-site-drift-2026.md
@@ -1,0 +1,57 @@
+# Server call-site drift fixes (2026)
+
+Three server-side failures came from local copies diverging from an existing
+correct implementation.
+
+## Windows extended-length paths
+
+`FileWatcher` removed the first four characters from every `\\?\` path. That
+works for `\\?\C:\...` but converted `\\?\UNC\server\share\...` into the
+relative path `UNC\server\share\...`, so recursive subscriptions on network
+shares never matched descendant events.
+
+The correct two-form conversion already existed in the server path
+canonicalizer. It now lives in one dependency-free helper used by the server,
+watcher, global test sandbox, short-path coverage, and the HOT-02 fixture. The
+helper is deliberately ungated: POSIX paths cannot carry the prefix and pass
+through unchanged, while the pure form can be tested on every platform. Bare
+prefix-only strings are not returned by `realpathSync.native()`; tests pin their
+mechanical results only to detect future drift.
+
+Fail-first coverage reported the extended UNC value as
+`UNC\server\share\project` instead of `\\server\share\project`.
+
+## Orphan-host sweep executable
+
+The startup sweep invoked bare `powershell.exe` through `PATH` and ignored the
+callback error. A stripped path disabled cleanup silently, while an
+attacker-ordered path could select an unintended executable.
+
+The sweep now consumes the same absolute in-box PowerShell resolver already used
+by keep-awake and hibernation handling. Its options seam covers platform,
+environment, process launch, and logging without changing the zero-argument
+startup call. Synchronous and asynchronous launch errors feed one warning guard,
+so startup remains non-fatal but never silent.
+
+Fail-first coverage observed zero process launches and zero warnings when the
+Windows path was injected on a non-Windows test host.
+
+## Invalid session structure
+
+Malformed JSON was preserved before recovery, but valid JSON with the wrong
+shape was discarded without a backup. Autosave could then replace the only
+copy.
+
+Both paths now use one preservation helper and one
+`sessions.json.corrupted.<timestamp>` naming scheme. Rename is preferred; a
+byte-for-byte copy is the fallback. If both operations fail, an in-memory latch
+blocks writes with `ESESSIONBACKUPFAILED` while leaving the original bytes
+untouched. The latch clears only after the protected file disappears, a later
+load is valid, or explicit session clearing succeeds.
+
+Fail-first coverage found no backup for any wrong-shape fixture and no latch
+after forced rename and copy failures.
+
+The greater-than-seven-day path remains unchanged by design. Expiry is intended
+policy for valid data, and labelling an expired file as corrupted would be
+misleading.

--- a/docs/specs/file-browser.md
+++ b/docs/specs/file-browser.md
@@ -314,6 +314,14 @@ Add a path to the active subscription set for a session's open SSE stream.
 
 The server's chokidar watcher watches the SUPERSET of all subscribed paths' parent directories — narrower than the entire `workingDir`, broader than per-file. Subsequent SSE events for `path` will arrive on the open EventSource for that session.
 
+Before registration or matching, watcher paths are canonicalized with
+`fs.realpathSync.native()` so Windows 8.3 aliases expand before chokidar sees
+them. One shared prefix helper handles both native extended-length forms:
+`\\?\C:\...` becomes `C:\...`, while `\\?\UNC\server\share\...` becomes
+`\\server\share\...`. It removes only the prefix and preserves drive spelling,
+separator style, and trailing separators. This keeps recursive subscriptions on
+Windows network shares absolute and matchable against descendant events.
+
 **Errors:** 401, 403, 404 (no open SSE stream for that session id), 409 (subscription already active for this path).
 
 #### `POST /api/files/watch/unsubscribe`

--- a/docs/specs/model-hosts.md
+++ b/docs/specs/model-hosts.md
@@ -99,7 +99,9 @@ The sweep launches the in-box Windows PowerShell 5.1 executable by absolute path
 under `SystemRoot` (falling back through `windir` and then `C:\Windows`), never
 through `PATH`. A synchronous launch failure, missing executable, timeout, or
 non-zero exit emits one warning naming that path. Sweep failure remains
-non-fatal so server startup continues in degraded containment mode.
+non-fatal so server startup continues in degraded containment mode. Windows
+coverage parses the generated command with the in-box PowerShell 5.1 parser
+before the sweep contract is accepted.
 
 There remains a PID-reuse window between process creation and assignment because
 the launcher does not yet create the process suspended. This is documented, not

--- a/docs/specs/model-hosts.md
+++ b/docs/specs/model-hosts.md
@@ -95,6 +95,12 @@ only when that original owning core no longer exists. Shell processes whose
 command text happens to contain marker strings are never candidates, and a host
 owned by another live server instance is never retired.
 
+The sweep launches the in-box Windows PowerShell 5.1 executable by absolute path
+under `SystemRoot` (falling back through `windir` and then `C:\Windows`), never
+through `PATH`. A synchronous launch failure, missing executable, timeout, or
+non-zero exit emits one warning naming that path. Sweep failure remains
+non-fatal so server startup continues in degraded containment mode.
+
 There remains a PID-reuse window between process creation and assignment because
 the launcher does not yet create the process suspended. This is documented, not
 claimed as closed.

--- a/docs/specs/session-store.md
+++ b/docs/specs/session-store.md
@@ -79,11 +79,13 @@ Restores sessions from disk into an in-memory `Map`.
 2. Reads file contents as UTF-8.
 3. Handles empty/whitespace-only files by returning an empty `Map`.
 4. Parses JSON with error recovery:
-   - On parse failure, renames the corrupted file to `sessions.json.corrupted.<timestamp>` for forensics, then returns an empty `Map`.
+   - On parse failure, preserves the unusable file as `sessions.json.corrupted.<timestamp>` for forensics, then returns an empty `Map`.
 5. Validates the parsed structure:
    - Must be a non-null object with a `sessions` array property.
-   - Returns an empty `Map` if the structure is invalid.
-6. Checks the `savedAt` timestamp -- if older than **7 days**, the data is considered stale and an empty `Map` is returned.
+   - Preserves valid JSON with the wrong structure through the same corruption-recovery path before returning an empty `Map`.
+   - Preservation first renames the source and falls back to a byte-for-byte copy if rename is unavailable.
+   - If neither operation succeeds, the store keeps the source in place and blocks later saves with `ESESSIONBACKUPFAILED` so autosave cannot overwrite unrecovered bytes.
+6. Checks the `savedAt` timestamp -- if older than **7 days**, the data is considered stale and an empty `Map` is returned. This intentional expiry does not create a corruption backup.
 7. For each session entry:
    - Skips entries without an `id` field.
    - Deserializes `created` and `lastActivity` back to `Date` objects.
@@ -176,7 +178,8 @@ The server calls `SessionStore` in these contexts:
 The store handles corruption gracefully:
 
 1. **Empty file** -- Detected by checking `!data || !data.trim()`. Returns empty Map.
-2. **Invalid JSON** -- Caught by `JSON.parse` try/catch. The corrupted file is renamed with a `.corrupted.<timestamp>` suffix for manual inspection, then returns empty Map.
-3. **Invalid structure** -- If parsed data is not an object or lacks a `sessions` array, returns empty Map.
-4. **Stale data** -- Sessions older than 7 days are discarded entirely.
-5. **Invalid session entries** -- Individual entries without an `id` field are silently skipped.
+2. **Invalid JSON** -- Caught by `JSON.parse` try/catch. The unusable file is moved to a `.corrupted.<timestamp>` sibling, or copied there if rename fails, then returns empty Map.
+3. **Invalid structure** -- Valid JSON that is not an object with a `sessions` array uses the same byte-preserving backup path before returning empty Map.
+4. **Backup failure** -- If both rename and copy fail, the source remains untouched and subsequent saves return `false` with `ESESSIONBACKUPFAILED` without incrementing the ordinary save-failure counter. The in-memory block clears when the protected file is removed, a later load parses successfully, or `clearOldSessions()` removes it.
+5. **Stale data** -- Sessions older than 7 days are intentionally discarded without a backup; a well-formed expired file is not labelled as corruption.
+6. **Invalid session entries** -- Individual entries without an `id` field are silently skipped.

--- a/src/keepalive-manager.js
+++ b/src/keepalive-manager.js
@@ -152,8 +152,8 @@ class KeepaliveManager {
 
   // Absolute path to in-box Windows PowerShell 5.1 (PATH-hijack hardening --
   // never resolve a bare "powershell.exe" off PATH).
-  static powershellPath() {
-    const root = process.env.SystemRoot || process.env.windir || 'C:\\Windows';
+  static powershellPath(env = process.env) {
+    const root = env.SystemRoot || env.windir || 'C:\\Windows';
     return path.join(root, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
   }
 

--- a/src/model-host-containment.js
+++ b/src/model-host-containment.js
@@ -47,7 +47,7 @@ function buildOrphanSweepScript(currentPid) {
     '    Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue',
     '  }',
     '}',
-  ].join('; ');
+  ].join('\n');
 }
 
 function sweepOrphanHosts(options = {}) {

--- a/src/model-host-containment.js
+++ b/src/model-host-containment.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const { execFile } = require('child_process');
+const { execFile: defaultExecFile } = require('child_process');
 const jobGuard = require('./job-guard');
+const KeepaliveManager = require('./keepalive-manager');
 
 function attachHost(child) {
   if (process.platform !== 'win32') return { ok: true, job: null };
@@ -49,13 +50,45 @@ function buildOrphanSweepScript(currentPid) {
   ].join('; ');
 }
 
-function sweepOrphanHosts() {
-  if (process.platform !== 'win32' || process.env.AI_OR_DIE_SKIP_ORPHAN_SWEEP === '1') return;
+function sweepOrphanHosts(options = {}) {
+  const platform = options.platform || process.platform;
+  const env = options.env || process.env;
+  const execFile = options.execFile || defaultExecFile;
+  const logger = options.logger || console;
+  if (platform !== 'win32' || env.AI_OR_DIE_SKIP_ORPHAN_SWEEP === '1') return;
+
   const script = buildOrphanSweepScript(process.pid);
-  execFile('powershell.exe', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script], {
-    windowsHide: true,
-    timeout: 10000,
-  }, () => {});
+  const powershell = KeepaliveManager.powershellPath(env);
+  let warned = false;
+  const warnFailure = (error) => {
+    if (warned) return;
+    warned = true;
+    const message = error && error.code === 'ENOENT'
+      ? `PowerShell executable not found at ${powershell}; orphan model-host sweep did not run`
+      : `Orphan model-host sweep failed using ${powershell}: ${error && error.message ? error.message : error}`;
+    try {
+      if (logger && typeof logger.warn === 'function') logger.warn(message);
+    } catch (_) {
+      // Startup containment is best-effort and must not fail server boot.
+    }
+  };
+
+  try {
+    execFile(
+      powershell,
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
+      {
+        windowsHide: true,
+        timeout: 10000,
+        env,
+      },
+      (error) => {
+        if (error) warnFailure(error);
+      }
+    );
+  } catch (error) {
+    warnFailure(error);
+  }
 }
 
 module.exports = { attachHost, closeHostJob, sweepOrphanHosts, buildOrphanSweepScript };

--- a/src/model-host-containment.js
+++ b/src/model-host-containment.js
@@ -35,7 +35,7 @@ function buildOrphanSweepScript(currentPid) {
     '$self = ' + currentPid,
     '$hosts = Get-CimInstance Win32_Process | Where-Object {',
     '  $_.Name -match "^(?:node|bun)(?:\\.exe)?$" -and',
-    '  $_.CommandLine -match "(?:^|[\\\\/])(?:stt-host|sticky-note-host)\\.js(?:\\"|\\s)" -and',
+    '  $_.CommandLine -match \'(?:^|[\\\\/])(?:stt-host|sticky-note-host)\\.js(?:"|\\s)\' -and',
     '  $_.CommandLine -match "(?:^|\\s)--ai-or-die-model-host(?:\\s|$)" -and',
     '  $_.CommandLine -match "(?:^|\\s)--core-pid=(\\d+)(?:\\s|$)" -and',
     '  $_.CommandLine -match "(?:^|\\s)--host=(?:stt|sticky-note)(?:\\s|$)"',

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,7 @@ const crypto = require('crypto');
 const { execFile } = require('child_process');
 const search = require('./utils/search');
 const FileWatcher = require('./utils/file-watcher');
+const { stripWindowsLongPathPrefix } = require('./utils/win-long-path');
 const WebSocket = require('ws');
 const cors = require('cors');
 const { v4: uuidv4 } = require('uuid');
@@ -667,9 +668,7 @@ class ClaudeCodeWebServer {
       //   `\\?\UNC\server\share\…` → `\\server\share\…`
       // Without this, baseFolder (resolved before the prefix was added)
       // and the realpath'd target would still lexically disagree.
-      if (process.platform === 'win32' && out.startsWith('\\\\?\\')) {
-        out = out.startsWith('\\\\?\\UNC\\') ? '\\\\' + out.slice(8) : out.slice(4);
-      }
+      out = stripWindowsLongPathPrefix(out);
       return out;
     } catch (_) {
       // Path doesn't exist — recurse on the parent (which usually does)

--- a/src/utils/file-watcher.js
+++ b/src/utils/file-watcher.js
@@ -49,6 +49,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { EventEmitter } = require('events');
+const { stripWindowsLongPathPrefix } = require('./win-long-path');
 
 let _chokidar = null;
 
@@ -87,7 +88,7 @@ function _realpathStrict(p) {
     // 8.3 expansion is best-effort in that case.
     out = fs.realpathSync(p);
   }
-  return typeof out === 'string' && out.startsWith('\\\\?\\') ? out.slice(4) : out;
+  return stripWindowsLongPathPrefix(out);
 }
 
 function _getChokidar() {

--- a/src/utils/session-store.js
+++ b/src/utils/session-store.js
@@ -54,6 +54,10 @@ class SessionStore {
         // caller having to wrap saveSessions. Null after a successful
         // save; otherwise an Error-shaped object carrying .code.
         this._lastSaveError = null;
+        // If an unusable file cannot be preserved, writes stay blocked until
+        // the protected file is removed, replaced with valid data, or cleared.
+        this._saveBlockedReason = null;
+        this._saveBlockedWarningLogged = false;
         // DISK-04b: monotonically increasing counter of saveSessions()
         // calls that returned false. Surfaced in _collectDiagnostics so
         // the soak harness (and operators grepping the diagnostics log)
@@ -179,6 +183,7 @@ class SessionStore {
     }
 
     async saveSessions(sessions) {
+        if (await this._isSaveBlocked()) return false;
         if (!this._dirty) return true;
 
         // DISK-01 follow-up (SOAK-reported race): chain onto any prior
@@ -361,20 +366,18 @@ class SessionStore {
                 parsed = JSON.parse(data);
             } catch (parseError) {
                 console.error('Sessions file is corrupted, starting fresh:', parseError.message);
-                // Try to backup the corrupted file
-                try {
-                    await fs.rename(this.sessionsFile, `${this.sessionsFile}.corrupted.${Date.now()}`);
-                } catch (renameError) {
-                    // Ignore rename errors
-                }
+                await this._preserveUnusableSessionsFile('invalid JSON');
                 return new Map();
             }
             
             // Validate parsed data structure
             if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.sessions)) {
                 console.log('Invalid sessions file format, starting fresh');
+                await this._preserveUnusableSessionsFile('invalid structure');
                 return new Map();
             }
+
+            this._clearSaveBlock();
             
             // Check if data is recent (within last 7 days)
             if (parsed.savedAt) {
@@ -419,9 +422,84 @@ class SessionStore {
         }
     }
 
+    _clearSaveBlock() {
+        this._saveBlockedReason = null;
+        this._saveBlockedWarningLogged = false;
+        if (this._lastSaveError && this._lastSaveError.code === 'ESESSIONBACKUPFAILED') {
+            this._lastSaveError = null;
+        }
+    }
+
+    async _preserveUnusableSessionsFile(reason) {
+        const backupFile = `${this.sessionsFile}.corrupted.${Date.now()}`;
+        let fileStats = null;
+        try {
+            fileStats = await fs.stat(this.sessionsFile);
+        } catch (_) {
+            // Preservation attempts below surface the actionable failure.
+        }
+
+        let renameError;
+        try {
+            await fs.rename(this.sessionsFile, backupFile);
+            this._clearSaveBlock();
+            return backupFile;
+        } catch (error) {
+            renameError = error;
+        }
+
+        try {
+            await fs.copyFile(this.sessionsFile, backupFile);
+            this._clearSaveBlock();
+            return backupFile;
+        } catch (copyError) {
+            this._saveBlockedReason = {
+                reason,
+                at: Date.now(),
+                file: this.sessionsFile,
+                size: fileStats ? fileStats.size : null,
+                mtimeMs: fileStats ? fileStats.mtimeMs : null,
+                renameError,
+                copyError
+            };
+            this._saveBlockedWarningLogged = false;
+            console.error(
+                `Failed to preserve unusable sessions file (${reason}); future saves are blocked:`,
+                copyError.message
+            );
+            return null;
+        }
+    }
+
+    async _isSaveBlocked() {
+        if (!this._saveBlockedReason) return false;
+
+        try {
+            await fs.access(this.sessionsFile);
+        } catch (error) {
+            if (error.code === 'ENOENT') {
+                this._clearSaveBlock();
+                return false;
+            }
+        }
+
+        const error = new Error(
+            `Session save blocked because ${this.sessionsFile} could not be preserved`
+        );
+        error.code = 'ESESSIONBACKUPFAILED';
+        error.reason = this._saveBlockedReason;
+        this._lastSaveError = error;
+        if (!this._saveBlockedWarningLogged) {
+            this._saveBlockedWarningLogged = true;
+            console.error('Blocked session save to protect an unrecovered sessions file');
+        }
+        return true;
+    }
+
     async clearOldSessions() {
         try {
             await fs.unlink(this.sessionsFile);
+            this._clearSaveBlock();
             console.log('Cleared old sessions');
             return true;
         } catch (error) {

--- a/src/utils/win-long-path.js
+++ b/src/utils/win-long-path.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/**
+ * Strip the Windows extended-length prefix without changing the path remainder.
+ *
+ * fs.realpathSync.native() can return either \\?\C:\... or
+ * \\?\UNC\server\share\.... The UNC form must regain its leading double
+ * separator when the extended prefix and UNC marker are removed.
+ *
+ * Bare prefix values are not produced by realpathSync.native() and are outside
+ * this helper's input contract; their mechanical outputs are pinned by tests
+ * solely to detect drift between call sites.
+ */
+function stripWindowsLongPathPrefix(value) {
+  if (typeof value !== 'string' || !value.startsWith('\\\\?\\')) return value;
+  return value.startsWith('\\\\?\\UNC\\') ? '\\\\' + value.slice(8) : value.slice(4);
+}
+
+module.exports = { stripWindowsLongPathPrefix };

--- a/test/file-watcher-longpath.test.js
+++ b/test/file-watcher-longpath.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const FileWatcher = require('../src/utils/file-watcher');
+const { stripWindowsLongPathPrefix } = require('../src/utils/win-long-path');
+
+const canonicalizeForWatch = FileWatcher.canonicalizeForWatch;
+
+function withNativeResult(result, fn) {
+  const original = fs.realpathSync.native;
+  fs.realpathSync.native = () => result;
+  try {
+    return fn();
+  } finally {
+    fs.realpathSync.native = original;
+  }
+}
+
+describe('FileWatcher Windows long-path canonicalization', function () {
+  const cases = [
+    ['extended drive path', '\\\\?\\C:\\Users\\me', 'C:\\Users\\me'],
+    ['extended UNC path', '\\\\?\\UNC\\server\\share\\project', '\\\\server\\share\\project'],
+    ['drive path', 'C:\\plain', 'C:\\plain'],
+    ['forward-slash drive path', 'C:/plain/dir', 'C:/plain/dir'],
+    ['drive trailing separator', 'C:\\plain\\dir\\', 'C:\\plain\\dir\\'],
+    ['extended drive trailing separator', '\\\\?\\C:\\dir\\', 'C:\\dir\\'],
+    ['POSIX path', '/tmp/x', '/tmp/x'],
+    ['bare extended prefix', '\\\\?\\', ''],
+    ['bare extended UNC prefix', '\\\\?\\UNC\\', '\\\\'],
+    ['bare extended UNC marker', '\\\\?\\UNC', 'UNC'],
+  ];
+
+  for (const [name, nativeResult, expected] of cases) {
+    it(`maps ${name} without normalizing the remainder`, function () {
+      assert.strictEqual(stripWindowsLongPathPrefix(nativeResult), expected);
+    });
+  }
+
+  it('uses the shared mapping through the exported watcher canonicalizer', function () {
+    const actual = withNativeResult(
+      '\\\\?\\UNC\\server\\share\\project',
+      () => canonicalizeForWatch('\\\\server\\share\\project')
+    );
+    assert.strictEqual(actual, '\\\\server\\share\\project');
+  });
+
+  it('expands an 8.3-shaped path through realpathSync.native on every platform', function () {
+    const expanded = withNativeResult(
+      '\\\\?\\C:\\Users\\RUNNERADMIN\\proj',
+      () => canonicalizeForWatch('C:\\Users\\RUNNER~1\\proj')
+    );
+    assert.strictEqual(expanded, 'C:\\Users\\RUNNERADMIN\\proj');
+  });
+
+  it('matches a UNC descendant registered through subscribe on Windows', async function () {
+    if (process.platform !== 'win32') return this.skip();
+
+    const watcher = new FileWatcher({
+      watchRoot: os.tmpdir(),
+      includeHash: false,
+      debounceMs: 0,
+    });
+    watcher._watcher = {
+      add() {},
+      unwatch() {},
+      async close() {},
+    };
+
+    const share = '\\\\server\\share\\project';
+    const descendant = `${share}\\src\\index.js`;
+    const original = fs.realpathSync.native;
+    fs.realpathSync.native = (input) => (
+      path.resolve(input) === path.resolve(share)
+        ? '\\\\?\\UNC\\server\\share\\project'
+        : original(input)
+    );
+
+    try {
+      await watcher.subscribe(share, { recursive: true });
+    } finally {
+      fs.realpathSync.native = original;
+    }
+
+    try {
+      assert.strictEqual(watcher.hasSubscription(descendant), true);
+      const eventPromise = new Promise((resolve) => watcher.once('event', resolve));
+      watcher._onChokidar('change', descendant, { mtimeMs: 1, ino: 1 });
+      const event = await eventPromise;
+      assert.strictEqual(event.path, descendant.replace(/\\/g, '/'));
+    } finally {
+      await watcher.close();
+    }
+  });
+});

--- a/test/file-watcher-shortpath.test.js
+++ b/test/file-watcher-shortpath.test.js
@@ -19,6 +19,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { stripWindowsLongPathPrefix } = require('../src/utils/win-long-path');
 
 const IS_WIN = process.platform === 'win32';
 
@@ -58,7 +59,7 @@ describe('file-watcher 8.3 short-path canonicalization (Windows)', function () {
       return this.skip();
     }
     const viaJs = fs.realpathSync(short);
-    const viaNative = fs.realpathSync.native(short).replace(/^\\\\\?\\/, '');
+    const viaNative = stripWindowsLongPathPrefix(fs.realpathSync.native(short));
 
     assert.notStrictEqual(
       viaJs.toLowerCase(),

--- a/test/hooks/session-sandbox.js
+++ b/test/hooks/session-sandbox.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const assert = require('assert');
+const { stripWindowsLongPathPrefix } = require('../../src/utils/win-long-path');
 
 const realStore = path.join(os.homedir(), '.ai-or-die');
 
@@ -25,7 +26,7 @@ const realStore = path.join(os.homedir(), '.ai-or-die');
   try {
     const current = os.tmpdir();
     let resolved = fs.realpathSync.native(current);
-    if (typeof resolved === 'string' && resolved.startsWith('\\\\?\\')) resolved = resolved.slice(4);
+    resolved = stripWindowsLongPathPrefix(resolved);
     if (resolved && resolved !== current) {
       for (const key of ['TEMP', 'TMP', 'TMPDIR']) {
         if (process.env[key]) process.env[key] = resolved;

--- a/test/longevity/event-loop/hot-02-filewatcher-hash.test.js
+++ b/test/longevity/event-loop/hot-02-filewatcher-hash.test.js
@@ -44,6 +44,7 @@ const path = require('path');
 const { monitorEventLoopDelay } = require('perf_hooks');
 
 const FileWatcher = require('../../../src/utils/file-watcher');
+const { stripWindowsLongPathPrefix } = require('../../../src/utils/win-long-path');
 
 function busyWait(ms) {
   const end = Date.now() + ms;
@@ -69,7 +70,7 @@ function realpathNative(p) {
   } catch (_) {
     out = fs.realpathSync(p);
   }
-  return typeof out === 'string' && out.startsWith('\\\\?\\') ? out.slice(4) : out;
+  return stripWindowsLongPathPrefix(out);
 }
 
 describe('HOT-02: FileWatcher sync MD5 on hot path (event-loop block under bulk edits)', function () {

--- a/test/model-host-containment.test.js
+++ b/test/model-host-containment.test.js
@@ -23,6 +23,7 @@ describe('model-host Windows orphan sweep', function () {
       script,
       /-match '\(\?:\^\|\[\\\\\/\]\)\(\?:stt-host\|sticky-note-host\)\\\.js\(\?:"\|\\s\)' -and/
     );
+    assert.doesNotMatch(script, /-and;/);
   });
 
   it('does not classify shell executables as model hosts', function () {

--- a/test/model-host-containment.test.js
+++ b/test/model-host-containment.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const KeepaliveManager = require('../src/keepalive-manager');
@@ -18,12 +19,36 @@ describe('model-host Windows orphan sweep', function () {
     assert.match(script, /--host=\(\?:stt\|sticky-note\)/);
     assert.match(script, /ParentProcessId -eq \$ownerPid/);
     assert.match(script, /\$ownerPid -ne \$self/);
+    assert.match(
+      script,
+      /-match '\(\?:\^\|\[\\\\\/\]\)\(\?:stt-host\|sticky-note-host\)\\\.js\(\?:"\|\\s\)' -and/
+    );
   });
 
   it('does not classify shell executables as model hosts', function () {
     const script = buildOrphanSweepScript(1234);
     assert.match(script, /\^\(\?:node\|bun\)/);
     assert.ok(!script.includes('powershell|pwsh|cmd'));
+  });
+
+  it('produces syntax accepted by Windows PowerShell 5.1', function () {
+    if (process.platform !== 'win32') return this.skip();
+
+    const source = Buffer.from(buildOrphanSweepScript(1234), 'utf8').toString('base64');
+    const parser = [
+      `$source = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${source}'))`,
+      '$tokens = $null',
+      '$errors = $null',
+      '[void][Management.Automation.Language.Parser]::ParseInput($source, [ref]$tokens, [ref]$errors)',
+      'if ($errors.Count) { $errors | ForEach-Object { Write-Error $_.Message }; exit 1 }',
+    ].join('; ');
+    const result = spawnSync(
+      KeepaliveManager.powershellPath(),
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', parser],
+      { encoding: 'utf8', windowsHide: true }
+    );
+
+    assert.strictEqual(result.status, 0, result.stderr || result.error);
   });
 
   it('spawns the existing anchored PowerShell path without consulting PATH', function () {

--- a/test/model-host-containment.test.js
+++ b/test/model-host-containment.test.js
@@ -1,7 +1,13 @@
 'use strict';
 
 const assert = require('assert');
-const { buildOrphanSweepScript } = require('../src/model-host-containment');
+const fs = require('fs');
+const path = require('path');
+const KeepaliveManager = require('../src/keepalive-manager');
+const {
+  buildOrphanSweepScript,
+  sweepOrphanHosts,
+} = require('../src/model-host-containment');
 
 describe('model-host Windows orphan sweep', function () {
   it('requires a model-host runtime, entrypoint, host name, and original parent', function () {
@@ -18,5 +24,117 @@ describe('model-host Windows orphan sweep', function () {
     const script = buildOrphanSweepScript(1234);
     assert.match(script, /\^\(\?:node\|bun\)/);
     assert.ok(!script.includes('powershell|pwsh|cmd'));
+  });
+
+  it('spawns the existing anchored PowerShell path without consulting PATH', function () {
+    const env = {
+      ...process.env,
+      PATH: '',
+    };
+    const calls = [];
+    sweepOrphanHosts({
+      platform: 'win32',
+      env,
+      execFile(binary, args, options, callback) {
+        calls.push({ binary, args, options });
+        callback(null);
+      },
+      logger: { warn() {} },
+    });
+
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].binary, KeepaliveManager.powershellPath(env));
+    assert.strictEqual(path.win32.isAbsolute(calls[0].binary), true);
+    if (process.platform === 'win32') {
+      assert.strictEqual(fs.existsSync(calls[0].binary), true);
+    }
+  });
+
+  it('resolves PowerShell through SystemRoot, windir, then C:\\Windows', function () {
+    const calls = [];
+    const env = { windir: 'E:\\Windows', PATH: '' };
+    sweepOrphanHosts({
+      platform: 'win32',
+      env,
+      execFile(binary, args, options, callback) {
+        calls.push(binary);
+        callback(null);
+      },
+      logger: { warn() {} },
+    });
+
+    assert.strictEqual(calls[0], KeepaliveManager.powershellPath(env));
+    assert.ok(calls[0].startsWith('E:\\Windows'));
+    assert.ok(KeepaliveManager.powershellPath({}).startsWith('C:\\Windows'));
+    assert.strictEqual(path.win32.isAbsolute(calls[0]), true);
+  });
+
+  it('warns exactly once when PowerShell is not found', function () {
+    const warnings = [];
+    sweepOrphanHosts({
+      platform: 'win32',
+      env: {},
+      execFile(binary, args, options, callback) {
+        const error = new Error('spawn ENOENT');
+        error.code = 'ENOENT';
+        callback(error);
+        callback(error);
+      },
+      logger: { warn(message) { warnings.push(message); } },
+    });
+
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /not found/i);
+    assert.ok(warnings[0].includes(KeepaliveManager.powershellPath({})));
+  });
+
+  it('warns once and never throws when execFile throws synchronously', function () {
+    const warnings = [];
+    assert.doesNotThrow(() => sweepOrphanHosts({
+      platform: 'win32',
+      env: {},
+      execFile() {
+        throw new Error('invalid spawn options');
+      },
+      logger: { warn(message) { warnings.push(message); } },
+    }));
+
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /failed/i);
+  });
+
+  it('warns exactly once when PowerShell exits with a generic failure', function () {
+    const warnings = [];
+    sweepOrphanHosts({
+      platform: 'win32',
+      env: {},
+      execFile(binary, args, options, callback) {
+        callback(new Error('process exited 1'));
+      },
+      logger: { warn(message) { warnings.push(message); } },
+    });
+
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /failed/i);
+    assert.doesNotMatch(warnings[0], /not found/i);
+  });
+
+  it('remains a no-op off Windows and when explicitly skipped', function () {
+    let calls = 0;
+    let warnings = 0;
+    const options = {
+      execFile() { calls++; },
+      logger: { warn() { warnings++; } },
+    };
+
+    sweepOrphanHosts({ ...options, platform: 'linux', env: {} });
+    sweepOrphanHosts({
+      ...options,
+      platform: 'win32',
+      env: { AI_OR_DIE_SKIP_ORPHAN_SWEEP: '1' },
+    });
+
+    assert.strictEqual(calls, 0);
+    assert.strictEqual(warnings, 0);
   });
 });

--- a/test/session-store.test.js
+++ b/test/session-store.test.js
@@ -17,9 +17,7 @@ describe('SessionStore', function() {
       // Directory might already exist
     }
 
-    sessionStore = new SessionStore();
-    // Override the default session file path for testing
-    sessionStore.storageDir = tempDir;
+    sessionStore = new SessionStore({ storageDir: tempDir });
     sessionStore.sessionsFile = path.join(tempDir, 'test-sessions.json');
   });
 
@@ -66,6 +64,201 @@ describe('SessionStore', function() {
       assert(loadedSessions instanceof Map);
       assert.strictEqual(loadedSessions.size, 1);
       assert(loadedSessions.has('session1'));
+    });
+
+    const invalidStructures = [
+      ['object sessions', '{"sessions": {}}'],
+      ['string sessions', '{"sessions": "x"}'],
+      ['array root', '[]'],
+      ['null root', 'null'],
+      ['numeric sessions', '{"sessions": 3}'],
+    ];
+
+    for (const [name, bytes] of invalidStructures) {
+      it(`preserves exact bytes for invalid structure: ${name}`, async function () {
+        await fs.writeFile(sessionStore.sessionsFile, bytes);
+
+        const loaded = await sessionStore.loadSessions();
+        const files = await fs.readdir(tempDir);
+        const backups = files.filter((file) => (
+          file.startsWith(`${path.basename(sessionStore.sessionsFile)}.corrupted.`)
+        ));
+
+        assert(loaded instanceof Map);
+        assert.strictEqual(loaded.size, 0);
+        assert.strictEqual(backups.length, 1);
+        const backupBytes = await fs.readFile(path.join(tempDir, backups[0]));
+        assert.strictEqual(Buffer.compare(backupBytes, Buffer.from(bytes)), 0);
+        await assert.rejects(fs.access(sessionStore.sessionsFile), { code: 'ENOENT' });
+      });
+    }
+
+    it('preserves corrupt JSON through the same byte-exact backup path', async function () {
+      const bytes = Buffer.from('{"sessions":[');
+      await fs.writeFile(sessionStore.sessionsFile, bytes);
+
+      const loaded = await sessionStore.loadSessions();
+      const files = await fs.readdir(tempDir);
+      const backup = files.find((file) => (
+        file.startsWith(`${path.basename(sessionStore.sessionsFile)}.corrupted.`)
+      ));
+
+      assert.strictEqual(loaded.size, 0);
+      assert.ok(backup);
+      assert.strictEqual(
+        Buffer.compare(await fs.readFile(path.join(tempDir, backup)), bytes),
+        0
+      );
+    });
+
+    it('copies invalid data to the backup when rename fails', async function () {
+      const bytes = Buffer.from('{"sessions": "x"}');
+      await fs.writeFile(sessionStore.sessionsFile, bytes);
+      const originalRename = fs.rename;
+      fs.rename = async () => {
+        const error = new Error('rename unavailable');
+        error.code = 'EACCES';
+        throw error;
+      };
+
+      try {
+        const loaded = await sessionStore.loadSessions();
+        const files = await fs.readdir(tempDir);
+        const backup = files.find((file) => (
+          file.startsWith(`${path.basename(sessionStore.sessionsFile)}.corrupted.`)
+        ));
+        assert.strictEqual(loaded.size, 0);
+        assert.ok(backup);
+        assert.strictEqual(
+          Buffer.compare(await fs.readFile(path.join(tempDir, backup)), bytes),
+          0
+        );
+        assert.strictEqual(
+          Buffer.compare(await fs.readFile(sessionStore.sessionsFile), bytes),
+          0
+        );
+      } finally {
+        fs.rename = originalRename;
+      }
+    });
+
+    it('blocks saves without altering bytes when every backup method fails', async function () {
+      const bytes = Buffer.from('{"sessions": "x"}');
+      await fs.writeFile(sessionStore.sessionsFile, bytes);
+      const originalRename = fs.rename;
+      const originalCopyFile = fs.copyFile;
+      const originalConsoleError = console.error;
+      const errors = [];
+      fs.rename = async () => {
+        const error = new Error('rename unavailable');
+        error.code = 'EACCES';
+        throw error;
+      };
+      fs.copyFile = async () => {
+        const error = new Error('copy unavailable');
+        error.code = 'EACCES';
+        throw error;
+      };
+      console.error = (...args) => errors.push(args.join(' '));
+
+      try {
+        const loaded = await sessionStore.loadSessions();
+        assert.strictEqual(loaded.size, 0);
+        assert.ok(sessionStore._saveBlockedReason);
+
+        sessionStore.markDirty();
+        const saved = await sessionStore.saveSessions(new Map());
+        assert.strictEqual(saved, false);
+        assert.strictEqual(await sessionStore.saveSessions(new Map()), false);
+        assert.strictEqual(sessionStore._lastSaveError.code, 'ESESSIONBACKUPFAILED');
+        assert.strictEqual(sessionStore._saveFailureCount, 0);
+        assert.strictEqual(
+          Buffer.compare(await fs.readFile(sessionStore.sessionsFile), bytes),
+          0
+        );
+
+        const blockedSaveWarnings = errors.filter((message) => (
+          message.includes('Blocked session save')
+        ));
+        assert.strictEqual(blockedSaveWarnings.length, 1);
+      } finally {
+        fs.rename = originalRename;
+        fs.copyFile = originalCopyFile;
+        console.error = originalConsoleError;
+      }
+    });
+
+    it('clears the backup-failure latch when the protected file is removed', async function () {
+      const bytes = Buffer.from('{"sessions": "x"}');
+      await fs.writeFile(sessionStore.sessionsFile, bytes);
+      const originalRename = fs.rename;
+      const originalCopyFile = fs.copyFile;
+      fs.rename = async () => { throw new Error('rename unavailable'); };
+      fs.copyFile = async () => { throw new Error('copy unavailable'); };
+
+      try {
+        await sessionStore.loadSessions();
+      } finally {
+        fs.rename = originalRename;
+        fs.copyFile = originalCopyFile;
+      }
+
+      await fs.unlink(sessionStore.sessionsFile);
+      sessionStore.markDirty();
+      assert.strictEqual(await sessionStore.saveSessions(new Map()), true);
+      assert.strictEqual(sessionStore._saveBlockedReason, null);
+    });
+
+    it('clears the backup-failure latch after a later valid load', async function () {
+      await fs.writeFile(sessionStore.sessionsFile, '{"sessions": "x"}');
+      const originalRename = fs.rename;
+      const originalCopyFile = fs.copyFile;
+      fs.rename = async () => { throw new Error('rename unavailable'); };
+      fs.copyFile = async () => { throw new Error('copy unavailable'); };
+
+      try {
+        await sessionStore.loadSessions();
+      } finally {
+        fs.rename = originalRename;
+        fs.copyFile = originalCopyFile;
+      }
+
+      await fs.writeFile(sessionStore.sessionsFile, JSON.stringify({
+        savedAt: new Date().toISOString(),
+        sessions: [],
+      }));
+      await sessionStore.loadSessions();
+      assert.strictEqual(sessionStore._saveBlockedReason, null);
+    });
+
+    it('clears the backup-failure latch after clearOldSessions removes the file', async function () {
+      await fs.writeFile(sessionStore.sessionsFile, '{"sessions": "x"}');
+      const originalRename = fs.rename;
+      const originalCopyFile = fs.copyFile;
+      fs.rename = async () => { throw new Error('rename unavailable'); };
+      fs.copyFile = async () => { throw new Error('copy unavailable'); };
+
+      try {
+        await sessionStore.loadSessions();
+      } finally {
+        fs.rename = originalRename;
+        fs.copyFile = originalCopyFile;
+      }
+
+      assert.strictEqual(await sessionStore.clearOldSessions(), true);
+      assert.strictEqual(sessionStore._saveBlockedReason, null);
+    });
+
+    it('does not preserve intentionally expired session data as corruption', async function () {
+      await fs.writeFile(sessionStore.sessionsFile, JSON.stringify({
+        savedAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+        sessions: [{ id: 'expired' }],
+      }));
+
+      const loaded = await sessionStore.loadSessions();
+      const files = await fs.readdir(tempDir);
+      assert.strictEqual(loaded.size, 0);
+      assert.strictEqual(files.some((file) => file.includes('.corrupted.')), false);
     });
   });
 


### PR DESCRIPTION
## Summary
- preserve UNC roots during extended-path canonicalization
- anchor the orphan-host sweep executable, fix its generated command syntax, and surface launch failures
- preserve invalid session files and block destructive autosaves when backup fails

## Verification
- regression coverage for watcher matching, process launch, PowerShell parsing, and session recovery
- full CI matrix on Windows and Ubuntu