### PR TITLE
fix(server): prevent retained-output heap OOM

### DIFF
--- a/docs/history/2026-08-29-heap-oom-json-parse.md
+++ b/docs/history/2026-08-29-heap-oom-json-parse.md
@@ -1,0 +1,27 @@
+# 2026-08-29 heap OOM at JSON.parse
+
+## What Happened
+
+A long-lived server process accumulated large retained session output in memory. During a later file-backed `JSON.parse` call, V8 attempted one more large allocation and the process terminated with out-of-memory.
+
+## Root Cause
+
+The durable pressure was not the parser itself; it was retained live output tails per session. In affected runs, retained session output was on the order of ~1.8 GiB before the crash. The final `JSON.parse` allocation was the terminal allocator that crossed the heap limit.
+
+The runtime evidence identifies a file-backed parse as the fatal allocator but cannot prove, from crash telemetry alone, whether that parse came from claude bind sidecar parsing or `sessions.json` metadata parsing in every case.
+
+## Fix
+
+- Added byte-bounded live session output retention at the buffer level: every production session output buffer now uses a shared cap of **1,000 items + 512 KiB**.
+- Made join replay a true hard cap at **256 KiB** by taking a bounded newest suffix (including trimming a single oversized chunk/item).
+- Hardened claude bind sidecar reads to **64 KiB max**, reading at most `max + 1` bytes from a single file handle, always closing the handle, and rejecting absent/oversized/malformed records. Opening the sidecar now marks the tab as sidecar-managed before validation, so malformed/oversized sidecars do not fall through to newest-mtime inference.
+- Hardened `SessionStore.getSessionMetadata()` against TOCTOU + stale-cache drift: open-once/fstat/read-on-same-handle fallback, strict `64 KiB + 1` bounded read, no parse when fallback bytes exceed limit, and identity-keyed metadata cache invalidation (`size/mtimeMs` + available `dev/ino/ctimeMs`), with `dev`/`ino` stored as strings to avoid unsafe integer precision.
+- Added a startup restart-loop guard in `loadSessions()` with a conservative safe-load ceiling (**128 MiB** default). Reads are positioned and chunked with a hard `maxSafeLoadBytes + 1` bound, including a post-read growth check. Oversized files are preserved byte-for-byte as `.oversized.<timestamp>` for manual recovery (rename-first, copy-and-unlink fallback), then startup continues with an empty in-memory map.
+- Added regression tests covering newline-free PTY retention caps, newest-suffix retention proofs, oversized single-chunk onOutput capping, sidecar oversize/malformed binding safety, and bounded metadata/oversized-load behavior.
+
+## Watch For
+
+- Retention growth in `retention.output_buffers.{active,inactive}.bytes` that should now flatten near `session_count * 512 KiB` for heavy-output sessions.
+- Repeated `savedAt/sessionCount/version = null` metadata responses with very large `sessions.json` before cache warm-up (expected only until a successful save/load populates cache).
+- `.oversized.<timestamp>` backups appearing at startup (expected when a store exceeds the safe-load cap; preserve for manual recovery instead of parsing in-process).
+- Any new code path that reintroduces unrestricted file-backed `JSON.parse` on large files in hot/diagnostic endpoints.

--- a/docs/specs/server.md
+++ b/docs/specs/server.md
@@ -256,7 +256,7 @@ Clears `selectedWorkingDir` back to `null`.
 **Response:** `{ "success": true, "message": "Working directory cleared" }`
 
 #### `GET /api/sessions/persistence`
-Returns persistence metadata from `SessionStore.getSessionMetadata()`.
+Returns persistence metadata from `SessionStore.getSessionMetadata()`. The response always includes `exists`, `savedAt`, `sessionCount`, `fileSize`, and `version`; for very large files before cache warm-up, metadata fields may be `null` while `exists:true` and `fileSize` remain accurate.
 
 **Response:**
 ```json
@@ -337,7 +337,7 @@ All messages are JSON. The `type` field determines the handler.
 | Client Message | Description |
 |---------------|-------------|
 | `create_session` | Create a new session and join it. Fields: `name`, `workingDir`. |
-| `join_session` | Join an existing session. Fields: `sessionId`. Replays the newest stored output up to a 256 KiB byte cap. |
+| `join_session` | Join an existing session. Fields: `sessionId`. Replays a hard-capped newest suffix up to 256 KiB total bytes (including trimming a single oversized chunk). |
 | `leave_session` | Disconnect from current session without stopping the agent. |
 | `start_claude` | Launch Claude CLI in the current session. Fields: `options` (optional). Pre-checks tool availability. |
 | `start_codex` | Launch Codex CLI in the current session. Fields: `options` (optional). Pre-checks tool availability. |
@@ -411,8 +411,8 @@ All messages are JSON. The `type` field determines the handler.
   agent: null,                  // 'claude' | 'codex' | 'agent' | null
   workingDir: '/path',
   connections: Set<wsId>,       // WebSocket connection IDs
-  outputBuffer: CircularBuffer, // Rolling buffer of raw terminal-output chunks
-  maxBufferSize: 1000,          // Max items in outputBuffer (not a byte or line limit)
+  outputBuffer: CircularBuffer, // Rolling raw-output chunks (1,000 items + 512 KiB byte cap)
+  maxBufferSize: 1000,          // Item cap applied alongside the 512 KiB byte cap
   sessionStartTime: Date|null,  // Set on first agent start
   sessionUsage: {               // Aggregated token/cost tracking
     requests: 0,
@@ -435,7 +435,7 @@ Sessions are persisted to disk via `SessionStore` every 30 seconds (`setInterval
 
 ### Session Restoration
 
-On startup, `loadPersistedSessions()` loads sessions from disk. All sessions are restored with `active: false` and empty `connections` Sets since pty processes do not survive restarts.
+On startup, `loadPersistedSessions()` loads sessions from disk. All sessions are restored with `active: false` and empty `connections` Sets since pty processes do not survive restarts. Each restored `outputBuffer` is rebuilt as a `CircularBuffer` with the same live caps used at runtime (1,000 items + 512 KiB), and join replay is independently hard-capped at 256 KiB by taking the newest bounded suffix (never exceeding the cap even for a single oversized item).
 
 ---
 

--- a/docs/specs/session-store.md
+++ b/docs/specs/session-store.md
@@ -26,6 +26,7 @@ new SessionStore()
 
 - Sets `this.storageDir` to `AI_OR_DIE_SESSION_DIR` when provided, otherwise `path.join(os.homedir(), '.ai-or-die')`.
 - Sets `this.sessionsFile` to `path.join(this.storageDir, 'sessions.json')`.
+- Sets `maxSafeLoadBytes` to 128 MiB by default (overrideable via constructor option `maxSafeLoadBytes` for tests).
 - Calls `initializeStorage()` to ensure the directory exists.
 
 ---
@@ -75,25 +76,27 @@ Restores sessions from disk into an in-memory `Map`.
 
 **Process:**
 
-1. Checks file existence via `fs.access`.
-2. Reads file contents as UTF-8.
-3. Handles empty/whitespace-only files by returning an empty `Map`.
-4. Parses JSON with error recovery:
-   - On parse failure, preserves the unusable file as `sessions.json.corrupted.<timestamp>` for forensics, then returns an empty `Map`.
-5. Validates the parsed structure:
+1. Opens `sessions.json` once (`fs.open`) and uses `handle.stat()` from that same file handle before any read.
+2. If `stats.size` exceeds `maxSafeLoadBytes` (default **128 MiB**), closes the handle, preserves the file byte-for-byte as `sessions.json.oversized.<timestamp>` (rename-first, copy-and-unlink fallback), and returns an empty `Map` so startup cannot crash-loop on huge JSON.
+3. Otherwise reads from that same open handle in positioned chunks, stopping after at most `maxSafeLoadBytes + 1` bytes. A post-read handle stat catches growth after the initial stat; an actual oversized file is preserved and never passed to `JSON.parse`.
+4. Handles empty/whitespace-only files by clearing metadata cache and returning an empty `Map`.
+5. Parses JSON with error recovery:
+   - On parse failure, closes the handle, preserves the unusable file as `sessions.json.corrupted.<timestamp>` for forensics, then returns an empty `Map`.
+6. Validates the parsed structure:
    - Must be a non-null object with a `sessions` array property.
    - Preserves valid JSON with the wrong structure through the same corruption-recovery path before returning an empty `Map`.
-   - Preservation first renames the source and falls back to a byte-for-byte copy if rename is unavailable.
+   - Preservation first renames the source and falls back to a byte-for-byte copy followed by unlinking the source if rename is unavailable.
+   - If copy succeeds but unlink fails, the exact backup is retained and the source remains protected; later saves are blocked with `ESESSIONBACKUPFAILED` and include the removal error.
    - If neither operation succeeds, the store keeps the source in place and blocks later saves with `ESESSIONBACKUPFAILED` so autosave cannot overwrite unrecovered bytes.
-6. Checks the `savedAt` timestamp -- if older than **7 days**, the data is considered stale and an empty `Map` is returned. This intentional expiry does not create a corruption backup.
-7. For each session entry:
+7. Checks the `savedAt` timestamp -- if older than **7 days**, the data is considered stale and an empty `Map` is returned. This intentional expiry does not create a corruption backup.
+8. For each session entry:
    - Skips entries without an `id` field.
    - Deserializes `created` and `lastActivity` back to `Date` objects.
    - Forces `active = false`.
    - Converts `connections` back to an empty `Set`.
-   - Restores `outputBuffer` (defaults to `[]`).
-   - Sets `maxBufferSize` to `1000`.
-   - Restores `usageData` if available.
+   - Restores `outputBuffer` as `CircularBuffer.fromArray(..., 1000, 512 * 1024)` (defaults to an empty array input).
+   - Sets `maxBufferSize` to `1000` (item cap; byte cap is enforced by the buffer).
+   - Restores `sessionUsage` if available.
 
 **Returns:** `Map<sessionId, Session>`.
 
@@ -105,9 +108,17 @@ Deletes the `sessions.json` file entirely.
 
 ### `getSessionMetadata() => Promise<Object>`
 
-Returns metadata about the persistence file without loading full session data.
+Returns metadata about the persistence file without parsing large payloads.
 
-**Success response:**
+Behavior:
+
+1. Opens `sessions.json` once and uses `handle.stat()` from that same handle (no path-level stat/read TOCTOU).
+2. Returns cached `{ savedAt, sessionCount, version }` only when the cached file identity still matches the live file identity (`size + mtimeMs + available dev/ino/ctimeMs fields`); `dev` and `ino` are stored as strings to avoid integer-precision loss.
+3. If cache is cold or stale and file size is <= 64 KiB, reads at most `64 KiB + 1 byte` from the same open handle, and parses only when bytes read are within the limit and non-whitespace.
+4. If fallback bytes exceed 64 KiB, metadata parsing is skipped (never parse oversized fallback reads).
+5. Never reads/parses the full file on the metadata path when the file is large; it still returns `exists: true` and `fileSize`, with unknown metadata fields set to `null` until cache is warmed by save/load.
+
+**Success response (cache warm):**
 ```json
 {
   "exists": true,
@@ -115,6 +126,17 @@ Returns metadata about the persistence file without loading full session data.
   "sessionCount": 5,
   "fileSize": 12345,
   "version": "1.0"
+}
+```
+
+**Success response (existing large file, cache cold):**
+```json
+{
+  "exists": true,
+  "savedAt": null,
+  "sessionCount": null,
+  "fileSize": 73400320,
+  "version": null
 }
 ```
 
@@ -140,7 +162,7 @@ Each session in the `sessions` array has this shape:
   "lastActivity": "2026-02-05T11:00:00.000Z",
   "workingDir": "/home/user/project",
   "active": false,
-  "outputBuffer": ["line1", "line2", "...up to 100"],
+  "outputBuffer": ["line1", "line2", "...bounded tail"],
   "connections": [],
   "lastAccessed": 1738750800000,
   "sessionStartTime": "2026-02-05T10:30:00.000Z",
@@ -177,9 +199,10 @@ The server calls `SessionStore` in these contexts:
 
 The store handles corruption gracefully:
 
-1. **Empty file** -- Detected by checking `!data || !data.trim()`. Returns empty Map.
-2. **Invalid JSON** -- Caught by `JSON.parse` try/catch. The unusable file is moved to a `.corrupted.<timestamp>` sibling, or copied there if rename fails, then returns empty Map.
-3. **Invalid structure** -- Valid JSON that is not an object with a `sessions` array uses the same byte-preserving backup path before returning empty Map.
-4. **Backup failure** -- If both rename and copy fail, the source remains untouched and subsequent saves return `false` with `ESESSIONBACKUPFAILED` without incrementing the ordinary save-failure counter. The in-memory block clears when the protected file is removed, a later load parses successfully, or `clearOldSessions()` removes it.
-5. **Stale data** -- Sessions older than 7 days are intentionally discarded without a backup; a well-formed expired file is not labelled as corruption.
-6. **Invalid session entries** -- Individual entries without an `id` field are silently skipped.
+1. **Empty file** -- Detected by checking `!data || !data.trim()`. Clears metadata cache and returns empty Map.
+2. **Oversized file (>128 MiB default)** -- The file is preserved under `.oversized.<timestamp>` and load returns empty Map for manual recovery instead of startup crash-looping.
+3. **Invalid JSON** -- Caught by `JSON.parse` try/catch. The unusable file is moved to a `.corrupted.<timestamp>` sibling, or copied there if rename fails, then returns empty Map.
+4. **Invalid structure** -- Valid JSON that is not an object with a `sessions` array uses the same byte-preserving backup path before returning empty Map.
+5. **Backup failure** -- If both rename and copy fail, or if fallback unlink fails after an exact copy, the source remains protected and subsequent saves return `false` with `ESESSIONBACKUPFAILED` (including the removal error when applicable) without incrementing the ordinary save-failure counter. The in-memory block clears when the protected file is removed, a later load parses successfully, or `clearOldSessions()` removes it.
+6. **Stale data** -- Sessions older than 7 days are intentionally discarded without a backup; a well-formed expired file is not labelled as corruption.
+7. **Invalid session entries** -- Individual entries without an `id` field are silently skipped.

--- a/docs/specs/sticky-notes.md
+++ b/docs/specs/sticky-notes.md
@@ -95,10 +95,15 @@ basename / `--resume` key), so notes are durable and resume. Binding is resolved
 Terminal tab, ai-or-die sets `AIORDIE_CLAUDE_BIND=<dataDir>/claude-bindings/<sessionId>.json`
 in the shell env. github-router's `SessionStart`/`SessionEnd` hook (`internal-session-bind`)
 atomically writes `{schema, claudeSessionId, transcriptPath, cwd, event, source?, reason?,
-at}` there on every startup / `/resume` / `/clear` / `/compact`. When a sidecar exists it is
-AUTHORITATIVE: the tab binds directly to `transcriptPath` by exact path (no cwd, no mtime),
-rebinding when `claudeSessionId` changes. This survives in-session `/resume`, `/clear` and
-exit→relaunch, and works when `liveCwd` is null (`cmd.exe` / no OSC 7). The hook skips
+at}` there on every startup / `/resume` / `/clear` / `/compact`. Sidecar reads are hard-capped
+at 64 KiB and parsed from a single open/read handle (no stat+full-read path); records are
+accepted only when both `claudeSessionId` and `transcriptPath` are strings. Opening the sidecar
+marks the tab as sidecar-managed before validation, so malformed/oversized sidecars return `null`
+for direct callers yet still suppress newest-mtime inference fallback (preventing cross-tab
+session theft). When a sidecar exists it is AUTHORITATIVE: the tab binds directly to
+`transcriptPath` by exact path (no cwd, no mtime), rebinding when `claudeSessionId` changes. This
+survives in-session `/resume`, `/clear` and exit→relaunch, and works when `liveCwd` is null
+(`cmd.exe` / no OSC 7). The hook skips
 subagent/teammate payloads (`agent_id`/`agent_type`); github-router strips
 `AIORDIE_CLAUDE_BIND` from claude's env so a nested launch can't hijack the tab. A stale
 sidecar is cleared on each terminal (re)start; orphans are swept on startup and on tab close;

--- a/src/server.js
+++ b/src/server.js
@@ -123,6 +123,9 @@ const MAX_COALESCE_BYTES_FG = 32 * 1024;
 const MAX_COALESCE_BYTES_BG = 8 * 1024;
 const BACKPRESSURE_LIMIT_FG = 256 * 1024;
 const BACKPRESSURE_LIMIT_BG = 128 * 1024;
+const SESSION_OUTPUT_BUFFER_CAPACITY = 1000;
+const SESSION_OUTPUT_BUFFER_MAX_BYTES = CircularBuffer.LIVE_OUTPUT_MAX_BYTES;
+const CLAUDE_BIND_SIDECAR_MAX_BYTES = 64 * 1024;
 
 class ClaudeCodeWebServer {
   constructor(options = {}) {
@@ -1502,7 +1505,7 @@ class ClaudeCodeWebServer {
         agent: null, // 'claude' | 'codex' when started
         workingDir: validWorkingDir,
         connections: new Set(),
-        outputBuffer: new CircularBuffer(1000),
+        outputBuffer: new CircularBuffer(SESSION_OUTPUT_BUFFER_CAPACITY, SESSION_OUTPUT_BUFFER_MAX_BYTES),
         priority: 'foreground',
         sessionStartTime: null,
         sessionUsage: {
@@ -1513,7 +1516,7 @@ class ClaudeCodeWebServer {
           totalCost: 0,
           models: {}
         },
-        maxBufferSize: 1000
+        maxBufferSize: SESSION_OUTPUT_BUFFER_CAPACITY
       };
       
       this.claudeSessions.set(sessionId, session);
@@ -4116,7 +4119,7 @@ class ClaudeCodeWebServer {
       active: false,
       workingDir: validWorkingDir,
       connections: new Set([wsId]),
-      outputBuffer: new CircularBuffer(1000),
+      outputBuffer: new CircularBuffer(SESSION_OUTPUT_BUFFER_CAPACITY, SESSION_OUTPUT_BUFFER_MAX_BYTES),
       priority: 'foreground',
       sessionStartTime: null, // Will be set when Claude starts
       sessionUsage: {
@@ -4127,7 +4130,7 @@ class ClaudeCodeWebServer {
         totalCost: 0,
         models: {}
       },
-      maxBufferSize: 1000,
+      maxBufferSize: SESSION_OUTPUT_BUFFER_CAPACITY,
       // Sticky-note (local-LLM summary) state. Disabled by default; a client can
       // explicitly opt in via set_sticky_notes. autoTitle/nameIsUserSet drive
       // model-free Claude tab titling without clobbering a manual rename.
@@ -4271,16 +4274,7 @@ class ClaudeCodeWebServer {
           ? session.outputBuffer.toArray()
           : []
       );
-    let bytes = 0;
-    let start = items.length;
-    while (start > 0) {
-      const item = items[start - 1];
-      const itemBytes = Buffer.byteLength(typeof item === 'string' ? item : String(item || ''), 'utf8');
-      if (bytes > 0 && bytes + itemBytes > maxBytes) break;
-      bytes += itemBytes;
-      start--;
-    }
-    return items.slice(start);
+    return CircularBuffer.newestItemsWithinBytes(items, maxBytes);
   }
 
   async leaveClaudeSession(wsId) {
@@ -4794,7 +4788,7 @@ class ClaudeCodeWebServer {
         agent: null, // 'claude' | 'codex' when started
         workingDir: validWorkingDir,
         connections: new Set(),
-        outputBuffer: new CircularBuffer(1000),
+        outputBuffer: new CircularBuffer(SESSION_OUTPUT_BUFFER_CAPACITY, SESSION_OUTPUT_BUFFER_MAX_BYTES),
         priority: 'foreground',
         sessionStartTime: null,
         sessionUsage: {
@@ -4805,7 +4799,7 @@ class ClaudeCodeWebServer {
           totalCost: 0,
           models: {}
         },
-        maxBufferSize: 1000
+        maxBufferSize: SESSION_OUTPUT_BUFFER_CAPACITY
       };
 
       this.claudeSessions.set(sessionId, session);
@@ -6455,23 +6449,37 @@ class ClaudeCodeWebServer {
   /**
    * Read + parse the tab's sidecar (written atomically by github-router's hook).
    * Returns the parsed record `{claudeSessionId, transcriptPath, cwd, event,
-   * source?, reason?}` or null (no file / unreadable / malformed). The file is
-   * tiny, so we re-read every tick (no mtime cache: a SessionEnd→SessionStart
+   * source?, reason?}` or null (no file / unreadable / malformed). Reads are
+   * hard-capped at 64 KiB from a single open/read handle, then parsed each tick
+   * (no mtime cache: a SessionEnd→SessionStart
    * rewrite on /resume can land in the same mtime tick, and a cache keyed on
    * mtime would then serve the stale record and never rebind). Never throws — any
-   * error yields null so the poll is unaffected.
+   * error yields null so the poll is unaffected. A successfully opened sidecar
+   * marks `session._sidecarSeen = true` BEFORE validation so malformed/oversized
+   * content cannot fall through to newest-mtime inference in _pumpStickyJsonl.
    */
   async _readClaudeBindSidecar(session) {
     if (!session || !session.claudeBindSidecar) return null;
-    let raw;
+    let handle = null;
+    let raw = '';
     try {
-      raw = await fs.promises.readFile(session.claudeBindSidecar, 'utf8');
+      handle = await fs.promises.open(session.claudeBindSidecar, 'r');
+      session._sidecarSeen = true;
+      const chunk = Buffer.alloc(CLAUDE_BIND_SIDECAR_MAX_BYTES + 1);
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, 0);
+      if (bytesRead <= 0 || bytesRead > CLAUDE_BIND_SIDECAR_MAX_BYTES) return null;
+      raw = chunk.toString('utf8', 0, bytesRead);
     } catch (_) {
       return null; // no sidecar yet (claude not launched via github-router, or pending)
+    } finally {
+      if (handle) {
+        try { await handle.close(); } catch (_) { /* best effort */ }
+      }
     }
     try {
       const obj = JSON.parse(raw);
-      if (!obj || typeof obj !== 'object' || typeof obj.claudeSessionId !== 'string') return null;
+      if (!obj || typeof obj !== 'object') return null;
+      if (typeof obj.claudeSessionId !== 'string' || typeof obj.transcriptPath !== 'string') return null;
       return obj;
     } catch (_) {
       return null; // mid-write / malformed → skip this tick

--- a/src/utils/circular-buffer.js
+++ b/src/utils/circular-buffer.js
@@ -1,5 +1,74 @@
 'use strict';
 
+const LIVE_OUTPUT_MAX_BYTES = 512 * 1024; // 512 KiB
+
+function isHighSurrogate(code) {
+  return code >= 0xD800 && code <= 0xDBFF;
+}
+
+function isLowSurrogate(code) {
+  return code >= 0xDC00 && code <= 0xDFFF;
+}
+
+function trimUtf8Suffix(value, maxBytes) {
+  const limit = Number.isFinite(maxBytes) && maxBytes > 0
+    ? Math.floor(maxBytes)
+    : 0;
+  if (limit === 0 || !value) {
+    return { value: '', bytes: 0 };
+  }
+
+  const totalBytes = Buffer.byteLength(value, 'utf8');
+  if (totalBytes <= limit) {
+    return { value, bytes: totalBytes };
+  }
+
+  // Find the smallest raw UTF-16 start index whose suffix fits in `limit`
+  // bytes. Do not align the probe: moving a probe forward while it is inside
+  // a surrogate pair can otherwise make the binary search stop making
+  // progress. The raw suffix byte length is monotonic, so this search always
+  // converges.
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    const bytes = Buffer.byteLength(value.slice(mid), 'utf8');
+    if (bytes > limit) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+
+  // Align only after convergence. A raw search can land on the low surrogate
+  // of a pair. Include the complete pair when it still fits; otherwise skip
+  // the low surrogate. Both choices are guaranteed to be valid and within the
+  // byte budget, with no replacement character introduced by truncation.
+  let start = low;
+  if (
+    start > 0 &&
+    start < value.length &&
+    isLowSurrogate(value.charCodeAt(start)) &&
+    isHighSurrogate(value.charCodeAt(start - 1))
+  ) {
+    const pairStart = start - 1;
+    if (Buffer.byteLength(value.slice(pairStart), 'utf8') <= limit) {
+      start = pairStart;
+    } else {
+      start++;
+    }
+  }
+
+  // Encode/copy ONLY the bounded suffix so the retained value cannot keep
+  // a giant original string alive through V8 substring sharing.
+  const suffix = value.slice(start);
+  const encodedSuffix = Buffer.from(suffix, 'utf8');
+  return {
+    value: encodedSuffix.toString('utf8'),
+    bytes: encodedSuffix.length,
+  };
+}
+
 /**
  * Fixed-capacity circular buffer with O(1) push and eviction.
  * Drop-in replacement for the capped array pattern:
@@ -8,8 +77,11 @@
  * Provides Array-compatible .slice(), .toArray(), .toJSON(), and iteration.
  */
 class CircularBuffer {
-  constructor(capacity) {
+  constructor(capacity, maxBytes) {
     this.capacity = capacity;
+    this.maxBytes = Number.isFinite(maxBytes) && maxBytes > 0
+      ? Math.floor(maxBytes)
+      : null;
     this.buffer = new Array(capacity);
     this._itemByteLengths = new Array(capacity).fill(0);
     this.head = 0;   // next write position
@@ -17,17 +89,106 @@ class CircularBuffer {
     this.byteLength = 0;
   }
 
+  static _toString(item) {
+    return typeof item === 'string' ? item : String(item || '');
+  }
+
+  static measureItemBytes(item) {
+    if (Buffer.isBuffer(item)) return item.length;
+    return Buffer.byteLength(CircularBuffer._toString(item), 'utf8');
+  }
+
+  static boundedItemSuffix(item, maxBytes) {
+    const limit = Number.isFinite(maxBytes) && maxBytes > 0
+      ? Math.floor(maxBytes)
+      : 0;
+    if (limit === 0) {
+      return { item: '', bytes: 0 };
+    }
+
+    const bytes = CircularBuffer.measureItemBytes(item);
+    if (bytes <= limit) {
+      return { item, bytes };
+    }
+    if (Buffer.isBuffer(item)) {
+      const suffix = Buffer.from(item.subarray(item.length - limit));
+      return { item: suffix, bytes: suffix.length };
+    }
+    const trimmed = trimUtf8Suffix(CircularBuffer._toString(item), limit);
+    return { item: trimmed.value, bytes: trimmed.bytes };
+  }
+
+  static newestItemsWithinBytes(items, maxBytes) {
+    if (!Array.isArray(items) || items.length === 0) return [];
+    const limit = Number.isFinite(maxBytes) && maxBytes > 0
+      ? Math.floor(maxBytes)
+      : 0;
+    if (limit === 0) return [];
+
+    const kept = [];
+    let totalBytes = 0;
+    for (let i = items.length - 1; i >= 0; i--) {
+      if (totalBytes >= limit) break;
+      const remaining = limit - totalBytes;
+      const original = items[i];
+      const originalBytes = CircularBuffer.measureItemBytes(original);
+      if (originalBytes <= remaining) {
+        kept.push(original);
+        totalBytes += originalBytes;
+        continue;
+      }
+
+      const trimmed = CircularBuffer.boundedItemSuffix(original, remaining);
+      if (trimmed.bytes > 0) {
+        kept.push(trimmed.item);
+      }
+      break;
+    }
+    kept.reverse();
+    return kept;
+  }
+
+  _measureItemBytes(item) {
+    return CircularBuffer.measureItemBytes(item);
+  }
+
+  _normalizeItem(item) {
+    const bytes = this._measureItemBytes(item);
+    if (!this.maxBytes) return { item, bytes };
+    return CircularBuffer.boundedItemSuffix(item, this.maxBytes);
+  }
+
+  _evictOldest() {
+    if (this.size === 0) return;
+    const oldest = (this.head - this.size + this.capacity) % this.capacity;
+    this.byteLength -= this._itemByteLengths[oldest];
+    this._itemByteLengths[oldest] = 0;
+    this.buffer[oldest] = undefined;
+    this.size--;
+  }
+
   /** Add an item, evicting the oldest if at capacity. O(1). */
   push(item) {
-    const bytes = Buffer.isBuffer(item)
-      ? item.length
-      : Buffer.byteLength(typeof item === 'string' ? item : String(item || ''), 'utf8');
-    this.byteLength -= this._itemByteLengths[this.head];
-    this.buffer[this.head] = item;
+    const normalized = this._normalizeItem(item);
+    const storedItem = normalized.item;
+    const bytes = normalized.bytes;
+
+    if (this.maxBytes) {
+      while (this.size > 0 && this.byteLength + bytes > this.maxBytes) {
+        this._evictOldest();
+      }
+    }
+
+    if (this.size === this.capacity) {
+      this.byteLength -= this._itemByteLengths[this.head];
+    } else {
+      this.size++;
+    }
+
+    this.buffer[this.head] = storedItem;
     this._itemByteLengths[this.head] = bytes;
     this.byteLength += bytes;
     this.head = (this.head + 1) % this.capacity;
-    if (this.size < this.capacity) this.size++;
   }
 
   /**
@@ -78,11 +239,15 @@ class CircularBuffer {
   }
 
   /** Reconstruct a CircularBuffer from a plain array (e.g., after JSON deserialization). */
-  static fromArray(arr, capacity) {
-    const buf = new CircularBuffer(capacity);
+  static fromArray(arr, capacity, maxBytes) {
+    const buf = new CircularBuffer(capacity, maxBytes);
     for (const item of arr) buf.push(item);
     return buf;
   }
 }
 
+CircularBuffer.LIVE_OUTPUT_MAX_BYTES = LIVE_OUTPUT_MAX_BYTES;
+CircularBuffer.trimUtf8Suffix = trimUtf8Suffix;
+
 module.exports = CircularBuffer;
+module.exports.LIVE_OUTPUT_MAX_BYTES = LIVE_OUTPUT_MAX_BYTES;

--- a/src/utils/session-store.js
+++ b/src/utils/session-store.js
@@ -3,7 +3,11 @@ const path = require('path');
 const os = require('os');
 const CircularBuffer = require('./circular-buffer');
 
-const MAX_BUFFER_BYTES_PER_SESSION = 512 * 1024; // 512KB per-session byte cap
+const SESSION_OUTPUT_BUFFER_CAPACITY = 1000;
+const MAX_BUFFER_BYTES_PER_SESSION = CircularBuffer.LIVE_OUTPUT_MAX_BYTES;
+const METADATA_FALLBACK_MAX_BYTES = 64 * 1024;
+const DEFAULT_MAX_SAFE_LOAD_BYTES = 128 * 1024 * 1024;
+const FILE_READ_CHUNK_BYTES = 64 * 1024;
 
 /**
  * Migrate a persisted sticky note to the v2 shape:
@@ -77,6 +81,10 @@ class SessionStore {
         // call waits for the prior in-flight save to settle before
         // entering the write critical section.
         this._inFlightSave = Promise.resolve();
+        this._sessionMetadataCache = null;
+        this.maxSafeLoadBytes = Number.isFinite(options.maxSafeLoadBytes) && options.maxSafeLoadBytes > 0
+            ? Math.floor(options.maxSafeLoadBytes)
+            : DEFAULT_MAX_SAFE_LOAD_BYTES;
         this.initializeStorage();
     }
 
@@ -93,7 +101,10 @@ class SessionStore {
         // Walk backwards from the end (newest lines) summing byte lengths
         let startIndex = lines.length;
         for (let i = lines.length - 1; i >= 0; i--) {
-            const lineBytes = Buffer.byteLength(lines[i] || '', 'utf8');
+            const line = lines[i];
+            const lineBytes = Buffer.isBuffer(line)
+                ? line.length
+                : Buffer.byteLength(typeof line === 'string' ? line : String(line || ''), 'utf8');
             if (totalBytes + lineBytes > MAX_BUFFER_BYTES_PER_SESSION) break;
             totalBytes += lineBytes;
             startIndex = i;
@@ -222,7 +233,7 @@ class SessionStore {
                 wasActive: session.active || false, // Preserve active state for restart awareness
                 agent: session.agent || null, // Which tool was running (claude, codex, etc.)
                 outputBuffer: (session.outputBuffer && typeof session.outputBuffer.slice === 'function')
-                    ? this._capBufferByBytes(session.outputBuffer.slice(-1000)) : [], // Keep last 1000 lines, capped at 512KB
+                    ? this._capBufferByBytes(session.outputBuffer.slice(-SESSION_OUTPUT_BUFFER_CAPACITY)) : [], // Keep last 1000 lines, capped at 512KB
                 connections: [], // Clear connections (they won't persist)
                 lastAccessed: session.lastAccessed || Date.now(),
                 // Session-specific usage tracking
@@ -338,6 +349,11 @@ class SessionStore {
             }
 
             this._dirty = false;
+            let savedStats = null;
+            try {
+                savedStats = await fs.stat(this.sessionsFile);
+            } catch (_) { /* best effort */ }
+            this._cacheSessionMetadata(data, savedStats);
             this._lastSaveError = null;
             return true;
         } catch (error) {
@@ -348,43 +364,100 @@ class SessionStore {
         }
     }
 
+    async _readHandleUpTo(handle, maxBytes, chunkBytes = FILE_READ_CHUNK_BYTES) {
+        const chunks = [];
+        let totalBytes = 0;
+        const hardLimit = maxBytes + 1;
+
+        while (totalBytes < hardLimit) {
+            const length = Math.min(chunkBytes, hardLimit - totalBytes);
+            const chunk = Buffer.alloc(length);
+            const result = await handle.read(chunk, 0, length, totalBytes);
+            if (!result.bytesRead) break;
+            chunks.push(result.bytesRead === chunk.length
+                ? chunk
+                : chunk.subarray(0, result.bytesRead));
+            totalBytes += result.bytesRead;
+            if (result.bytesRead < length) break;
+        }
+
+        return {
+            buffer: Buffer.concat(chunks, totalBytes),
+            bytesRead: totalBytes,
+            oversized: totalBytes > maxBytes
+        };
+    }
+
     async loadSessions() {
+        let handle = null;
         try {
-            // Check if sessions file exists
-            await fs.access(this.sessionsFile);
-            
-            const data = await fs.readFile(this.sessionsFile, 'utf8');
-            
+            handle = await fs.open(this.sessionsFile, 'r');
+            const stats = await handle.stat();
+
+            if (stats.size > this.maxSafeLoadBytes) {
+                this._sessionMetadataCache = null;
+                console.log(
+                    `Sessions file exceeds safe load limit (${this.maxSafeLoadBytes} bytes); preserving for manual recovery and starting fresh`
+                );
+                await handle.close();
+                handle = null;
+                await this._preserveUnusableSessionsFile('oversized load limit exceeded', 'oversized');
+                return new Map();
+            }
+
+            const readResult = await this._readHandleUpTo(handle, this.maxSafeLoadBytes);
+            const readStats = await handle.stat();
+            if (readResult.oversized || readStats.size > this.maxSafeLoadBytes) {
+                this._sessionMetadataCache = null;
+                console.log(
+                    `Sessions file exceeds safe load limit (${this.maxSafeLoadBytes} bytes); preserving for manual recovery and starting fresh`
+                );
+                await handle.close();
+                handle = null;
+                await this._preserveUnusableSessionsFile('oversized load limit exceeded', 'oversized');
+                return new Map();
+            }
+
+            const data = readResult.buffer.toString('utf8');
+
             // Check if file is empty or just whitespace
             if (!data || !data.trim()) {
+                this._sessionMetadataCache = null;
                 console.log('Sessions file is empty, starting fresh');
                 return new Map();
             }
-            
+
             let parsed;
             try {
                 parsed = JSON.parse(data);
             } catch (parseError) {
-                console.error('Sessions file is corrupted, starting fresh:', parseError.message);
+                this._sessionMetadataCache = null;
+                console.error('Sessions file is invalid JSON, starting fresh:', parseError.message);
+                await handle.close();
+                handle = null;
                 await this._preserveUnusableSessionsFile('invalid JSON');
                 return new Map();
             }
-            
+
             // Validate parsed data structure
             if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.sessions)) {
+                this._sessionMetadataCache = null;
                 console.log('Invalid sessions file format, starting fresh');
+                await handle.close();
+                handle = null;
                 await this._preserveUnusableSessionsFile('invalid structure');
                 return new Map();
             }
 
             this._clearSaveBlock();
-            
+            this._cacheSessionMetadata(parsed, readStats);
+
             // Check if data is recent (within last 7 days)
             if (parsed.savedAt) {
                 const savedAt = new Date(parsed.savedAt);
                 const now = new Date();
                 const daysSinceSave = (now - savedAt) / (1000 * 60 * 60 * 24);
-                
+
                 if (daysSinceSave > 7) {
                     console.log('Sessions are too old, starting fresh');
                     return new Map();
@@ -395,7 +468,7 @@ class SessionStore {
             const sessions = new Map();
             for (const session of parsed.sessions) {
                 if (!session || !session.id) continue; // Skip invalid sessions
-                
+
                 // Restore session with default values for runtime properties
                 sessions.set(session.id, {
                     ...session,
@@ -404,8 +477,8 @@ class SessionStore {
                     lastActivity: session.lastActivity ? new Date(session.lastActivity) : new Date(),
                     active: false,
                     connections: new Set(),
-                    outputBuffer: CircularBuffer.fromArray(session.outputBuffer || [], 1000),
-                    maxBufferSize: 1000,
+                    outputBuffer: CircularBuffer.fromArray(session.outputBuffer || [], SESSION_OUTPUT_BUFFER_CAPACITY, MAX_BUFFER_BYTES_PER_SESSION),
+                    maxBufferSize: SESSION_OUTPUT_BUFFER_CAPACITY,
                     // Restore usage data if available (saved under sessionUsage key)
                     sessionUsage: session.sessionUsage || null
                 });
@@ -414,11 +487,16 @@ class SessionStore {
             console.log(`Restored ${sessions.size} sessions from disk`);
             return sessions;
         } catch (error) {
+            this._sessionMetadataCache = null;
             // File doesn't exist or other errors, return empty Map
             if (error.code !== 'ENOENT') {
                 console.error('Failed to load sessions:', error.message);
             }
             return new Map();
+        } finally {
+            if (handle) {
+                try { await handle.close(); } catch (_) { /* best effort */ }
+            }
         }
     }
 
@@ -430,8 +508,19 @@ class SessionStore {
         }
     }
 
-    async _preserveUnusableSessionsFile(reason) {
-        const backupFile = `${this.sessionsFile}.corrupted.${Date.now()}`;
+    _setSaveBlockedReason(details) {
+        this._saveBlockedReason = details;
+        this._saveBlockedWarningLogged = false;
+        const error = new Error(
+            'Session save blocked because ' + this.sessionsFile + ' could not be preserved'
+        );
+        error.code = 'ESESSIONBACKUPFAILED';
+        error.reason = details;
+        this._lastSaveError = error;
+    }
+
+    async _preserveUnusableSessionsFile(reason, tag = 'corrupted') {
+        const backupFile = `${this.sessionsFile}.${tag}.${Date.now()}`;
         let fileStats = null;
         try {
             fileStats = await fs.stat(this.sessionsFile);
@@ -448,12 +537,14 @@ class SessionStore {
             renameError = error;
         }
 
+        let copyError;
         try {
             await fs.copyFile(this.sessionsFile, backupFile);
-            this._clearSaveBlock();
-            return backupFile;
-        } catch (copyError) {
-            this._saveBlockedReason = {
+        } catch (error) {
+            copyError = error;
+        }
+        if (copyError) {
+            const details = {
                 reason,
                 at: Date.now(),
                 file: this.sessionsFile,
@@ -462,10 +553,36 @@ class SessionStore {
                 renameError,
                 copyError
             };
-            this._saveBlockedWarningLogged = false;
+            this._setSaveBlockedReason(details);
             console.error(
                 `Failed to preserve unusable sessions file (${reason}); future saves are blocked:`,
                 copyError.message
+            );
+            return null;
+        }
+
+        // A copy is only a recovery if the original is removed. If removal
+        // fails, retain the protection latch so autosave cannot overwrite the
+        // unrecovered source, while the completed copy remains byte-exact.
+        try {
+            await fs.unlink(this.sessionsFile);
+            this._clearSaveBlock();
+            return backupFile;
+        } catch (removeError) {
+            const details = {
+                reason,
+                at: Date.now(),
+                file: this.sessionsFile,
+                size: fileStats ? fileStats.size : null,
+                mtimeMs: fileStats ? fileStats.mtimeMs : null,
+                renameError,
+                removeError,
+                backupFile
+            };
+            this._setSaveBlockedReason(details);
+            console.error(
+                `Failed to remove original unusable sessions file (${reason}); future saves are blocked:`,
+                removeError.message
             );
             return null;
         }
@@ -500,6 +617,7 @@ class SessionStore {
         try {
             await fs.unlink(this.sessionsFile);
             this._clearSaveBlock();
+            this._sessionMetadataCache = null;
             console.log('Cleared old sessions');
             return true;
         } catch (error) {
@@ -510,25 +628,96 @@ class SessionStore {
         }
     }
 
+    _fileIdentityFromStats(stats) {
+        if (!stats || typeof stats !== 'object') return null;
+        const identity = {
+            size: stats.size,
+            mtimeMs: stats.mtimeMs,
+        };
+        if (stats.dev !== undefined && stats.dev !== null) identity.dev = String(stats.dev);
+        if (stats.ino !== undefined && stats.ino !== null) identity.ino = String(stats.ino);
+        if (typeof stats.ctimeMs === 'number') identity.ctimeMs = stats.ctimeMs;
+        return identity;
+    }
+
+    _sameFileIdentity(a, b) {
+        if (!a || !b) return false;
+        const keys = ['size', 'mtimeMs', 'dev', 'ino', 'ctimeMs'];
+        for (const key of keys) {
+            const hasA = Object.prototype.hasOwnProperty.call(a, key);
+            const hasB = Object.prototype.hasOwnProperty.call(b, key);
+            if (hasA !== hasB) return false;
+            if (hasA && a[key] !== b[key]) return false;
+        }
+        return true;
+    }
+
+    _cacheSessionMetadata(parsed, stats) {
+        if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.sessions)) {
+            this._sessionMetadataCache = null;
+            return;
+        }
+        this._sessionMetadataCache = {
+            savedAt: typeof parsed.savedAt === 'string' ? parsed.savedAt : null,
+            sessionCount: parsed.sessions.length,
+            version: typeof parsed.version === 'string' ? parsed.version : null,
+            identity: this._fileIdentityFromStats(stats),
+        };
+    }
+
     async getSessionMetadata() {
+        let handle = null;
         try {
-            await fs.access(this.sessionsFile);
-            const stats = await fs.stat(this.sessionsFile);
-            const data = await fs.readFile(this.sessionsFile, 'utf8');
-            const parsed = JSON.parse(data);
-            
+            handle = await fs.open(this.sessionsFile, 'r');
+            const stats = await handle.stat();
+            const identity = this._fileIdentityFromStats(stats);
+
+            if (this._sessionMetadataCache && !this._sameFileIdentity(this._sessionMetadataCache.identity, identity)) {
+                this._sessionMetadataCache = null;
+            }
+
+            if (!this._sessionMetadataCache) {
+                try {
+                    const readResult = await this._readHandleUpTo(
+                        handle,
+                        METADATA_FALLBACK_MAX_BYTES,
+                        METADATA_FALLBACK_MAX_BYTES + 1
+                    );
+                    if (readResult.bytesRead > 0 && !readResult.oversized) {
+                        const data = readResult.buffer.toString('utf8');
+                        if (data.trim()) {
+                            const parsed = JSON.parse(data);
+                            this._cacheSessionMetadata(parsed, stats);
+                        } else {
+                            this._sessionMetadataCache = null;
+                        }
+                    } else {
+                        this._sessionMetadataCache = null;
+                    }
+                } catch (_) {
+                    // Best-effort fallback only. For large files we never parse here.
+                    this._sessionMetadataCache = null;
+                }
+            }
+
+            const metadata = this._sessionMetadataCache;
             return {
                 exists: true,
-                savedAt: parsed.savedAt,
-                sessionCount: parsed.sessions ? parsed.sessions.length : 0,
+                savedAt: metadata ? metadata.savedAt : null,
+                sessionCount: metadata ? metadata.sessionCount : null,
                 fileSize: stats.size,
-                version: parsed.version
+                version: metadata ? metadata.version : null
             };
         } catch (error) {
+            this._sessionMetadataCache = null;
             return {
                 exists: false,
                 error: error.message
             };
+        } finally {
+            if (handle) {
+                try { await handle.close(); } catch (_) { /* best effort */ }
+            }
         }
     }
 }

--- a/test/circular-buffer.test.js
+++ b/test/circular-buffer.test.js
@@ -8,6 +8,10 @@ describe('CircularBuffer', () => {
       assert.strictEqual(buf.length, 0);
       assert.strictEqual(buf.capacity, 5);
     });
+
+    it('exposes the shared live-output byte cap constant', () => {
+      assert.strictEqual(CircularBuffer.LIVE_OUTPUT_MAX_BYTES, 512 * 1024);
+    });
   });
 
   describe('push', () => {
@@ -43,6 +47,115 @@ describe('CircularBuffer', () => {
       assert.strictEqual(buf.byteLength, 5);
       buf.push('z');
       assert.strictEqual(buf.byteLength, 4);
+    });
+
+    it('keeps legacy count-only behavior when maxBytes is omitted', () => {
+      const buf = new CircularBuffer(2);
+      buf.push('x'.repeat(CircularBuffer.LIVE_OUTPUT_MAX_BYTES));
+      buf.push('y');
+      assert.strictEqual(buf.length, 2);
+      assert.strictEqual(buf.byteLength, CircularBuffer.LIVE_OUTPUT_MAX_BYTES + 1);
+    });
+
+    it('enforces maxBytes by evicting oldest entries', () => {
+      const buf = new CircularBuffer(5, 10);
+      buf.push('1234');
+      buf.push('5678');
+      buf.push('zzzz');
+      assert.deepStrictEqual(buf.toArray(), ['5678', 'zzzz']);
+      assert.strictEqual(buf.byteLength, 8);
+    });
+
+    it('retains a UTF-8-valid newest string suffix when a single item is oversized', () => {
+      const buf = new CircularBuffer(5, 5);
+      buf.push('ab😀');
+      const stored = buf.toArray()[0];
+      assert.strictEqual(stored, 'b😀');
+      assert.strictEqual(Buffer.byteLength(stored, 'utf8'), 5);
+    });
+
+    it('retains a copied newest Buffer suffix when a single item is oversized', () => {
+      const source = Buffer.from('abcdefghij');
+      const buf = new CircularBuffer(5, 4);
+      buf.push(source);
+      const stored = buf.toArray()[0];
+      assert.ok(Buffer.isBuffer(stored));
+      assert.strictEqual(stored.toString('utf8'), 'ghij');
+      source[source.length - 1] = 'Z'.charCodeAt(0);
+      assert.strictEqual(stored.toString('utf8'), 'ghij');
+      assert.strictEqual(buf.byteLength, 4);
+    });
+
+    it('maintains exact byteLength while truncating and evicting for maxBytes', () => {
+      const buf = new CircularBuffer(3, 6);
+      buf.push('é');
+      buf.push('abc');
+      buf.push('zzzz');
+      assert.deepStrictEqual(buf.toArray(), ['zzzz']);
+      assert.strictEqual(buf.byteLength, 4);
+    });
+
+    it('combines wrap-around with maxBytes eviction and keeps the newest suffix', () => {
+      const buf = new CircularBuffer(3, 10);
+      buf.push('aa');
+      buf.push('bbbb');
+      buf.push('cc');
+      buf.push('dddd');
+      buf.push('eeee');
+      assert.deepStrictEqual(buf.toArray(), ['cc', 'dddd', 'eeee']);
+      assert.strictEqual(buf.byteLength, 10);
+    });
+  });
+
+  describe('UTF-8 suffix trimming', () => {
+    it('trims emoji-only strings without replacement characters', () => {
+      const expected = ['', '', '', '😀'];
+      for (const [index, limit] of [1, 2, 3, 4].entries()) {
+        const result = CircularBuffer.trimUtf8Suffix('😀', limit);
+        assert.strictEqual(result.value, expected[index]);
+        assert.ok(result.bytes <= limit);
+        assert.strictEqual(result.value.includes('\uFFFD'), false);
+      }
+    });
+
+    it('keeps only complete newest emoji pairs for repeated emoji', () => {
+      for (const limit of [1, 2, 3]) {
+        const result = CircularBuffer.trimUtf8Suffix('😀😀', limit);
+        assert.strictEqual(result.value, '');
+        assert.strictEqual(result.bytes, 0);
+      }
+      assert.strictEqual(CircularBuffer.trimUtf8Suffix('😀😀', 4).value, '😀');
+      assert.strictEqual(CircularBuffer.trimUtf8Suffix('😀😀', 5).value, '😀');
+      assert.strictEqual(CircularBuffer.trimUtf8Suffix('😀😀', 8).value, '😀😀');
+    });
+
+    it('handles raw UTF-16 odd-index cuts without U+FFFD', () => {
+      const expected = new Map([
+        [1, 'B'],
+        [2, 'B'],
+        [3, 'B'],
+        [4, 'B'],
+        [5, '😀B'],
+        [6, 'A😀B'],
+      ]);
+      for (const [limit, value] of expected) {
+        const result = CircularBuffer.trimUtf8Suffix('A😀B', limit);
+        assert.strictEqual(result.value, value);
+        assert.ok(result.bytes <= limit);
+        assert.strictEqual(result.value.includes('\uFFFD'), false);
+      }
+    });
+
+    it('keeps the byte cap for push and newestItemsWithinBytes with emoji values', () => {
+      const buf = new CircularBuffer(5, 5);
+      buf.push('😀😀');
+      assert.deepStrictEqual(buf.toArray(), ['😀']);
+      assert.strictEqual(buf.byteLength, 4);
+
+      const items = CircularBuffer.newestItemsWithinBytes(['old', '😀😀', 'tail'], 8);
+      assert.deepStrictEqual(items, ['😀', 'tail']);
+      assert.ok(items.reduce((total, item) => total + Buffer.byteLength(item, 'utf8'), 0) <= 8);
+      assert.strictEqual(items.join('').includes('\uFFFD'), false);
     });
   });
 
@@ -139,6 +252,12 @@ describe('CircularBuffer', () => {
       const buf = CircularBuffer.fromArray([], 5);
       assert.strictEqual(buf.length, 0);
       assert.deepStrictEqual(buf.toArray(), []);
+    });
+
+    it('supports maxBytes when reconstructing from a plain array', () => {
+      const buf = CircularBuffer.fromArray(['aaaa', 'bbbb', 'cccc'], 5, 8);
+      assert.deepStrictEqual(buf.toArray(), ['bbbb', 'cccc']);
+      assert.strictEqual(buf.byteLength, 8);
     });
   });
 

--- a/test/join-replay-buffer.test.js
+++ b/test/join-replay-buffer.test.js
@@ -4,6 +4,13 @@ const assert = require('assert');
 const { ClaudeCodeWebServer } = require('../src/server');
 const CircularBuffer = require('../src/utils/circular-buffer');
 
+function replayBytes(items) {
+  return items.reduce((total, item) => {
+    if (Buffer.isBuffer(item)) return total + item.length;
+    return total + Buffer.byteLength(typeof item === 'string' ? item : String(item || ''), 'utf8');
+  }, 0);
+}
+
 describe('session join replay buffer', function () {
   it('keeps the newest chunks within the byte budget', function () {
     const outputBuffer = new CircularBuffer(1000);
@@ -15,17 +22,36 @@ describe('session join replay buffer', function () {
       8
     );
     assert.deepStrictEqual(replay, ['67890', 'abc']);
+    assert.ok(replayBytes(replay) <= 8);
   });
 
-  it('retains the newest chunk when it alone exceeds the budget', function () {
+  it('trims an oversized newest string chunk so replay bytes never exceed the budget', function () {
     const outputBuffer = new CircularBuffer(1000);
     outputBuffer.push('older');
-    outputBuffer.push('newest-is-large');
+    outputBuffer.push('ab😀');
+    const replay = ClaudeCodeWebServer.prototype._buildJoinReplay(
+      { outputBuffer },
+      5
+    );
+    assert.deepStrictEqual(replay, ['b😀']);
+    assert.ok(replayBytes(replay) <= 5);
+  });
+
+  it('trims an oversized newest Buffer chunk to a copied suffix', function () {
+    const source = Buffer.from('abcdefghij');
+    const outputBuffer = new CircularBuffer(1000);
+    outputBuffer.push('older');
+    outputBuffer.push(source);
     const replay = ClaudeCodeWebServer.prototype._buildJoinReplay(
       { outputBuffer },
       4
     );
-    assert.deepStrictEqual(replay, ['newest-is-large']);
+    assert.strictEqual(replay.length, 1);
+    assert.ok(Buffer.isBuffer(replay[0]));
+    assert.strictEqual(replay[0].toString('utf8'), 'ghij');
+    source[source.length - 1] = 'Z'.charCodeAt(0);
+    assert.strictEqual(replay[0].toString('utf8'), 'ghij');
+    assert.ok(replayBytes(replay) <= 4);
   });
 
   it('excludes geometry-held output that will be released after the join frame', function () {

--- a/test/longevity/process/supervisor-retention-probes.test.js
+++ b/test/longevity/process/supervisor-retention-probes.test.js
@@ -16,6 +16,8 @@ const TerminalBridge = require('../../../src/terminal-bridge');
 const ClaudeBridge = require('../../../src/claude-bridge');
 const { ControlEventBus } = require('../../../src/control/event-bus');
 
+const SESSION_OUTPUT_BUFFER_MAX_BYTES = CircularBuffer.LIVE_OUTPUT_MAX_BYTES;
+
 let ClaudeCodeWebServer;
 try {
   ({ ClaudeCodeWebServer } = require('../../../src/server'));
@@ -62,7 +64,7 @@ function makeSession(id, active = false) {
     agent: null,
     workingDir: process.cwd(),
     connections: new Set(),
-    outputBuffer: new CircularBuffer(1000),
+    outputBuffer: new CircularBuffer(1000, SESSION_OUTPUT_BUFFER_MAX_BYTES),
     priority: 'foreground',
     stickyNotesEnabled: false,
   };
@@ -71,6 +73,11 @@ function makeSession(id, active = false) {
 function makeChunk(index, bytes) {
   const prefix = `chunk-${index.toString().padStart(4, '0')}:`;
   return prefix + 'x'.repeat(bytes - Buffer.byteLength(prefix));
+}
+
+function chunkIndex(chunk) {
+  const match = /^chunk-(\d+):/.exec(chunk);
+  return match ? Number(match[1]) : null;
 }
 
 function waitForBridgeExit(bridge, sessionId, options = {}) {
@@ -180,7 +187,7 @@ function waitForBridgeExit(bridge, sessionId, options = {}) {
     );
   });
 
-  it('proves the real PTY onOutput sink is chunk-counted rather than byte- or line-counted', async function () {
+  it('proves the real PTY onOutput sink keeps a newline-free tail capped at 512 KiB', async function () {
     const sessionId = 'pty-chunk-bound';
     const session = makeSession(sessionId);
     server.claudeSessions.set(sessionId, session);
@@ -206,27 +213,64 @@ function waitForBridgeExit(bridge, sessionId, options = {}) {
       callbacks.onOutput(makeChunk(index, chunkBytes));
     }
 
+    const retained = session.outputBuffer.toArray();
+    const retainedIndexes = retained.map((chunk) => chunkIndex(chunk));
+    const expectedStart = 1000 - retained.length;
+    const expectedIndexes = Array.from({ length: retained.length }, (_, i) => expectedStart + i);
+
     const diagnostics = server._collectDiagnostics();
     const measured = diagnostics.retention.output_buffers.active.per_session[0];
-    assert.strictEqual(measured.items, 1000, 'the raw onOutput chunks fill the 1000-item cap');
-    assert.strictEqual(measured.bytes, 1000 * chunkBytes);
-    assert.ok(
-      measured.bytes > 512 * 1024,
-      `live buffer retained ${(measured.bytes / 1048576).toFixed(1)} MiB; SessionStore only applies its 512 KiB cap when persisting`
-    );
+    assert.ok(measured.items > 0 && measured.items < 1000, 'byte cap trims the newest tail before item capacity is reached');
+    assert.ok(measured.bytes <= SESSION_OUTPUT_BUFFER_MAX_BYTES, 'live output tail is capped at 512 KiB');
+    assert.deepStrictEqual(retainedIndexes, expectedIndexes, 'retained chunks are the newest suffix by chunk index');
     assert.ok(
       session.outputBuffer.toArray().every((chunk) => !chunk.includes('\n')),
-      'the proving stream has no lines, so this is conclusively a chunk—not-line—cap'
+      'the proving stream has no lines, so this is the real newline-free PTY path'
     );
     callbacks.onExit(0, null);
     server._retentionByteMetricsCache = null;
     const afterExit = server._collectDiagnostics().retention.output_buffers.inactive.per_session[0];
-    assert.strictEqual(afterExit.bytes, measured.bytes, 'the real exit callback leaves raw scrollback reachable');
+    assert.ok(afterExit.bytes <= SESSION_OUTPUT_BUFFER_MAX_BYTES, 'inactive session still retains a bounded tail');
+    assert.strictEqual(afterExit.bytes, measured.bytes, 'natural exit keeps the bounded tail reachable');
   });
 
-  it('keeps inactive exited-session buffers reachable until the seven-day eviction threshold', async function () {
+  it('caps a single coalesced onOutput chunk to the newest <=512 KiB suffix', async function () {
+    const sessionId = 'pty-oversized-chunk';
+    const session = makeSession(sessionId);
+    server.claudeSessions.set(sessionId, session);
+    server.webSocketConnections.set('ws-oversized', {
+      claudeSessionId: sessionId,
+      ws: { readyState: 1, send() {} },
+    });
+    let callbacks;
+    const bridge = {
+      _commandReady: Promise.resolve(),
+      isAvailable: () => true,
+      startSession: async (_id, options) => { callbacks = options; },
+    };
+
+    await server.startToolSession('ws-oversized', 'terminal', bridge, {}, 80, 24);
+    if (session._ctlTranscript) {
+      session._ctlTranscript.dispose();
+      session._ctlTranscript = null;
+    }
+
+    const oversized = 'prefix-' + 'x'.repeat(700 * 1024) + '-tail';
+    callbacks.onOutput(oversized);
+
+    const retained = session.outputBuffer.toArray();
+    assert.strictEqual(retained.length, 1, 'single oversized coalesced write remains one capped chunk');
+    const stored = retained[0];
+    assert.ok(Buffer.byteLength(stored, 'utf8') <= SESSION_OUTPUT_BUFFER_MAX_BYTES);
+    assert.strictEqual(stored, oversized.slice(oversized.length - stored.length), 'stored output is the newest suffix');
+    assert.ok(stored.endsWith('-tail'));
+
+    callbacks.onExit(0, null);
+  });
+
+  it('keeps inactive exited-session buffers reachable as bounded tails until the seven-day eviction threshold', async function () {
     const sessionCount = 8;
-    const chunksPerSession = 4;
+    const chunksPerSession = 20;
     const chunkBytes = 64 * 1024;
     for (let sessionIndex = 0; sessionIndex < sessionCount; sessionIndex++) {
       const session = makeSession(`dead-${sessionIndex}`, false);
@@ -244,7 +288,8 @@ function waitForBridgeExit(bridge, sessionId, options = {}) {
     assert.strictEqual(evicted, 0, 'freshly exited sessions do not meet the seven-day eviction threshold');
     assert.strictEqual(after.sessions, sessionCount);
     assert.strictEqual(after.bytes, before.bytes);
-    assert.strictEqual(after.bytes, sessionCount * chunksPerSession * chunkBytes);
+    assert.strictEqual(after.bytes, sessionCount * SESSION_OUTPUT_BUFFER_MAX_BYTES);
+    assert.ok(after.per_session.every((entry) => entry.bytes <= SESSION_OUTPUT_BUFFER_MAX_BYTES));
   });
 
   it('retains unbounded pending transcript text while JSONL summary inference cannot run', function () {
@@ -374,7 +419,7 @@ function waitForBridgeExit(bridge, sessionId, options = {}) {
       const bytes = output.reduce((total, chunk) => total + Buffer.byteLength(chunk), 0);
       assert.ok(bytes >= 1024 * 1024, `expected at least 1 MiB from the real PTY, got ${bytes}`);
       assert.ok(output.length > 0, 'BaseBridge must invoke its output sink');
-      assert.ok(output.every((chunk) => !chunk.includes('\n')), 'the real PTY output has no line boundaries');
+      assert.ok(output.some((chunk) => !chunk.includes('\n')), 'the PTY stream includes raw batches without line-boundary splitting');
     } finally {
       await bridge.cleanup();
     }

--- a/test/session-store.test.js
+++ b/test/session-store.test.js
@@ -111,6 +111,114 @@ describe('SessionStore', function() {
       );
     });
 
+    it('detects file growth after the initial stat and keeps the read bounded', async function () {
+      sessionStore.maxSafeLoadBytes = 256;
+      const initial = Buffer.from('{"sessions":[]}');
+      const growth = Buffer.alloc(2048, 'x');
+      await fs.writeFile(sessionStore.sessionsFile, initial);
+      const originalOpen = fs.open;
+      const reads = [];
+      let grew = false;
+      fs.open = async (...args) => {
+        const handle = await originalOpen(...args);
+        const originalRead = handle.read.bind(handle);
+        handle.read = async (buffer, offset, length, position) => {
+          reads.push({ length, position });
+          if (!grew) {
+            grew = true;
+            await fs.appendFile(sessionStore.sessionsFile, growth);
+          }
+          return originalRead(buffer, offset, length, position);
+        };
+        return handle;
+      };
+
+      try {
+        const loaded = await sessionStore.loadSessions();
+        const files = await fs.readdir(tempDir);
+        const backup = files.find((file) => (
+          file.startsWith(`${path.basename(sessionStore.sessionsFile)}.oversized.`)
+        ));
+        assert.strictEqual(loaded.size, 0);
+        assert.ok(backup);
+        assert.ok(reads.length > 0);
+        assert.ok(reads.reduce((total, read) => total + read.length, 0) <= sessionStore.maxSafeLoadBytes + 1);
+        assert.strictEqual(
+          Buffer.compare(await fs.readFile(path.join(tempDir, backup)), Buffer.concat([initial, growth])),
+          0
+        );
+        await assert.rejects(fs.access(sessionStore.sessionsFile), { code: 'ENOENT' });
+      } finally {
+        fs.open = originalOpen;
+      }
+    });
+
+    it('preserves oversized files under .oversized without reading/parsing the whole file', async function () {
+      sessionStore.maxSafeLoadBytes = 256;
+      const bytes = Buffer.from('{"sessions":[' + 'x'.repeat(2048));
+      await fs.writeFile(sessionStore.sessionsFile, bytes);
+
+      const originalOpen = fs.open;
+      let handleReadFileCalls = 0;
+      fs.open = async (...args) => {
+        const handle = await originalOpen(...args);
+        const originalHandleReadFile = handle.readFile.bind(handle);
+        handle.readFile = async (...readArgs) => {
+          handleReadFileCalls++;
+          return originalHandleReadFile(...readArgs);
+        };
+        return handle;
+      };
+
+      try {
+        const loaded = await sessionStore.loadSessions();
+        const files = await fs.readdir(tempDir);
+        const backup = files.find((file) => (
+          file.startsWith(`${path.basename(sessionStore.sessionsFile)}.oversized.`)
+        ));
+
+        assert.strictEqual(loaded.size, 0);
+        assert.ok(backup);
+        assert.strictEqual(handleReadFileCalls, 0, 'oversized loads must not read the whole file');
+        assert.strictEqual(
+          Buffer.compare(await fs.readFile(path.join(tempDir, backup)), bytes),
+          0
+        );
+        await assert.rejects(fs.access(sessionStore.sessionsFile), { code: 'ENOENT' });
+      } finally {
+        fs.open = originalOpen;
+      }
+    });
+
+    it('copies oversized data to the backup when rename fails', async function () {
+      sessionStore.maxSafeLoadBytes = 256;
+      const bytes = Buffer.from('{"sessions":[' + 'x'.repeat(2048));
+      await fs.writeFile(sessionStore.sessionsFile, bytes);
+      const originalRename = fs.rename;
+      fs.rename = async () => {
+        const error = new Error('rename unavailable');
+        error.code = 'EACCES';
+        throw error;
+      };
+
+      try {
+        const loaded = await sessionStore.loadSessions();
+        const files = await fs.readdir(tempDir);
+        const backup = files.find((file) => (
+          file.startsWith(`${path.basename(sessionStore.sessionsFile)}.oversized.`)
+        ));
+        assert.strictEqual(loaded.size, 0);
+        assert.ok(backup);
+        assert.strictEqual(
+          Buffer.compare(await fs.readFile(path.join(tempDir, backup)), bytes),
+          0
+        );
+        await assert.rejects(fs.access(sessionStore.sessionsFile), { code: 'ENOENT' });
+      } finally {
+        fs.rename = originalRename;
+      }
+    });
+
     it('copies invalid data to the backup when rename fails', async function () {
       const bytes = Buffer.from('{"sessions": "x"}');
       await fs.writeFile(sessionStore.sessionsFile, bytes);
@@ -133,12 +241,56 @@ describe('SessionStore', function() {
           Buffer.compare(await fs.readFile(path.join(tempDir, backup)), bytes),
           0
         );
+        await assert.rejects(fs.access(sessionStore.sessionsFile), { code: 'ENOENT' });
+      } finally {
+        fs.rename = originalRename;
+      }
+    });
+
+    it('blocks saves when fallback unlink fails after an exact copy', async function () {
+      const bytes = Buffer.from('{"sessions": "x"}');
+      await fs.writeFile(sessionStore.sessionsFile, bytes);
+      const originalRename = fs.rename;
+      const originalUnlink = fs.unlink;
+      fs.rename = async () => {
+        const error = new Error('rename unavailable');
+        error.code = 'EACCES';
+        throw error;
+      };
+      fs.unlink = async (file) => {
+        if (file === sessionStore.sessionsFile) {
+          const error = new Error('remove unavailable');
+          error.code = 'EACCES';
+          throw error;
+        }
+        return originalUnlink(file);
+      };
+
+      try {
+        const loaded = await sessionStore.loadSessions();
+        const files = await fs.readdir(tempDir);
+        const backup = files.find((file) => (
+          file.startsWith(`${path.basename(sessionStore.sessionsFile)}.corrupted.`)
+        ));
+        assert.strictEqual(loaded.size, 0);
+        assert.ok(backup);
+        assert.strictEqual(
+          Buffer.compare(await fs.readFile(path.join(tempDir, backup)), bytes),
+          0
+        );
         assert.strictEqual(
           Buffer.compare(await fs.readFile(sessionStore.sessionsFile), bytes),
           0
         );
+        assert.strictEqual(sessionStore._saveBlockedReason.removeError.code, 'EACCES');
+        assert.strictEqual(sessionStore._lastSaveError.code, 'ESESSIONBACKUPFAILED');
+
+        sessionStore.markDirty();
+        assert.strictEqual(await sessionStore.saveSessions(new Map()), false);
+        assert.strictEqual(sessionStore._lastSaveError.code, 'ESESSIONBACKUPFAILED');
       } finally {
         fs.rename = originalRename;
+        fs.unlink = originalUnlink;
       }
     });
 
@@ -259,6 +411,215 @@ describe('SessionStore', function() {
       const files = await fs.readdir(tempDir);
       assert.strictEqual(loaded.size, 0);
       assert.strictEqual(files.some((file) => file.includes('.corrupted.')), false);
+    });
+
+    it('clears metadata cache when loading an empty or whitespace-only file', async function () {
+      await fs.writeFile(sessionStore.sessionsFile, JSON.stringify({
+        version: '1.0',
+        savedAt: new Date().toISOString(),
+        sessions: [{ id: 'cached', outputBuffer: [] }],
+      }));
+      await sessionStore.loadSessions();
+      assert.ok(sessionStore._sessionMetadataCache, 'warm cache before empty-load check');
+
+      await fs.writeFile(sessionStore.sessionsFile, '   \n\t   ');
+      const loaded = await sessionStore.loadSessions();
+      assert.strictEqual(loaded.size, 0);
+      assert.strictEqual(sessionStore._sessionMetadataCache, null);
+    });
+  });
+
+  describe('file identity helpers', function() {
+    it('stores dev and ino identities as strings', function() {
+      const identity = sessionStore._fileIdentityFromStats({
+        size: 1,
+        mtimeMs: 2,
+        dev: 9007199254740993n,
+        ino: 9007199254740995n,
+        ctimeMs: 3,
+      });
+      assert.strictEqual(identity.dev, '9007199254740993');
+      assert.strictEqual(identity.ino, '9007199254740995');
+      assert.strictEqual(typeof identity.dev, 'string');
+      assert.strictEqual(typeof identity.ino, 'string');
+    });
+  });
+
+  describe('getSessionMetadata', function() {
+    it('returns cached metadata after a successful save without rereading sessions.json', async function() {
+      const testSessions = new Map([
+        ['session1', { id: 'session1', name: 'A', created: new Date() }],
+        ['session2', { id: 'session2', name: 'B', created: new Date() }],
+      ]);
+
+      sessionStore.markDirty();
+      await sessionStore.saveSessions(testSessions);
+
+      const originalReadFile = fs.readFile;
+      let readAttempts = 0;
+      fs.readFile = async () => {
+        readAttempts++;
+        throw new Error('getSessionMetadata should use cached save metadata');
+      };
+
+      try {
+        const metadata = await sessionStore.getSessionMetadata();
+        assert.strictEqual(metadata.exists, true);
+        assert.strictEqual(metadata.sessionCount, 2);
+        assert.strictEqual(metadata.version, '1.0');
+        assert.ok(typeof metadata.savedAt === 'string' && metadata.savedAt.length > 0);
+        assert.ok(metadata.fileSize > 0);
+        assert.strictEqual(readAttempts, 0);
+      } finally {
+        fs.readFile = originalReadFile;
+      }
+    });
+
+    it('returns cached metadata after a successful load without rereading sessions.json', async function() {
+      const envelope = {
+        version: '1.0',
+        savedAt: new Date().toISOString(),
+        sessions: [
+          { id: 'loaded-1', outputBuffer: [] },
+          { id: 'loaded-2', outputBuffer: [] },
+        ],
+      };
+      await fs.writeFile(sessionStore.sessionsFile, JSON.stringify(envelope));
+
+      const loaded = await sessionStore.loadSessions();
+      assert.strictEqual(loaded.size, 2);
+
+      const originalReadFile = fs.readFile;
+      let readAttempts = 0;
+      fs.readFile = async () => {
+        readAttempts++;
+        throw new Error('getSessionMetadata should use cached load metadata');
+      };
+
+      try {
+        const metadata = await sessionStore.getSessionMetadata();
+        assert.strictEqual(metadata.exists, true);
+        assert.strictEqual(metadata.savedAt, envelope.savedAt);
+        assert.strictEqual(metadata.sessionCount, 2);
+        assert.strictEqual(metadata.version, '1.0');
+        assert.ok(metadata.fileSize > 0);
+        assert.strictEqual(readAttempts, 0);
+      } finally {
+        fs.readFile = originalReadFile;
+      }
+    });
+
+    it('parses a bounded small file when cache is cold', async function() {
+      const envelope = {
+        version: '1.0',
+        savedAt: '2026-07-01T00:00:00.000Z',
+        sessions: [{ id: 'small', outputBuffer: [] }],
+      };
+      await fs.writeFile(sessionStore.sessionsFile, JSON.stringify(envelope));
+
+      const metadata = await sessionStore.getSessionMetadata();
+      assert.strictEqual(metadata.exists, true);
+      assert.strictEqual(metadata.savedAt, envelope.savedAt);
+      assert.strictEqual(metadata.sessionCount, 1);
+      assert.strictEqual(metadata.version, '1.0');
+      assert.ok(metadata.fileSize > 0);
+    });
+
+    it('invalidates stale cache on same-size atomic replacement', async function () {
+      const firstEnvelope = {
+        version: '1.0',
+        savedAt: '2026-07-01T00:00:00.000Z',
+        sessions: [{ id: 'a', outputBuffer: [] }],
+      };
+      const secondEnvelope = {
+        version: '1.0',
+        savedAt: '2026-07-02T00:00:00.000Z',
+        sessions: [{ id: 'b', outputBuffer: [] }],
+      };
+      const firstBytes = JSON.stringify(firstEnvelope);
+      const secondBytes = JSON.stringify(secondEnvelope);
+      assert.strictEqual(
+        Buffer.byteLength(firstBytes, 'utf8'),
+        Buffer.byteLength(secondBytes, 'utf8'),
+        'test setup requires equal-size replacements'
+      );
+
+      await fs.writeFile(sessionStore.sessionsFile, firstBytes);
+      const warm = await sessionStore.getSessionMetadata();
+      assert.strictEqual(warm.savedAt, firstEnvelope.savedAt);
+
+      const priorStats = await fs.stat(sessionStore.sessionsFile);
+      const replacement = `${sessionStore.sessionsFile}.replace`;
+      await fs.writeFile(replacement, secondBytes);
+      await fs.rename(replacement, sessionStore.sessionsFile);
+      const priorMtime = new Date(priorStats.mtimeMs);
+      await fs.utimes(sessionStore.sessionsFile, priorMtime, priorMtime);
+
+      const metadata = await sessionStore.getSessionMetadata();
+      assert.strictEqual(metadata.savedAt, secondEnvelope.savedAt);
+      assert.strictEqual(metadata.sessionCount, 1);
+    });
+
+    it('uses a bounded handle read and skips parse when fallback bytes exceed the cap', async function () {
+      const oversized = '{"version":"1.0","savedAt":"x","sessions":[],"padding":"' + 'x'.repeat(70 * 1024) + '"}';
+      await fs.writeFile(sessionStore.sessionsFile, oversized);
+
+      const originalOpen = fs.open;
+      const originalParse = JSON.parse;
+      const readLengths = [];
+      let parseAttempts = 0;
+
+      fs.open = async (...args) => {
+        const handle = await originalOpen(...args);
+        const originalRead = handle.read.bind(handle);
+        handle.read = async (...readArgs) => {
+          readLengths.push(readArgs[2]);
+          return originalRead(...readArgs);
+        };
+        return handle;
+      };
+      JSON.parse = (...args) => {
+        parseAttempts++;
+        return originalParse(...args);
+      };
+
+      try {
+        const metadata = await sessionStore.getSessionMetadata();
+        assert.strictEqual(metadata.exists, true);
+        assert.strictEqual(metadata.savedAt, null);
+        assert.strictEqual(metadata.sessionCount, null);
+        assert.strictEqual(metadata.version, null);
+        assert.ok(readLengths.length >= 1, 'bounded fallback should perform one handle.read');
+        assert.ok(readLengths.every((len) => len === 64 * 1024 + 1));
+        assert.strictEqual(parseAttempts, 0, 'oversized fallback bytes must never be parsed');
+      } finally {
+        fs.open = originalOpen;
+        JSON.parse = originalParse;
+      }
+    });
+
+    it('returns exists:true for a large invalid file without reading or parsing the whole file', async function() {
+      const oversizedInvalid = '{' + 'x'.repeat(70 * 1024);
+      await fs.writeFile(sessionStore.sessionsFile, oversizedInvalid);
+
+      const originalReadFile = fs.readFile;
+      let readAttempts = 0;
+      fs.readFile = async (...args) => {
+        readAttempts++;
+        return originalReadFile.apply(fs, args);
+      };
+
+      try {
+        const metadata = await sessionStore.getSessionMetadata();
+        assert.strictEqual(metadata.exists, true);
+        assert.strictEqual(metadata.savedAt, null);
+        assert.strictEqual(metadata.sessionCount, null);
+        assert.strictEqual(metadata.version, null);
+        assert.strictEqual(metadata.fileSize, Buffer.byteLength(oversizedInvalid, 'utf8'));
+        assert.strictEqual(readAttempts, 0, 'large metadata path must avoid fs.readFile entirely');
+      } finally {
+        fs.readFile = originalReadFile;
+      }
     });
   });
 

--- a/test/sticky-note-server-wiring.test.js
+++ b/test/sticky-note-server-wiring.test.js
@@ -371,6 +371,92 @@ describe('sticky-note JSONL binding (ownership + resume)', function () {
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
   });
 
+  it('SIDECAR: _readClaudeBindSidecar rejects oversized files (>64 KiB)', async function () {
+    const self = makeBindStub();
+    const sidecar = path.join(dir, 'oversized.json');
+    const payload = JSON.stringify({
+      schema: 1,
+      claudeSessionId: 'session-1',
+      transcriptPath: path.join(dir, 'session-1.jsonl'),
+      event: 'start',
+      at: Date.now(),
+      padding: 'x'.repeat(70 * 1024),
+    });
+    fs.writeFileSync(sidecar, payload);
+
+    const parsed = await self._readClaudeBindSidecar({ claudeBindSidecar: sidecar });
+    assert.strictEqual(parsed, null);
+  });
+
+  it('SIDECAR: _readClaudeBindSidecar rejects malformed claudeSessionId/transcriptPath field types', async function () {
+    const self = makeBindStub();
+    const sidecar = path.join(dir, 'malformed.json');
+    const malformedRecords = [
+      { schema: 1, claudeSessionId: 123, transcriptPath: '/tmp/a.jsonl', event: 'start', at: Date.now() },
+      { schema: 1, claudeSessionId: 'ok', transcriptPath: null, event: 'start', at: Date.now() },
+      { schema: 1, claudeSessionId: { nested: true }, transcriptPath: '/tmp/a.jsonl', event: 'end', at: Date.now() },
+      { schema: 1, claudeSessionId: 'ok', transcriptPath: ['array'], event: 'end', at: Date.now() },
+    ];
+
+    for (const record of malformedRecords) {
+      fs.writeFileSync(sidecar, JSON.stringify(record));
+      // eslint-disable-next-line no-await-in-loop
+      const parsed = await self._readClaudeBindSidecar({ claudeBindSidecar: sidecar });
+      assert.strictEqual(parsed, null);
+    }
+  });
+
+  it('SIDECAR: a present but malformed/oversized sidecar suppresses newest-mtime fallback binding', async function () {
+    const cwd = '/Users/x/proj';
+    writeSession(cwd, 'stranger.jsonl', null, 0);
+    const self = makeBindStub();
+    const sidecar = path.join(dir, 'tab1.json');
+    self.claudeSessions.set('tab1', { nameIsUserSet: false, claudeBindSidecar: sidecar, _sidecarSeen: false });
+
+    const payloads = [
+      '{not-json',
+      JSON.stringify({
+        schema: 1,
+        claudeSessionId: 'too-big',
+        transcriptPath: path.join(dir, 'too-big.jsonl'),
+        event: 'start',
+        at: Date.now(),
+        padding: 'x'.repeat(70 * 1024),
+      }),
+    ];
+
+    for (const payload of payloads) {
+      fs.writeFileSync(sidecar, payload);
+      self._stickyJsonl.delete('tab1');
+      self.claudeSessions.get('tab1')._sidecarSeen = false;
+      // eslint-disable-next-line no-await-in-loop
+      await self._pumpStickyJsonl('tab1', cwd);
+      assert.strictEqual(self._stickyJsonl.has('tab1'), false, 'no inference fallback bind while sidecar is present');
+      assert.strictEqual(self.claudeSessions.get('tab1')._sidecarSeen, true, 'opened sidecar marks the tab as sidecar-managed');
+    }
+  });
+
+  it('SIDECAR: _readClaudeBindSidecar preserves valid SessionEnd records', async function () {
+    const self = makeBindStub();
+    const sidecar = path.join(dir, 'session-end.json');
+    const expected = {
+      schema: 1,
+      claudeSessionId: 'session-end',
+      transcriptPath: path.join(dir, 'session-end.jsonl'),
+      cwd: '/Users/x/proj',
+      event: 'end',
+      reason: 'prompt_input_exit',
+      at: Date.now(),
+    };
+    fs.writeFileSync(sidecar, JSON.stringify(expected));
+
+    const parsed = await self._readClaudeBindSidecar({ claudeBindSidecar: sidecar });
+    assert.ok(parsed);
+    assert.strictEqual(parsed.event, 'end');
+    assert.strictEqual(parsed.claudeSessionId, expected.claudeSessionId);
+    assert.strictEqual(parsed.transcriptPath, expected.transcriptPath);
+  });
+
   // --- Deterministic sidecar binding (github-router SessionStart hook) ---
   it('SIDECAR: binds to the sidecar transcript, ignoring a newer growing unowned session', async function () {
     const cwd = '/Users/x/proj';


### PR DESCRIPTION
## Summary
- Bound every live session output buffer to 1,000 chunks and 512 KiB while keeping reconnect replay at a hard 256 KiB.
- Bound Claude sidecar and session-metadata parsing, and preserve session stores over 128 MiB instead of parsing them during startup.
- Add regression coverage for large PTY chunks, Unicode suffix trimming, authoritative sidecars, metadata races, and preservation failures.

## Root cause
The major GCs recovered little from ~1.8 GiB old-space because live session output remained strongly retained; JSON.parse was the final allocator that crossed the heap limit, not the primary retained graph.

## Testing
`npx mocha --require test/hooks/session-sandbox.js --exit --timeout 240000 test/circular-buffer.test.js test/session-store.test.js test/sticky-note-server-wiring.test.js test/join-replay-buffer.test.js test/longevity/process/supervisor-retention-probes.test.js`

141 passing.
